### PR TITLE
Automate TL index updates for Hachimi-Edge, get in-game TL updates working

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -1,8 +1,6 @@
 name: Update EN TL index on dev repo
 
 on:
-  # test only
-  workflow_dispatch:
   push:
     branches:
       - 'dev'

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -1,0 +1,40 @@
+name: Update EN TL index on dev repo
+
+on:
+  # test only
+  workflow_dispatch:
+  push:
+    branches:
+      - 'dev'
+    paths:
+      - 'localized_data/**'
+
+jobs:
+  update_index:
+    runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout latest changes
+        uses: actions/checkout@v4
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: 3.12
+          activate-environment: true
+          enable-cache: true
+          cache-dependency-glob: "**/requirements*.txt"
+      - name: Fetch updater dependencies
+        run: uv pip install -r requirements.txt
+      - name: Run index update script
+        run: uv run -s gen_index.py
+      - name: Commit new index file
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -am "[BOT] feature: update index for latest commit"
+      - name: Push new index file
+        uses: ad-m/github-push-action@master

--- a/index.json
+++ b/index.json
@@ -4,1879 +4,109 @@
   "zip_dir": "tl-en-dev/localized_data",
   "files": [
     {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_announce_supportcard00/tx_uTex_fl_announce_supportcard00_0.diff.png",
-      "hash": "9a859a136c5410e3e078242a441441c2f3b7669cff6f5a6e9e90a674cef9ad36",
-      "size": 450413
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_footer_btn00/tx_uTex_fl_footer_btn00_0.png",
+      "hash": "62477e9e6fb691e4c2a05eb9aae1bccee10d1415c7bf22e35a9e70ca2859e529",
+      "size": 392006
     },
     {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_champions_notice_round00/tx_uTex_fl_champions_notice_round00_0.diff.png",
-      "hash": "3c42e0909391953a64424795024425412978e70cbd1dbe9117fb3bee4b6f72f3",
-      "size": 603375
+      "path": "assets/atlas/home/home.png",
+      "hash": "9640ad81b7534b00e96582ee19d923894b85af1b6b22c07d4c2fef77591dee35",
+      "size": 957506
     },
     {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_champions_result_finalranking00/tx_uTex_fl_champions_result_finalranking00_0.diff.png",
-      "hash": "12ebf2998f1df623453b2a126c8ed7328f8814a0bec9c2d4c4743ac2fa2ab566",
-      "size": 71622
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_chara_txt_hint_lvup00/tx_uTex_fl_chara_txt_hint_lvup00_0.diff.png",
-      "hash": "782ea007c89eadea410d2d37c6fb56ce0ef4a7628be6d609f743a158133885e7",
-      "size": 79780
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_cmn_badge00/tx_uTex_fl_cmn_badge00_0.diff.png",
-      "hash": "7b5c3ed19ed88296f9a76821391b08af0e333bf7316488d5bb12c5860f5b8d89",
-      "size": 1499
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_cmn_txt_event_reward00/tx_uTex_fl_cmn_txt_event_reward00_0.diff.png",
-      "hash": "824b21b08afc0b9b6ad1156a5a277a078449b05dee2aa609ccc2dc2958efa72c",
-      "size": 110144
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_contactcard_photolibrary_icon00/tx_uTex_fl_contactcard_photolibrary_icon00_0.diff.png",
-      "hash": "25c8c2c224a4e03910b225a090d050ea6348cdb0f123a421789faff41023011a",
-      "size": 8385
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_factorresearch_gauge00/tx_uTex_fl_factorresearch_gauge00_0.diff.png",
-      "hash": "75cab709efd94e8cf717105afb962f05d5db8c976a2ebbb5570d1856373eb0d9",
-      "size": 133216
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_factorresearch_reward_txt_title00/tx_uTex_fl_factorresearch_reward_txt_title00_0.diff.png",
-      "hash": "36b90a7bbbcffc912f5d50a2151867746909d5fb52572f487a1a5c579fd56f09",
-      "size": 75551
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_footer_btn00/tx_uTex_fl_footer_btn00_0.diff.png",
-      "hash": "6150ca8754e70c6bf3ed5261cc8db24969b1ce78e41528c1a0a7a8b9c3aea738",
-      "size": 62041
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_footer_landscape_btn00/tx_uTex_fl_footer_landscape_btn00_0.diff.png",
-      "hash": "79568e0c164737afcd76326f289573309f9a259abdbac04c12bd202770fb079d",
-      "size": 43049
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_gacha_chara_piece00/tx_uTex_fl_gacha_chara_piece00_0.diff.png",
-      "hash": "140d146c7ba383f5f52269ce67d12c50bc4fda2bac9fd124b9018f33c06882b3",
-      "size": 6767
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_btn_get_heroskill00/tx_uTex_fl_heroes_btn_get_heroskill00_0.diff.png",
-      "hash": "c4717083c55ddd35cc7d8816cd8508bced93759ed9757980be7f03fa3a688e1b",
-      "size": 69041
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_get_heroskill00/tx_uTex_fl_heroes_get_heroskill00_0.diff.png",
-      "hash": "ec4326573bfd24167961a20b10e87a6a5e482dfeb35683e19282df3c17822034",
-      "size": 76586
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_matching_comp00/tx_uTex_fl_heroes_matching_comp00_0.diff.png",
-      "hash": "ac313eb513b0f2d1f94271b65ed327d21a3ce72da31fa870e1f0c9f0833c0138",
-      "size": 380439
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_raceresult_gaugemax00/tx_uTex_fl_heroes_raceresult_gaugemax00_0.diff.png",
-      "hash": "56bf06395e605b7412cf315b65bbbd6768515ae2be2d12bcb3978f8f14949227",
-      "size": 360981
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_raceresult_raceend_pt00/tx_uTex_fl_heroes_raceresult_raceend_pt00_0.diff.png",
-      "hash": "7e9cf7854d587880ce96f8d7b3bc0a5956318745a77962ba9d5330826288a512",
-      "size": 74623
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_txt_racereward00/tx_uTex_fl_heroes_txt_racereward00_0.diff.png",
-      "hash": "34c10b6a21f7c9788f0a8087a685c98b864595cf69c3d4e7b10e8dae2c8b3307",
-      "size": 39106
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_login_normal_title00/tx_uTex_fl_login_normal_title00_0.diff.png",
-      "hash": "4e8f5b2279b669da6257f810ddc553e000d7fdde65844290a845d14ec8379759",
-      "size": 25234
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_mng_credit00/tx_uTex_fl_mng_credit00_0.diff.png",
-      "hash": "4ac28e91644fa2f9a6ffe3e0943ae209f98dab817732f4c9308139a036d6c9bc",
-      "size": 39230
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_mng_dialog_get00/tx_uTex_fl_mng_dialog_get00_0.diff.png",
-      "hash": "eb9bb0d02bd2e252a3c680def707168a9c7ce4bb3fa103d153ae73b9de33be4e",
-      "size": 20028
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_race_result_rank00/tx_uTex_fl_race_result_rank00_0.diff.png",
-      "hash": "2fa9e508b28be62c93b2dab5381146d127dab94150b38f616281114572a34bc9",
-      "size": 492276
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_race_rt_04_00/tx_uTex_fl_race_rt_04_00_0.diff.png",
-      "hash": "5f017159fef5199a20d1506d063bf2e119f1131105d3603435ab131add3b6dbd",
-      "size": 27464
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_race_rt_06_00/tx_uTex_fl_race_rt_06_00_0.diff.png",
-      "hash": "fcd1d8aeb1ebb0424f4f993a39b735f24641d0e60c2e15dd81251780e9de7d03",
-      "size": 36470
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_ratingrace_result_rank00/tx_uTex_fl_ratingrace_result_rank00_0.diff.png",
-      "hash": "15f77618b652f12dc4d71b304cb3a638d1789641e6e32e86d0c0ace53e07660e",
-      "size": 397686
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_abroad_expedition00/tx_uTex_fl_singlemode_arc_abroad_expedition00_0.diff.png",
-      "hash": "9d7bd634c2f5d895ff074d7d529411d4164abea0b84f6c6ce6f66c8fbb069b13",
-      "size": 391104
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_btn_trainingmenu_ssmatch00/tx_uTex_fl_singlemode_arc_btn_trainingmenu_ssmatch00_0.diff.png",
-      "hash": "363b106bbe5c1bfb510f075c4e3e56e3fc9e38b7478d0c1c5086093d1a975426",
-      "size": 38065
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_event_racebonus00/tx_uTex_fl_singlemode_arc_event_racebonus00_0.diff.png",
-      "hash": "091c11ad1f64acc0f5d35bbb7aac1ffa18fc8c7b03ed77ffb066958456fce3d7",
-      "size": 69623
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_event_stargauge_up00/tx_uTex_fl_singlemode_arc_event_stargauge_up00_0.diff.png",
-      "hash": "b184007834ff016c2cb2299440edca22621adecd74db62d2ab4b246a58ca8c8e",
-      "size": 47485
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_extrarace_result00/tx_uTex_fl_singlemode_arc_extrarace_result00_0.diff.png",
-      "hash": "2411263ca7fc4f8af9e60b7a22b9e13a56baa54e2066061a92958fc9052ae71f",
-      "size": 736269
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_get_response00/tx_uTex_fl_singlemode_arc_get_response00_0.diff.png",
-      "hash": "09a4bc8b05a5bcf95859aea1a779850c500d9f71a0d6579645043691a5669dca",
-      "size": 77675
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_header_turncounter00/tx_uTex_fl_singlemode_arc_header_turncounter00_0.diff.png",
-      "hash": "59bf46c771261f50c135850d45061c03c8981b0ac8c15e9cbcc5d74657697a05",
-      "size": 8822
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_next_target00/tx_uTex_fl_singlemode_arc_next_target00_0.diff.png",
-      "hash": "f0cbae74a3b0d715479889dad25aac1ff010bea62131e8d2be98d2709e9fa322",
-      "size": 98923
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_remind_turn00/tx_uTex_fl_singlemode_arc_remind_turn00_0.diff.png",
-      "hash": "81d4fe8d5bba6d7690d71388fcbb64391ebd23fc821f06aeea4511834b07cea9",
-      "size": 71745
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_speech_bubble00/tx_uTex_fl_singlemode_arc_speech_bubble00_0.diff.png",
-      "hash": "a1bd560cab7438d764d12cfcad9fc0977cbccf22469e5db3364583fc2129fd7f",
-      "size": 49993
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_txt_lvup_response00/tx_uTex_fl_singlemode_arc_txt_lvup_response00_0.diff.png",
-      "hash": "4aaa9fd44476be56f5df08a9f1928299aa1b474ff27c85f6255991ec1f491639",
-      "size": 90565
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_break_resultpoint_record00/tx_uTex_fl_singlemode_break_resultpoint_record00_0.diff.png",
-      "hash": "ae3cbfadecab54d3432fe0fa53555acc4193636b1a2bb46e80124632120f32a2",
-      "size": 129314
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_btn_factor_succession00/tx_uTex_fl_singlemode_btn_factor_succession00_0.diff.png",
-      "hash": "b799c32a0442dcb3bc8541ab92c57e122cd1e2f5288277912913a9dc2bd1731c",
-      "size": 72174
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_btn_trainingmenu00/tx_uTex_fl_singlemode_btn_trainingmenu00_0.diff.png",
-      "hash": "86032b9953786f6cfb855ea5d9021f13e53e71646fbeb7464433ebe881a1c783",
-      "size": 6343
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_btn_trainingmenu01/tx_uTex_fl_singlemode_btn_trainingmenu01_0.diff.png",
-      "hash": "728c99e1772ce65753f875dcf90e4b7b68964e424144f50af2d34512f4884630",
-      "size": 6941
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_badge_garden_reinforcement00/tx_uTex_fl_singlemode_cook_badge_garden_reinforcement00_0.diff.png",
-      "hash": "9c7efaefd8a7c73eafb9f1735deedbb47cbfda279b03ebec48843c616b933090",
-      "size": 2596
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_btn_recommend_dish00/tx_uTex_fl_singlemode_cook_btn_recommend_dish00_0.diff.png",
-      "hash": "ebffd8df07ab7e39733cec5e54111d743b8bd24238ed6450ed765d418a2b19ad",
-      "size": 43378
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_btn_trainingmenu00/tx_uTex_fl_singlemode_cook_btn_trainingmenu00_0.diff.png",
-      "hash": "23c061f4720f5fa3517f396495928e99fde650e2cc9f34cfcae693a991af42bb",
-      "size": 7584
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_care_harvestup00/tx_uTex_fl_singlemode_cook_care_harvestup00_0.diff.png",
-      "hash": "eb03ffb7a49ee9e06fc642ed4c624d0f27ac496b59f03d7a1476d30970cdc25c",
-      "size": 65076
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_care_title00/tx_uTex_fl_singlemode_cook_care_title00_0.diff.png",
-      "hash": "93e7568800fd73d554b026a3ff88bf95e034e60830c743fd1f76e12e0cc7508a",
-      "size": 129986
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_btn_kaien00/tx_uTex_fl_singlemode_cook_event_btn_kaien00_0.diff.png",
-      "hash": "f4d9911d853f643ebd9051d99ec7e62482f4bded699f493017a49ab364dce1ae",
-      "size": 144086
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_dish_add00/tx_uTex_fl_singlemode_cook_event_dish_add00_0.diff.png",
-      "hash": "5f588f7210fae7773a788c1914897d86788a0204813bb4e3cb04ce2e77a5f984",
-      "size": 56590
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_dish_efficacy_up00/tx_uTex_fl_singlemode_cook_event_dish_efficacy_up00_0.diff.png",
-      "hash": "f0b8cc3006031ad5d46036fbf1a4ccef4f233c67f3efd493cb4d6be15a1b94c6",
-      "size": 78432
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_join00/tx_uTex_fl_singlemode_cook_event_join00_0.diff.png",
-      "hash": "4ef9c0dd31e5d4de6e1204d44529040e01440b76901f7ca4ef71a18f8020f75c",
-      "size": 87132
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_uptrainingeffect00/tx_uTex_fl_singlemode_cook_event_uptrainingeffect00_0.diff.png",
-      "hash": "50f94e25f758ac39e0f331fad7edb76bdfebfdab38a8eed24f83f31a71af404c",
-      "size": 71553
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_vegetables_lv_maxup00/tx_uTex_fl_singlemode_cook_event_vegetables_lv_maxup00_0.diff.png",
-      "hash": "876eea69d9033d9653d67c7bbff2e93fb3fc582fd736b69d270d5dcbafb6b4ca",
-      "size": 82547
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_get_vegetables00/tx_uTex_fl_singlemode_cook_get_vegetables00_0.diff.png",
-      "hash": "93cebfd8d75f66fef2026fdcd8749df29127504e158e2c3015db4afef731deed",
-      "size": 55212
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_header_turncounter00/tx_uTex_fl_singlemode_cook_header_turncounter00_0.diff.png",
-      "hash": "30aa59df423c5f7fffbcf563a95f4da946ea2b1477bb9fbf0104acaf6882027c",
-      "size": 12131
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_premonition00/tx_uTex_fl_singlemode_cook_premonition00_0.diff.png",
-      "hash": "caffab025719f2ebf64dd2cffb14a4b57474041761b1a83525e7c97f89da83ed",
-      "size": 34065
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_ptup00/tx_uTex_fl_singlemode_cook_ptup00_0.diff.png",
-      "hash": "ca32e307fb270b9a15c91cdf6ea728a7dcccdb9c0b8e673774148ea73e99ec2e",
-      "size": 71959
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_remind_turn00/tx_uTex_fl_singlemode_cook_remind_turn00_0.diff.png",
-      "hash": "1f95c39c90989983b2b2e569a32ddd96042c93a1698d3defc4059e9584cb95f1",
-      "size": 35396
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_training_multiple00/tx_uTex_fl_singlemode_cook_training_multiple00_0.diff.png",
-      "hash": "d046fff5d1e69f8e9c855237fdfe51169c38b451fd9a4346c9910466a5d247f0",
-      "size": 90106
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_txt_harvest00/tx_uTex_fl_singlemode_cook_txt_harvest00_0.diff.png",
-      "hash": "d3e93154305187f8a70d1bf908bbd239b08da4265549254243659ac5b9967990",
-      "size": 90418
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_txt_manzoku00/tx_uTex_fl_singlemode_cook_txt_manzoku00_0.diff.png",
-      "hash": "d9a4063f34319b6ab17f5e4c53d4fe9267b99e4d99aa3e2380ea9e0f2e366049",
-      "size": 187614
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_txt_success00/tx_uTex_fl_singlemode_cook_txt_success00_0.diff.png",
-      "hash": "2d1bc27c43566de28cd049ce8669309261240193dda092eb3f6413f4e2453438",
-      "size": 84181
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_activecondition00/tx_uTex_fl_singlemode_eventbonus_activecondition00_0.diff.png",
-      "hash": "1c04cba14b6677267e4689fc526f8e22342b59e16dbd5a35e2510f7d8a9b1a93",
-      "size": 57734
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_apptraining00/tx_uTex_fl_singlemode_eventbonus_apptraining00_0.diff.png",
-      "hash": "cbf171467ad7790e3cbe2ccf206d00942d9a7d18f13a674d57c753c63fc45cc3",
-      "size": 56087
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_dncondition00/tx_uTex_fl_singlemode_eventbonus_dncondition00_0.diff.png",
-      "hash": "fb20a54dfa04a77d76b4ac6b2b3f449a74a071627cec07e823d7ba8ed0bb5768",
-      "size": 140277
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_dnskill00/tx_uTex_fl_singlemode_eventbonus_dnskill00_0.diff.png",
-      "hash": "5e6c6f40f7b1ab245219da9478b196f5b8e82fc9839fbeb483e64d0a9a6e19ae",
-      "size": 133649
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_racebonus00/tx_uTex_fl_singlemode_eventbonus_racebonus00_0.diff.png",
-      "hash": "766991f1336f8aa149a9491e575225ef696ab5a03068108ba19bc5c0a68bf6cf",
-      "size": 88619
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_resolve_dnskill00/tx_uTex_fl_singlemode_eventbonus_resolve_dnskill00_0.diff.png",
-      "hash": "ff36c633d2168c5eb5819edf649352be298cbccec6ac587f323c10a258ab6eab",
-      "size": 64692
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_resolvecondition00/tx_uTex_fl_singlemode_eventbonus_resolvecondition00_0.diff.png",
-      "hash": "ce39146449e4bb8ac1cc6233e227a3cddf18c5cf872a251f44852c652900a928",
-      "size": 62188
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_succession00/tx_uTex_fl_singlemode_eventbonus_succession00_0.diff.png",
-      "hash": "b7f20dcbd4ced2ac00d488c72c939625991e603a60e0b9a41736a73bd39a6f80",
-      "size": 67292
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_target00/tx_uTex_fl_singlemode_eventbonus_target00_0.diff.png",
-      "hash": "4da0372b1e667666eb589947d60b8cccb3437326ecdd37cc01cc4faf6a41a5a4",
-      "size": 107934
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_upcondition00/tx_uTex_fl_singlemode_eventbonus_upcondition00_0.diff.png",
-      "hash": "a157cc476f38822e0d7d62591d715d2f929c1ebbbe2a2e4423d58c9ff8a78611",
-      "size": 134301
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_upevent00/tx_uTex_fl_singlemode_eventbonus_upevent00_0.diff.png",
-      "hash": "6837083ea3a89438bc232abc176f70ba9e7e67447efa5cc0074c4a0c0c39bd03",
-      "size": 63012
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_uphint00/tx_uTex_fl_singlemode_eventbonus_uphint00_0.diff.png",
-      "hash": "6c70b7d4ea7d69bb8f1242c146bb05824c57d0ea0f3a01526003ebfa67925c3f",
-      "size": 127418
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_upskilllv00/tx_uTex_fl_singlemode_eventbonus_upskilllv00_0.diff.png",
-      "hash": "2ac604fd400777dabae3ed4b9c65f9943e2cf9b2fa0e6acc8bc59a55164fe6df",
-      "size": 134641
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_extrarace_result00/tx_uTex_fl_singlemode_extrarace_result00_0.diff.png",
-      "hash": "d519a00d31a337772b62abf81a0787ccc7d4bd6c00a8485dfc952822b986e9af",
-      "size": 236762
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_free_header_turncounter00/tx_uTex_fl_singlemode_free_header_turncounter00_0.diff.png",
-      "hash": "3b3387744cdf8d27aaae310e7cad0d8ff34e9dd5f367bbcc8b7932a435f21a3b",
-      "size": 2954
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_header_hpgauge00/tx_uTex_fl_singlemode_header_hpgauge00_0.diff.png",
-      "hash": "909a16e7f1a66a4293961563cf0cf5c7580c3a162ae7958dcdcc5fc23b17c2a2",
-      "size": 6489
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_header_turncounter00/tx_uTex_fl_singlemode_header_turncounter00_0.diff.png",
-      "hash": "f7625a08cdca2fac64c884fa95512b93413b9de0a1a779d81cf7fe1dfe38b451",
-      "size": 2585
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_hint00/tx_uTex_fl_singlemode_hint00_0.diff.png",
-      "hash": "789f0e4c3d115bbebc8af1e3c4687ae00bbf69f137ede902b543e3ffd188d3c2",
-      "size": 2630
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_icon_motivation00/tx_uTex_fl_singlemode_icon_motivation00_0.diff.png",
-      "hash": "01552e7cd1e54044df24abb211f190a34631836564d5fcadca0fc4d03f62b95d",
-      "size": 36437
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_btn_trainingmenu00/tx_uTex_fl_singlemode_legend_btn_trainingmenu00_0.diff.png",
-      "hash": "5176e39d76294a90761a7c3cfaecd9721c129c17b995016ceef06085a168f930",
-      "size": 7766
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_buff_get00/tx_uTex_fl_singlemode_legend_buff_get00_0.diff.png",
-      "hash": "2fcfd933eca4f11be431e743cf37cdcf8a36296f6d5405499a83dd49d74048a5",
-      "size": 50782
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_enter_masterly00/tx_uTex_fl_singlemode_legend_enter_masterly00_0.diff.png",
-      "hash": "ce1f19f5bb67bc910aebe9c7366814aa704d7825e5a7fce2ead359c5e089be11",
-      "size": 126546
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_enter_masterly01/tx_uTex_fl_singlemode_legend_enter_masterly01_0.diff.png",
-      "hash": "6017d1013bc89fdfc68ae73fd2133a6832f67b633c2a937a5bc08a8431b3744d",
-      "size": 125789
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_enter_masterly02/tx_uTex_fl_singlemode_legend_enter_masterly02_0.diff.png",
-      "hash": "f07970dc57bedd3d83e2c08f194475a67300c6b4da7992c1a63d1d36e8f4b05c",
-      "size": 150154
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_event_legendappear00/tx_uTex_fl_singlemode_legend_event_legendappear00_0.diff.png",
-      "hash": "4729ed944889126c6bc0e4d386b73a3e20d5938b031bd71ec7f0995eca1eb8b4",
-      "size": 158543
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_eventbonus_upmotivation00/tx_uTex_fl_singlemode_legend_eventbonus_upmotivation00_0.diff.png",
-      "hash": "9480ee3dcdce3863bf7acc93dd7edc676e42de4e1e6def69d7874153471c83ee",
-      "size": 9310
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_extrarace_result00/tx_uTex_fl_singlemode_legend_extrarace_result00_0.diff.png",
-      "hash": "404a89caead0700d28081239331e555d5e8a9d5f729d7e9d962e695782d67bda",
-      "size": 115840
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_extrarace_result00_01/tx_uTex_fl_singlemode_legend_extrarace_result00_01_0.diff.png",
-      "hash": "bf8a8f62db14b408bf4dce6ec456e1b6518e6033a95dcb7310ef1ff804d03de7",
-      "size": 115984
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_extrarace_result00_02/tx_uTex_fl_singlemode_legend_extrarace_result00_02_0.diff.png",
-      "hash": "bed9e681372a694de5dbd64759fafe1b5846d020d038c184ff95b9f6d243c332",
-      "size": 115034
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_header_turncounter00/tx_uTex_fl_singlemode_legend_header_turncounter00_0.diff.png",
-      "hash": "b035645ec77a095d022399f45ce826211abe20b195750eacde65103808837b86",
-      "size": 7442
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_icon_motivation00/tx_uTex_fl_singlemode_legend_icon_motivation00_0.diff.png",
-      "hash": "6a7cf17aab350143ed463a9d7141ac00bda2a14fba367c961e8053f426047d6e",
-      "size": 145007
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_masterly_frame00/tx_uTex_fl_singlemode_legend_masterly_frame00_0.diff.png",
-      "hash": "faefd044afc5bd368a1dfd1852c8da98ed2179e358ee93145c1e67246a0a6167",
-      "size": 28439
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_masterly_frame01/tx_uTex_fl_singlemode_legend_masterly_frame01_0.diff.png",
-      "hash": "b010333da94270e48c6dc361174bba9ce205a85d46df8ebf7abdfd06e9454bf8",
-      "size": 41055
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_masterly_get00/tx_uTex_fl_singlemode_legend_masterly_get00_0.diff.png",
-      "hash": "501b0ade5e35402a8711792e7541c48a5da702de6230197cf0d7e0a78e5839f9",
-      "size": 395112
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_next_target00/tx_uTex_fl_singlemode_legend_next_target00_0.diff.png",
-      "hash": "725ab55fe561da8802d43a3a240a5dac0bbd0368a9324fac43925c705973cd38",
-      "size": 101623
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_remind_turn00/tx_uTex_fl_singlemode_legend_remind_turn00_0.diff.png",
-      "hash": "f7401e1abc43202377ae63e2b036c322f67541fe53f6deea8dbb65035767ee74",
-      "size": 31781
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_txt_buff_available00/tx_uTex_fl_singlemode_legend_txt_buff_available00_0.diff.png",
-      "hash": "95ce7b8ecc54bb9fd2cf9cfbb1fb289a1c1a507380ff5e136cbc075957353b3e",
-      "size": 61153
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_btn_trainingmenu00/tx_uTex_fl_singlemode_live_btn_trainingmenu00_0.diff.png",
-      "hash": "9d41927ea655caff9daff54557b212441b6cf4a779b2b4a918e7ba6aa302ccb5",
-      "size": 6303
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_event_join00/tx_uTex_fl_singlemode_live_event_join00_0.diff.png",
-      "hash": "3b967f3445dba761486314fb08d14cd8866052e20b4bc3472aed617dd7ed259b",
-      "size": 59413
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_event_live_expectations00/tx_uTex_fl_singlemode_live_event_live_expectations00_0.diff.png",
-      "hash": "1775671575ce47774a607cdc3ceadefe49087c2926cb58323e87112f379e5ef7",
-      "size": 323701
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_event_trainingbonus00/tx_uTex_fl_singlemode_live_event_trainingbonus00_0.diff.png",
-      "hash": "0979bc6a1f9a629bcda1fa03aa7a5fa39fbab8ab44990d00c6bdf085a5212f3e",
-      "size": 69163
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_header_turncounter00/tx_uTex_fl_singlemode_live_header_turncounter00_0.diff.png",
-      "hash": "b049518422705700abcb3b1aeed5502ec560832bafc191852c47923bdf1cf1df",
-      "size": 8746
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_remind_turn00/tx_uTex_fl_singlemode_live_remind_turn00_0.diff.png",
-      "hash": "c673180b14347050c0b5241bc47ef22208baa5d8b011823c89becbe40b15daf8",
-      "size": 63583
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_txt_get_livetech00/tx_uTex_fl_singlemode_live_txt_get_livetech00_0.diff.png",
-      "hash": "2ba54c10e5d013e6b41282ced1c5e6b4b2117774d2edcc9108c87eabfc8e1b37",
-      "size": 307142
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_txt_get_music00/tx_uTex_fl_singlemode_live_txt_get_music00_0.diff.png",
-      "hash": "22c8cbf2ea18fe4d4169208f7481c572d3c01e42834f0955ea39e0c7bf68c7e2",
-      "size": 81269
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_btn_overdrive00/tx_uTex_fl_singlemode_mecha_btn_overdrive00_0.diff.png",
-      "hash": "cf3fdf849f85d1b69a1b139d2dbe790fe46fb5a65ee1984b90ea8324ad5bd096",
-      "size": 61140
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_btn_trainingmenu00/tx_uTex_fl_singlemode_mecha_btn_trainingmenu00_0.diff.png",
-      "hash": "577b6a361308e529bf24dc3970dd3291bbea5261dcdd1d6d7e701e0ab3f5596b",
-      "size": 7934
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_event_join00/tx_uTex_fl_singlemode_mecha_event_join00_0.diff.png",
-      "hash": "64048eda95a3e2f9ff8cdd7cf3ba867636541c88a628b5cb2f7736a918036c80",
-      "size": 84587
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_event_uptrainingeffect00/tx_uTex_fl_singlemode_mecha_event_uptrainingeffect00_0.diff.png",
-      "hash": "c4f982641880719858271fc9a40cb88b86d59ff6f560609c1855f30f2abf3294",
-      "size": 110255
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_header_hpgauge00/tx_uTex_fl_singlemode_mecha_header_hpgauge00_0.diff.png",
-      "hash": "972e0c36a102bba6fc391fa7d506b82eeb128214ec01e227eae4498eb37e4090",
-      "size": 11260
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_header_turncounter00/tx_uTex_fl_singlemode_mecha_header_turncounter00_0.diff.png",
-      "hash": "2ffb6444b2e7846fc957cd29475615e955bb930efbc1e6eafec050fe1b7cc687",
-      "size": 8820
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_overdrive_recovery00/tx_uTex_fl_singlemode_mecha_overdrive_recovery00_0.diff.png",
-      "hash": "60517f2f5a6910902d3cb5421dddbff44f0983fc1c1d0b4a579afec8937145fe",
-      "size": 227369
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_overdrive_text00/tx_uTex_fl_singlemode_mecha_overdrive_text00_0.diff.png",
-      "hash": "4e43fd2fce7313c6d045700024d1b1cc1ba06452b5c8d1db4ed1dc88489162b7",
-      "size": 867422
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_remind_turn00/tx_uTex_fl_singlemode_mecha_remind_turn00_0.diff.png",
-      "hash": "cf839daa6cf398bc4ffbca5ae41a0feda38363530d24869346e78cc5b66d3da2",
-      "size": 34370
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_research_lv_maxup00/tx_uTex_fl_singlemode_mecha_research_lv_maxup00_0.diff.png",
-      "hash": "436c4eb7696bfef35cc650988e661270fc3a36317078ed3aacd50812e26e9cec",
-      "size": 94698
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_research_progress00/tx_uTex_fl_singlemode_mecha_research_progress00_0.diff.png",
-      "hash": "6f00556b377b8bdc7076b6f3d57d232ee9c989b5df7f479f1a3b305c31e1e90c",
-      "size": 81661
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_research_progress_text00/tx_uTex_fl_singlemode_mecha_research_progress_text00_0.diff.png",
-      "hash": "d764ed9d151e5ae2f356b0ffc36528176d366b8f268c6d5df874d31b2d80102a",
-      "size": 255070
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_sp_overdrive_activation00/tx_uTex_fl_singlemode_mecha_sp_overdrive_activation00_0.diff.png",
-      "hash": "0482743bbbd0ffbced3df17d497288427ff6b9829c79283a32746914ae5fdbf6",
-      "size": 500687
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_sp_overdrive_btn00/tx_uTex_fl_singlemode_mecha_sp_overdrive_btn00_0.diff.png",
-      "hash": "cff550e14d1823f167aff26de76212e7e852174b3ad76a7d9182229032b6b127",
-      "size": 344130
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_sp_overdrive_continuation00/tx_uTex_fl_singlemode_mecha_sp_overdrive_continuation00_0.diff.png",
-      "hash": "e272f86033ade82ec6bac0a67ab8207ae86de69479ed0e82ab975a6689977710",
-      "size": 53690
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_target_research_level00/tx_uTex_fl_singlemode_mecha_target_research_level00_0.diff.png",
-      "hash": "2c9d82dc871c90ed861a3f99ccdebb9cdf1edd24b22f5fc31bd5e28540113d1a",
-      "size": 28511
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_trainingmenu_base00/tx_uTex_fl_singlemode_mecha_trainingmenu_base00_0.diff.png",
-      "hash": "597708d677ccd024728834ac91fd43bacbdefe34cc98030d9d8285c8b8f0fca5",
-      "size": 15393
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_tuning_text00/tx_uTex_fl_singlemode_mecha_tuning_text00_0.diff.png",
-      "hash": "f4e3b18e3e53602b5850c00e8e7934c1667a4dd7625dc17f87d8fae1a0542f44",
-      "size": 577260
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_tuning_transition00/tx_uTex_fl_singlemode_mecha_tuning_transition00_0.diff.png",
-      "hash": "bea3f57d5c667718383318c387c55d89386218550f3c74472755eeed1a5e8319",
-      "size": 212319
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_txt_upgraderesult00/tx_uTex_fl_singlemode_mecha_txt_upgraderesult00_0.diff.png",
-      "hash": "7734f00a0eb26429e5f27f6f906d4b2d215a12beb50ab5302094ed2a4182bbba",
-      "size": 419707
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_upgradeexam_btn00/tx_uTex_fl_singlemode_mecha_upgradeexam_btn00_0.diff.png",
-      "hash": "fe86d934a7b886f953c5e786eb209e26b0d8485ce27177c76aab9cdd38ddf8ad",
-      "size": 76652
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_upgradeexam_start00/tx_uTex_fl_singlemode_mecha_upgradeexam_start00_0.diff.png",
-      "hash": "ebbfd7ab512626dfd4d6e91f536b52cd76a7866234fd366465bc1ade71aa7ca8",
-      "size": 71175
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_next_target00/tx_uTex_fl_singlemode_next_target00_0.diff.png",
-      "hash": "fef55939d571ed3176f2d1c536a2a1f50078a7dba015562808f0ac085ecfcb9a",
-      "size": 94746
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_btn_evaluate_decide00/tx_uTex_fl_singlemode_pioneer_btn_evaluate_decide00_0.diff.png",
-      "hash": "b967ad99ce21eb8009f97790d849e1fb868dc6d5c6442d1ad03d9c1bc1a8c888",
-      "size": 75752
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_btn_trainingmenu01/tx_uTex_fl_singlemode_pioneer_btn_trainingmenu01_0.diff.png",
-      "hash": "2a8930e1de102e95afd943ea1d6417e2e2ba828243542a2671e8998e6468f763",
-      "size": 10575
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_btn_trainingmenu_shima00/tx_uTex_fl_singlemode_pioneer_btn_trainingmenu_shima00_0.diff.png",
-      "hash": "16d6add486996fb9aae0bdd5b071c8ad8d6d5795c44b4f5077d4db78a2946345",
-      "size": 16772
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_construction_progress00/tx_uTex_fl_singlemode_pioneer_construction_progress00_0.diff.png",
-      "hash": "2e79b1853d6548c43587ea9f0085a28eabc9faa207d5d42018db1312935698fb",
-      "size": 98202
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_construction_progress_text00/tx_uTex_fl_singlemode_pioneer_construction_progress_text00_0.diff.png",
-      "hash": "ff72fc7b7da48097a10d15b5260611d47586e6965642303d63bb3af608cd27b1",
-      "size": 194495
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_evaluate_start00/tx_uTex_fl_singlemode_pioneer_evaluate_start00_0.diff.png",
-      "hash": "fd6d93f6e799eba760bb69cbbb4c452167fb9df8fc9d2a57d682983eb9e31e6c",
-      "size": 103613
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_evaluate_start01/tx_uTex_fl_singlemode_pioneer_evaluate_start01_0.diff.png",
-      "hash": "1390c7538bb19855326c6eeef843608e4a476930d5991464cfcf1da089df7c5f",
-      "size": 70898
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_event_join00/tx_uTex_fl_singlemode_pioneer_event_join00_0.diff.png",
-      "hash": "f781a32fba451d3af4b87646bb699234b3cb65538e08e5839f438d3de74a5bec",
-      "size": 98924
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_gauge_shimatraining00/tx_uTex_fl_singlemode_pioneer_gauge_shimatraining00_0.diff.png",
-      "hash": "bea05b9f57267759f135abd81f696066aa206f2d2a6083a8efd54911701e06b2",
-      "size": 6184
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_complete00/tx_uTex_fl_singlemode_pioneer_island_complete00_0.diff.png",
-      "hash": "2acee396a0cc0d3b65d2c6f641d4d43323364a06187c27b5c9fa752f38cc8061",
-      "size": 165694
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_complete01/tx_uTex_fl_singlemode_pioneer_island_complete01_0.diff.png",
-      "hash": "1d06418b2543944563daa51ba7c90326cb430ec169d0b6fc6eafd532b721df54",
-      "size": 220394
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_hint00/tx_uTex_fl_singlemode_pioneer_island_hint00_0.diff.png",
-      "hash": "5c71198593d8a9748ce1aefd01115b90a28c22a88207abce35fe992fe3f145c1",
-      "size": 2995
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_transition_logo00/tx_uTex_fl_singlemode_pioneer_island_transition_logo00_0.diff.png",
-      "hash": "5609e5bd1ea376e31b6c8297e884426ad8164256b32443294783dba06d94a421",
-      "size": 89771
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_transition_logo01/tx_uTex_fl_singlemode_pioneer_island_transition_logo01_0.diff.png",
-      "hash": "ea62eebb240826152c2319eca199125e9c741895a9d424e67265314ebe7a361a",
-      "size": 96554
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_notice_window00/tx_uTex_fl_singlemode_pioneer_notice_window00_0.diff.png",
-      "hash": "d6618e1d867b8fd0b8650d148f6862ffee4674807c664da0994c5e5b13c180f8",
-      "size": 118207
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_planning_island00/tx_uTex_fl_singlemode_pioneer_planning_island00_0.diff.png",
-      "hash": "16f72fbaa464cfe236022d18a5ebf2bf7f09818746201465f8a505e9621fa7b4",
-      "size": 24982
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_remind_turn00/tx_uTex_fl_singlemode_pioneer_remind_turn00_0.diff.png",
-      "hash": "d748bafae6b93ed73338f4afd840846e4d49e4f79c8f00981943496266627817",
-      "size": 24570
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_shimatraining_acquire00/tx_uTex_fl_singlemode_pioneer_shimatraining_acquire00_0.diff.png",
-      "hash": "c51925d5ad803f7251455ff450d0051dec27237d82ba0c38d04e8b0848c12b4e",
-      "size": 51517
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_shimatraining_period00/tx_uTex_fl_singlemode_pioneer_shimatraining_period00_0.diff.png",
-      "hash": "c80544813892e33ecd95a660aa755509c2f6b92865658ad0d3c0e8e7f8cf176a",
-      "size": 60185
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_shimatraining_split00/tx_uTex_fl_singlemode_pioneer_shimatraining_split00_0.diff.png",
-      "hash": "4d83a70bdb3c52322115daa5ed92152548a6b397acdeb77a312e0d19768c2111",
-      "size": 102049
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_start_tagtraining00/tx_uTex_fl_singlemode_pioneer_start_tagtraining00_0.diff.png",
-      "hash": "2f3cf3d477a663a0aac52af886dd0303ec6daa9e949f9f9ea37350e22e08f475",
-      "size": 126506
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_training_facility_upgrade00/tx_uTex_fl_singlemode_pioneer_training_facility_upgrade00_0.diff.png",
-      "hash": "a8d89ba6c5ac08d8789e23495e2203f0b1d2f0cd601c35428a84c2de3a145615",
-      "size": 57768
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_trainingmenu_base00/tx_uTex_fl_singlemode_pioneer_trainingmenu_base00_0.diff.png",
-      "hash": "dc9dcc2ccd7e0af312d4e32262cc0d5c28edb369c1bb447916e597560660174e",
-      "size": 46821
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_txt_evaluateresult00/tx_uTex_fl_singlemode_pioneer_txt_evaluateresult00_0.diff.png",
-      "hash": "5318c8f6243636fc21502f59ed82c25b800d5405b596f7f4c2e587f37c6da920",
-      "size": 709729
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_txt_shimatraining00/tx_uTex_fl_singlemode_pioneer_txt_shimatraining00_0.diff.png",
-      "hash": "78c103944209477362aa44ce937c244092b03346b8b1c3c1823970f5cabfb2ef",
-      "size": 64397
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_txt_tagtrainingresult00/tx_uTex_fl_singlemode_pioneer_txt_tagtrainingresult00_0.diff.png",
-      "hash": "34c7e599cee390dd5da26d0c608e5c59d27a42b32c6abccf8e33e63ef537b1c6",
-      "size": 325729
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_result_chararank00/tx_uTex_fl_singlemode_result_chararank00_0.diff.png",
-      "hash": "51b577209ab256a969d88e98a3d38163b29a62d917e82ba7c707004d0bcccccc",
-      "size": 19425
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_result_scenariorecord00/tx_uTex_fl_singlemode_result_scenariorecord00_0.diff.png",
-      "hash": "62629c34cac8770a438f2c8980fbeb16faf5dde524ed6de2928a8ed64f80ab58",
-      "size": 289609
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sectionstart01/tx_uTex_fl_singlemode_sectionstart01_0.diff.png",
-      "hash": "faa31e9ca7165414ba2fb61f02a6bbef2bd049d3c6eee6571771d397dc9399f8",
-      "size": 53744
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_single_target_achieve00/tx_uTex_fl_singlemode_single_target_achieve00_0.diff.png",
-      "hash": "5017a84ef911c828b431acb8dc8744f65914f2860dd5c0b8f3e6cc40880043c6",
-      "size": 75467
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_skillupgrade_skillname00/tx_uTex_fl_singlemode_skillupgrade_skillname00_0.diff.png",
-      "hash": "bc18517c528415d9d58a6aa7ab7b0db328e143b21fc66d64e19ed1e7012023d5",
-      "size": 208459
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_btn_competition_decide00/tx_uTex_fl_singlemode_sport_btn_competition_decide00_0.diff.png",
-      "hash": "cf931c223c51a41af1d6c6b885bbad59ad1c28b5ca9e739b0fa0a7450b378fb6",
-      "size": 81183
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_btn_trainingmenu00/tx_uTex_fl_singlemode_sport_btn_trainingmenu00_0.diff.png",
-      "hash": "9f82411517ad5dfa0a148833e5f360af759f1be0ead64d25456309258f4e6ba3",
-      "size": 10855
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_competition_gauge00/tx_uTex_fl_singlemode_sport_competition_gauge00_0.diff.png",
-      "hash": "fc4f3cf25809a8fd19e54c32c37b8603e9daba1e7581f187a258728c13fd22f4",
-      "size": 92973
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_competition_telop00/tx_uTex_fl_singlemode_sport_competition_telop00_0.diff.png",
-      "hash": "311c5f78cfc05aaddee21eada63a4b534a2c3a1e40d495fafaf29beb6c5e20cc",
-      "size": 10829
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_event_advice00/tx_uTex_fl_singlemode_sport_event_advice00_0.diff.png",
-      "hash": "ba631325fb9d5fc8e16f4acae960c3d47273d33cf64d07436b657201a639538a",
-      "size": 49662
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_event_stance_rankup00/tx_uTex_fl_singlemode_sport_event_stance_rankup00_0.diff.png",
-      "hash": "cfc4e18b4c0c718c4c61abb8502ab0a1e794e0eec29256eccd171729e67a9249",
-      "size": 62167
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_header_turncounter00/tx_uTex_fl_singlemode_sport_header_turncounter00_0.diff.png",
-      "hash": "9e7322cd81d44b0a7a6f08f924566dcb3fab314e5c3f4f901957f7b9a39773a6",
-      "size": 10184
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_remind_turn00/tx_uTex_fl_singlemode_sport_remind_turn00_0.diff.png",
-      "hash": "6c9df71503ea623b9fa3a9574deb234c2358dda3b554e4cd4c100577dc53f974",
-      "size": 58579
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_showdown_result00/tx_uTex_fl_singlemode_sport_showdown_result00_0.diff.png",
-      "hash": "9ecacd97a619fe6f5d9d47f4fdd5e664d25faf583a6ec178a5a015d7489d989a",
-      "size": 177654
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_trainingmenu_base00/tx_uTex_fl_singlemode_sport_trainingmenu_base00_0.diff.png",
-      "hash": "a45097bf9e53e8b8ba4b0bfface4b5a81e04d93224689020a5bda116be2a9cdf",
-      "size": 15690
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_competitionend00/tx_uTex_fl_singlemode_sport_txt_competitionend00_0.diff.png",
-      "hash": "3c875732077c41e146e5f066976d4c333be2161b689b2e557b02f93cf3eb81d6",
-      "size": 61099
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_heatup00/tx_uTex_fl_singlemode_sport_txt_heatup00_0.diff.png",
-      "hash": "799bd2e14916b45b53d4ed064dde93d4c1ed51750c612229faeac437beb0f8ac",
-      "size": 37496
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_tagtrainingresult00/tx_uTex_fl_singlemode_sport_txt_tagtrainingresult00_0.diff.png",
-      "hash": "08be52384adf917150d94af362d7717f8ce9df4ba26228a7daf8d684b32283da",
-      "size": 215640
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_trainingresult00/tx_uTex_fl_singlemode_sport_txt_trainingresult00_0.diff.png",
-      "hash": "bd9d3599a33350a7a49fc236dd3537c10aee85c6bf8326d717c6d024a791cdbd",
-      "size": 182748
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_start_succession00/tx_uTex_fl_singlemode_start_succession00_0.diff.png",
-      "hash": "0bf87054fdeb8dd4615a037b2a99e71ec3a82a7bf1c47912e23932d4e81401e5",
-      "size": 69688
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_start_tagtraining00/tx_uTex_fl_singlemode_start_tagtraining00_0.diff.png",
-      "hash": "c6d68b041e417f5db1ce85719184a7ef3247718834e3db4df1e00207f90737a8",
-      "size": 99789
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_target_decision00/tx_uTex_fl_singlemode_target_decision00_0.diff.png",
-      "hash": "596469e902f3e063a02a501625600c9208e13791b51d74da63723ec682504de7",
-      "size": 45444
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_teamrace_btn_trainingmenu00/tx_uTex_fl_singlemode_teamrace_btn_trainingmenu00_0.diff.png",
-      "hash": "2af8b0e21fabe982b30d2cf8670977851ceb5ab04fe30edc53087935db5d5838",
-      "size": 6418
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_teamrace_header_turncounter00/tx_uTex_fl_singlemode_teamrace_header_turncounter00_0.diff.png",
-      "hash": "b6a8cbd2c6f4c71ab97e1f07c192225a847fa2ea67218e54614176e3171c3dc0",
-      "size": 8837
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_title_getfactor00/tx_uTex_fl_singlemode_title_getfactor00_0.diff.png",
-      "hash": "03ebc06fedbc9eaea38fd102133e027f2b9e0ed0ed65d2e7039a94b53a872f84",
-      "size": 80436
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_title_getreward00/tx_uTex_fl_singlemode_title_getreward00_0.diff.png",
-      "hash": "15e49802eb915c9634071fb7f0694e6c4d4a951d7e759dcdfe4d0c68f2845cf3",
-      "size": 67574
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_auto_training00/tx_uTex_fl_singlemode_txt_auto_training00_0.diff.png",
-      "hash": "394de1d314eabe97f0d675eaa68753965d5d3cff4e2e115e69d405e44c93bf33",
-      "size": 17819
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_factor_succession00/tx_uTex_fl_singlemode_txt_factor_succession00_0.diff.png",
-      "hash": "0a56990c45f9eae5a52b66104a4c74667b7a1535a06bce750352eda9826b5b7e",
-      "size": 91713
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_tagtrainingresult00/tx_uTex_fl_singlemode_txt_tagtrainingresult00_0.diff.png",
-      "hash": "b7766191b5b29e59928256eb01a6061747be7ee57fb2ef7fd96de2587c3d1eec",
-      "size": 225445
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_trainingresult00/tx_uTex_fl_singlemode_txt_trainingresult00_0.diff.png",
-      "hash": "b3046e2c92425bc6a44f644f11fbadb4d8536ff47da17fad3fdb42e71c01762f",
-      "size": 118546
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_acquire_spirit00/tx_uTex_fl_singlemode_venus_acquire_spirit00_0.diff.png",
-      "hash": "5a5c32d54807495c1bb0205664e75d9670f3fb453f9ed4c82816cd81054218b3",
-      "size": 351909
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_btn_trainingmenu00/tx_uTex_fl_singlemode_venus_btn_trainingmenu00_0.diff.png",
-      "hash": "86032b9953786f6cfb855ea5d9021f13e53e71646fbeb7464433ebe881a1c783",
-      "size": 6343
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_enabletagtraining00/tx_uTex_fl_singlemode_venus_event_enabletagtraining00_0.diff.png",
-      "hash": "1feaeec3aca752008fc00a58c00c30d3cc36a7279e033cc3390f6b02341252a9",
-      "size": 78180
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_upeventrate00/tx_uTex_fl_singlemode_venus_event_upeventrate00_0.diff.png",
-      "hash": "5d1cca8c816554c929a0bf99f86d2c2171e208d8a95ec269783db253cc4b4a93",
-      "size": 85907
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_upknowledgelv00/tx_uTex_fl_singlemode_venus_event_upknowledgelv00_0.diff.png",
-      "hash": "83c590a2307cebd2582f1b821851c9cd5dfc46f74ecfeee576dfbac16bac3c7e",
-      "size": 39013
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_upskillhinteventeffect00/tx_uTex_fl_singlemode_venus_event_upskillhinteventeffect00_0.diff.png",
-      "hash": "7dcb62976405ae58a388b69179f4067810e14da3ba9631b92e99a233320bd358",
-      "size": 60363
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_uptrainingeffect00/tx_uTex_fl_singlemode_venus_event_uptrainingeffect00_0.diff.png",
-      "hash": "3198a3515fd5e58555ddb887c4730922ce4f0a1704a0625dcae3014dc6d2bdec",
-      "size": 74824
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_venusappear00/tx_uTex_fl_singlemode_venus_event_venusappear00_0.diff.png",
-      "hash": "3fe53b9804ca2de39fc43e87b77974b6daaac0c417b1486b6ed5e341a9ed02cc",
-      "size": 157888
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_get_spirit00/tx_uTex_fl_singlemode_venus_get_spirit00_0.diff.png",
-      "hash": "6f446588c5c7f701b5d7b605bfa8f043b9f606e44574ada4ae9edcda41d79b37",
-      "size": 73925
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_get_venus_spirit00/tx_uTex_fl_singlemode_venus_get_venus_spirit00_0.diff.png",
-      "hash": "38f08e4f3c83e97fc613ef9e9d3183fa710e06258112b0dcdc64561e3a956970",
-      "size": 221672
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_header_turncounter00/tx_uTex_fl_singlemode_venus_header_turncounter00_0.diff.png",
-      "hash": "8a43ffaedd8fc23bc1ce8090819b258d743dee59c587a45da4c94e2090918f47",
-      "size": 7843
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_remind_turn00/tx_uTex_fl_singlemode_venus_remind_turn00_0.diff.png",
-      "hash": "853e3a7f41065c1343cd6d55ba320ecb387226e4f79e729962cb79dc2f6c55d7",
-      "size": 28868
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_spirittree00/tx_uTex_fl_singlemode_venus_spirittree00_0.diff.png",
-      "hash": "5838271c22c53ebb72dc82516c1ad537efb27515c8f70ad4bd8de07d84d19fa2",
-      "size": 36980
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_txt_tagtrainingresult00/tx_uTex_fl_singlemode_venus_txt_tagtrainingresult00_0.diff.png",
-      "hash": "65bbdaf672def4e14d88d8a721c06c3fdf019121761a9fef97d03f8fc4b83130",
-      "size": 241779
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_txt_trainingresult00/tx_uTex_fl_singlemode_venus_txt_trainingresult00_0.diff.png",
-      "hash": "ab48ddd191317c042619b12755c037a6a246bfe461d9d85083e15eb11678f3a8",
-      "size": 101550
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_team_icon_winconfirm00/tx_uTex_fl_team_icon_winconfirm00_0.diff.png",
-      "hash": "df2653b2957139376271d32d19abf8e2b131d1bdc925a3d92e5ae2ff3efc3456",
-      "size": 17489
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_team_txt_winning_reward00/tx_uTex_fl_team_txt_winning_reward00_0.diff.png",
-      "hash": "18686a3bb4b77bb45bd537bffb565dd8e6baaf17b55ef29c1bdecac2f6b2b2dd",
-      "size": 134533
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_trainingreport_reward00/tx_uTex_fl_trainingreport_reward00_0.png",
-      "hash": "efc464756bcd3e3caca7b3f1480124d1ffaa98f214cf1c373ed6999f202024ad",
-      "size": 101832
-    },
-    {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_transfer_txt_negotiation00/tx_uTex_fl_transfer_txt_negotiation00_0.diff.png",
-      "hash": "dea566a4b63ac316e1727fa9ddf588a5161ab9d6da2475dd5a8660ca9a28ec55",
-      "size": 100782
-    },
-    {
-      "path": "assets/atlas/campaign/campaign.diff.png",
-      "hash": "d14a087abaf2dbe4741fa0f5ebc3ad48ef9fc3edbcf1249e3775caf370c95e18",
-      "size": 107733
-    },
-    {
-      "path": "assets/atlas/campaign/campaign.json",
-      "hash": "b7b97f3a8002eda0a5c597ac8c1fe47987be3d89c65c17151dcf9af12cd0855f",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/challengematch/challengematch.diff.png",
-      "hash": "c3ce185aad28a50bc6e01ca53edc28cef0292796970917ba2a05af260677c059",
-      "size": 182265
-    },
-    {
-      "path": "assets/atlas/challengematch/challengematch.json",
-      "hash": "ec68afef58d7eb66958d784f00213a20aa2b7342b1449a0cdc6595331e15d294",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/championsmeeting/championsmeeting.diff.png",
-      "hash": "120759ec6305bb95c912d6cb7e29cfc3dcade15ce6d161d2ed10949050985625",
-      "size": 1325416
-    },
-    {
-      "path": "assets/atlas/championsmeeting/championsmeeting.json",
-      "hash": "35f22a63abe0524fed5d21cbff42c32c774759a00f4655e4eed57f45123a322b",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/common/common.diff.png",
-      "hash": "90dc7df0efd7328c708a5087eee3a75521721f6f171c31b15d572d55945853ed",
-      "size": 418883
-    },
-    {
-      "path": "assets/atlas/common/common.json",
-      "hash": "5dbee5a0bb1e9652abe613bd9433442bc6aae185958c36c3e3a1ea3d785bfc76",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/factorresearch/factorresearch.diff.png",
-      "hash": "6a700ff1cf61a7824b1f21eda2bcef3489f39d328b8bf81738222634cd8fff2d",
-      "size": 47640
-    },
-    {
-      "path": "assets/atlas/factorresearch/factorresearch.json",
-      "hash": "6ca0b2d4a814f631afc5d621d24d93c8e13dd22ee584a73235926b1e12c85ce3",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/gacha/gacha.diff.png",
-      "hash": "316ff269f8a82544df13f13da8dff3e16e9bef6c2c5aefce85b8c746ddcfe477",
-      "size": 530647
-    },
-    {
-      "path": "assets/atlas/gacha/gacha.json",
-      "hash": "54a7e8321366257d15091d2718aecaef457a8eebe6fcaa32911f08cb81146904",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/heroes/heroes.diff.png",
-      "hash": "028348e544a11ebed253d7738270c6710e351f898d11ec88acf668319331f63f",
-      "size": 696284
-    },
-    {
-      "path": "assets/atlas/heroes/heroes.json",
-      "hash": "2719df38733c986eaa030942340167100c52c16094fdacd458b97da233b1bb86",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/home/home.diff.png",
-      "hash": "714a510c1c0399d55f1c1dc18dfcdb222fb2ab4425570e4fe4e398bccb088f9f",
-      "size": 141323
-    },
-    {
-      "path": "assets/atlas/home/home.json",
-      "hash": "32d8305bcb6e55fe9ec4640b941c93654ddb2099f09951ba1806dad4481cf5bd",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/mission/mission.diff.png",
-      "hash": "36fb0386f3f56725bfc59994f846fc8720e08e9be7a3a028fdeea6f5d35a44ea",
-      "size": 12672
-    },
-    {
-      "path": "assets/atlas/mission/mission.json",
-      "hash": "4da1e5aa54099ca8194f8f73a339869a24d453b1b5476ca9040c2947f2c74f48",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/photostudio/photostudio.diff.png",
-      "hash": "7e7b0ec37c62e52d0aec6c34bb9ab0dae45eed0ba0fcddfa3842cdfabee314ec",
-      "size": 7521
-    },
-    {
-      "path": "assets/atlas/photostudio/photostudio.json",
-      "hash": "bb0e702d18e3a0aeb6694ed122b5746e4dcebfe3d7f1b1094f45206824703403",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/practicerace/practicerace.diff.png",
-      "hash": "95eb03d85c8f1d39627b4a202fa1a0a4e8fbc0b7f2791756b4695a5723dbd948",
-      "size": 33416
-    },
-    {
-      "path": "assets/atlas/practicerace/practicerace.json",
-      "hash": "bfcd1f8589cde8cbef297ce41f34a009e07c4098058fa8180aee63a24670c7a2",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/race/race.diff.png",
-      "hash": "505008314ddfc36f03173f5458382e85400dd03ec17d94455e8562e454339870",
-      "size": 374921
-    },
-    {
-      "path": "assets/atlas/race/race.json",
-      "hash": "ddff08b743744230f9b19e38336832ada6afbdee0a7edc3d39ac3bbae65d5039",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/racecommon/racecommon.diff.png",
-      "hash": "ba7831d3ed2e6449c1ab0751ecfdecdc22875c999c48bb9088dc7ef2d5efd66a",
-      "size": 77088
-    },
-    {
-      "path": "assets/atlas/racecommon/racecommon.json",
-      "hash": "7f18ecf6ca4c3e6d46fdcb0d394526db622872630bb4e9ea53f796ee91f8297d",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/raceorder/raceorder.json",
-      "hash": "1c9a57cff67b0a7fb1fcb2f596601b54f786567f3d304a341d0560922547891f",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/raceorder/raceorder.png",
-      "hash": "930ac3f776e6a9b7b0b55526bcef53d2e4a0085a6fb94b6a7f3776ba501ebf8a",
-      "size": 649347
-    },
-    {
-      "path": "assets/atlas/roommatch/roommatch.diff.png",
-      "hash": "7a4439168e7678636dbbd5c3528ac0def3f39380075bde2edf8668ea5497e26e",
-      "size": 74885
-    },
-    {
-      "path": "assets/atlas/roommatch/roommatch.json",
-      "hash": "04ce0fb2e9190d335ab63739598beae90552919a4e21207c535f6ed02306455b",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/schedulebook/schedulebook.diff.png",
-      "hash": "c86d44176f3b1dfc241b7b6e76986d04a967ff9cf829a0bbdf49ca5621cef60c",
-      "size": 16700
-    },
-    {
-      "path": "assets/atlas/schedulebook/schedulebook.json",
-      "hash": "dc22d9a58a21dbcbdfbca2533a5014b3aa0dae5036798dd8fb2444f84c5d9678",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/single/single.diff.png",
-      "hash": "1167fe790e7da6af03c43510f5c378c3435f82e432c77284715677d6418cc158",
-      "size": 152194
-    },
-    {
-      "path": "assets/atlas/single/single.json",
-      "hash": "b6702d06015a0e9b52f15e3e8ab3dd468646c2216ee55d9b74a3502d719a6eb9",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenarioarc/singlemodescenarioarc.diff.png",
-      "hash": "dcca72aa950fa7d0879476348d180572eca05ab07a1a736230ff60ad83650ce1",
-      "size": 227861
-    },
-    {
-      "path": "assets/atlas/singlemodescenarioarc/singlemodescenarioarc.json",
-      "hash": "ca0818e2a2b7337bc8d47b5fbda9de25da759f458183da52126aa56e4cf4b75f",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariocook/singlemodescenariocook.diff.png",
-      "hash": "2cab1da13661442dbcca628d8103471fb2cd352bd0638f3e258c0b6217c273d2",
-      "size": 334681
-    },
-    {
-      "path": "assets/atlas/singlemodescenariocook/singlemodescenariocook.json",
-      "hash": "c9863c493c03c4665a0dea37ab4e3bd1765fc1ce812efcbad219197fe64d5f23",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariofree/singlemodescenariofree.diff.png",
-      "hash": "fa974d73d7aa2c052931e9490a6a65edf3935bdf77fc43f6b809c1bb76bd7e4a",
-      "size": 404901
-    },
-    {
-      "path": "assets/atlas/singlemodescenariofree/singlemodescenariofree.json",
-      "hash": "70bdd7f015966f28850173aad48a331780fab993f4ce4f554874160052eedc37",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariolegend/singlemodescenariolegend.diff.png",
-      "hash": "aa01704a2b459441942521a9b05ae86508de7d7454fdd3340dbdb73aee6a52b8",
-      "size": 56892
-    },
-    {
-      "path": "assets/atlas/singlemodescenariolegend/singlemodescenariolegend.json",
-      "hash": "0a16bba8e48cdde765f368277620887a1b7d8fe45ea069304e36e2dae51c4e16",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariolive/singlemodescenariolive.diff.png",
-      "hash": "9c049ad7cbe020fa040354af8816872a8f2060ec287abddaf2e6f0040bf78c03",
-      "size": 324007
-    },
-    {
-      "path": "assets/atlas/singlemodescenariolive/singlemodescenariolive.json",
-      "hash": "9c845bbcc4379542826aa405315c4ff22f0500b6260eb1dcb6ad37c06783b358",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariomecha/singlemodescenariomecha.diff.png",
-      "hash": "17556c52aaf17292df3f4a5c1a9392b3174bdd7a7a772c3d2048e4be23921f3b",
-      "size": 110937
-    },
-    {
-      "path": "assets/atlas/singlemodescenariomecha/singlemodescenariomecha.json",
-      "hash": "60de387c674b44eb4f60951c297c19e5023e29275e5749f463b27c205fde2ae2",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariopioneer/singlemodescenariopioneer.diff.png",
-      "hash": "1cbbdf9a59d12a52655287e861e2569babf0aeefc540031493bfbedf43627b8f",
-      "size": 398743
-    },
-    {
-      "path": "assets/atlas/singlemodescenariopioneer/singlemodescenariopioneer.json",
-      "hash": "bfaeaf69bd4fa5c57c740f68e1dc0e2391cc94a002a210861ee63ec8965516de",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariopioneerfacilityicon/singlemodescenariopioneerfacilityicon.diff.png",
-      "hash": "ab77b72cc68446baf9d9b6e8052985f900e8621879945968559c783a9bb8e123",
-      "size": 18444
-    },
-    {
-      "path": "assets/atlas/singlemodescenariopioneerfacilityicon/singlemodescenariopioneerfacilityicon.json",
-      "hash": "c7c9d6e047aeab4a488ea9d2ce995c4211e3089cbcdd5166a6fcbf82350127bb",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariosport/singlemodescenariosport.diff.png",
-      "hash": "152f44cbfba4a5bd9c8cdcd78aec18b5d58f258f841b8cc31ace0ae177fad368",
-      "size": 129828
-    },
-    {
-      "path": "assets/atlas/singlemodescenariosport/singlemodescenariosport.json",
-      "hash": "bfd1ce9c3b190184d97be3ce5432018c3cc02ec6b4018ace3176ae32b44e4f05",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenarioteamrace/singlemodescenarioteamrace.diff.png",
-      "hash": "db28502f4e3496bd943e404b00150c02682146d664116b3b9bbf58e98da28f7a",
-      "size": 309428
-    },
-    {
-      "path": "assets/atlas/singlemodescenarioteamrace/singlemodescenarioteamrace.json",
-      "hash": "8d89a587faa0df908fce068ac26725c45fbbc9ab598be85a192ee02933523d15",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlemodescenariovenus/singlemodescenariovenus.diff.png",
-      "hash": "e60a0438b7499ec2b46f6ff2dc09f4b2122903abd85d2f4f158443424f56be94",
-      "size": 152064
-    },
-    {
-      "path": "assets/atlas/singlemodescenariovenus/singlemodescenariovenus.json",
-      "hash": "15f90dc30de025a93000e887e2116587836a2f32a4ed13e6de26fae0dc7dbc21",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singleresult/singleresult.diff.png",
-      "hash": "a752a1b60204e2ad3e5dab297fd09f3638ca35b107c838b6d1efe72f13b77998",
-      "size": 98618
-    },
-    {
-      "path": "assets/atlas/singleresult/singleresult.json",
-      "hash": "b9e8ab06e6c60ae028df57b6f6805462a61a33005629d5169fd118d7e28dbbb0",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/singlestart/singlestart.diff.png",
-      "hash": "dbcabf1a510b73bf277809138941e79c5b16193183b3cd06b5f38a47010b0af8",
-      "size": 75501
-    },
-    {
-      "path": "assets/atlas/singlestart/singlestart.json",
-      "hash": "749af68822cb9bf6f48ec20b4f6e4aa8aa9b8c2679c8f637448ced36f54db340",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/storyevent/storyevent.diff.png",
-      "hash": "103dbb76bb86db5a7dbdeb289f0d3d65b49913509f6b39159a3eb07bf6f978e1",
-      "size": 235915
-    },
-    {
-      "path": "assets/atlas/storyevent/storyevent.json",
-      "hash": "495e79a30603c7cb0f3ec98851bb1b97282d022defccb464a306006664a82705",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/teambuilding/teambuilding.diff.png",
-      "hash": "11539f116502f9f8792b0529bc759a58cd0c46f2ebf8e74ed69aa2f451ac264c",
-      "size": 446989
-    },
-    {
-      "path": "assets/atlas/teambuilding/teambuilding.json",
-      "hash": "d0bbc8cae34537ff9319533d8a6a361acf86c2364d4c9168dac94f718fc8290a",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/teamstadium/teamstadium.diff.png",
-      "hash": "0cef50684171432b6d214e9ced1d3757469ef037cfb426332d6e5a27764e637d",
-      "size": 712062
-    },
-    {
-      "path": "assets/atlas/teamstadium/teamstadium.json",
-      "hash": "36f4b65c0182d6cad6c7bc3dbef17ba696e977f8f24d3942aa6fc14baa09c2b1",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/trainingreport/trainingreport.diff.png",
-      "hash": "b824e9b669d544b15fcabcf1dba42db7b00f3bd47c921f8fe826198274ca962f",
-      "size": 98758
-    },
-    {
-      "path": "assets/atlas/trainingreport/trainingreport.json",
-      "hash": "0154b50f59a3bdcb13e4de40aba734d7e116e73931df048515b2d71ae8476a07",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/transferevent/transferevent.diff.png",
-      "hash": "c50875b4a64ebea892ca6b77c43ced99b212a25ac7ae1e15e9f01369f1dd105e",
-      "size": 119937
-    },
-    {
-      "path": "assets/atlas/transferevent/transferevent.json",
-      "hash": "1e681af6288764f9a0df3022e7b5fc64643e41ce4823664f7c0d0a1cd9bda3b2",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/umamusume/umamusume.diff.png",
-      "hash": "5095e5e45bdd7da62b606ff25f48e5bc5b1cf0384a588c09d5296ae83f2d3937",
-      "size": 12000
-    },
-    {
-      "path": "assets/atlas/umamusume/umamusume.json",
-      "hash": "a079d1aae2ae198af513911299b72ac04a87cd0983d9ec7b4e260eeea5f127f2",
-      "size": 166
-    },
-    {
-      "path": "assets/atlas/walking/walking.diff.png",
-      "hash": "bae6b4b8655e5ecbd6fbc19e9f9db6758554d08c74e0c7880764d501d877c982",
-      "size": 25622
-    },
-    {
-      "path": "assets/atlas/walking/walking.json",
-      "hash": "a35aaf8626b4fc4fe9efd360d8a073a69ae24e7db0ba67d4afd4cd160d00c9e8",
-      "size": 166
+      "path": "assets/atlas/single/single.png",
+      "hash": "8e41c104fb2e5d61a09c0f64212d3dc6aa18e0c5e574887918a3aac334298798",
+      "size": 782052
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1004001.json",
-      "hash": "2df2a508ef60203ced9efb8cdecd96761269f87a170d963fe3d3beef2a5b7b8c",
-      "size": 579
+      "hash": "2f1a26a894d6a048031febf372f98acf738bf9472904ad2e9e8717c43b8b1e06",
+      "size": 551
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1004002.json",
-      "hash": "ebed2cefb1a90554c0f41f19c46ca601be51a274604f7928c59e6e252d5ef752",
-      "size": 599
+      "hash": "1207d600058ce8cc7e30067077223e13399e101ef9e82a591aaa548af1bb6edb",
+      "size": 574
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1004003.json",
-      "hash": "7ea0b413a3767ed78575da6209e643c7710b51c154c7f3cc329d81114eeadf5f",
-      "size": 700
+      "hash": "f0acdf2b0895e53a1d07dcad95e0297060c43d219f4add39e753d93a1396504d",
+      "size": 669
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1007001.json",
-      "hash": "3633b947d4487322eb15458476d09dea2ccf891fbb8bd10ad0aaa782bc8dd6c1",
-      "size": 708
+      "hash": "37d3a7ea35bde7a2572ff48f306366d25046df07b3988e5ba0d87597803f6fce",
+      "size": 678
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1007002.json",
-      "hash": "668e52d2dd29a7cad9c30c9db0fef884697499f763e7942edb21b27c57528b82",
-      "size": 813
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1010001.json",
-      "hash": "9f4044ada0f35f21b0ec9e95df8f19872219171fd2671fe8832278da547e6385",
-      "size": 798
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1010002.json",
-      "hash": "dc97901dd725d746f6fe83a11ace4d25979160c4a3b80ccbac239c99c3cf6dd6",
-      "size": 759
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1010003.json",
-      "hash": "a6707ffc06eddb6ca064312dc4f6d5efcbf90f935b80d566d6d90840dc614106",
-      "size": 823
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1013001.json",
-      "hash": "f062a278e8b542dbd844d1d2e00a3d4af267d1b26c48f73e7ed9b2af7dd90163",
-      "size": 707
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1013002.json",
-      "hash": "2d0ab02cb05d55d3b812a498ea79de3cca146971d58cb7cc0204ef793dd07698",
-      "size": 770
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1013003.json",
-      "hash": "7af806374848002b31612ec52f359d640be5796731dd9e799bfb653de8cd5cdd",
-      "size": 625
+      "hash": "d9ba51304b8745b18cb2e24f1a5fe614748eea59cd474fcf764a614291fb42c6",
+      "size": 782
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1026001.json",
-      "hash": "97edcdf36254871bf3d9255efc4329892f0ee255c7d84e755dce5b4edf4f2954",
-      "size": 719
+      "hash": "8f353c6605e12371908751ac87c69916a2f4ae961ed2d30e2c5fdc9efdb19249",
+      "size": 690
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1038001.json",
-      "hash": "d48fbfb95dc71c9de70c2446b8fc7a60468996b8d569d6d32b65552fdf4b3d23",
-      "size": 947
+      "hash": "0d78b5afd3c5fc298bf78f59aef1c5a9bd1179a1cea8897c448c01b3fb1e2ad6",
+      "size": 913
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1038002.json",
-      "hash": "2618e85106d5b25ed73c53e0c14edec4a5b4481f079a9be5b18a63f16b9a343e",
-      "size": 642
+      "hash": "ac61284c150a9946b62072ed087c1f1ca403c176ced1bd622668e3421af6d950",
+      "size": 614
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1038003.json",
-      "hash": "b9f257cac1162e488490330467e0aead95e1effbf6250a39a17034a15af37556",
-      "size": 633
+      "hash": "0f5a04d7ddabe1088d0b682305e3c3f4bb62f93846af6200527c0a9866aac7f7",
+      "size": 602
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1043003.json",
-      "hash": "b589835c706e2c73ae137ef98880e360d0fe9439eb6a9fccd4fc70429cc34b76",
-      "size": 763
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1055001.json",
-      "hash": "9b8eb3f8d2756cbead35e496fab040298f43fa9a6007e2e5ea0d90a8a773def1",
-      "size": 748
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1055002.json",
-      "hash": "00f0f16dc03dd843ea095cd391b72a3b6ba9fadde73fc87781c7017707602c6b",
-      "size": 886
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1055003.json",
-      "hash": "1ff4c7750f7469297339ee9d55c7266cd83aca4993ba0d86b2f25b60989a95ff",
-      "size": 570
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1057001.json",
-      "hash": "1c33823e4a04bc445986b45b29602a04bd4f7e69a4bbb6474e7da993205e6ae9",
-      "size": 742
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1057002.json",
-      "hash": "02a100904b32048608b09dda7dc378009068bc7d31601e62fb97f61e778e9b6b",
-      "size": 696
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1057003.json",
-      "hash": "91daa4d3f929899455e70c4622431b2e54d064b401b6c037e6565fbd74c7b1ba",
-      "size": 717
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1058001.json",
-      "hash": "44ee04b00aedb5a23885515a3eaf8d174fab2dce42e131659076585ae94450c6",
-      "size": 605
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1058002.json",
-      "hash": "06c86294ca3cf35676d6d108bbd8a9dc2231693f7169c378b552bbb318d7c3bc",
-      "size": 720
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1058003.json",
-      "hash": "932f85c36fee7933380eacce7ce9435b4352f4fd3d6e3b6241eacb74a62c4e89",
-      "size": 599
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1066001.json",
-      "hash": "0c144403bbe04b1cf8bd7b4b8028f416e87de30ab62d59e0e549724bd9822630",
-      "size": 603
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1066002.json",
-      "hash": "cd0440be2298be6c4e9831456bc658a2d973b6c66a2eadfb163c69a93e768f04",
-      "size": 541
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1066003.json",
-      "hash": "231c39586bf5ce4acfb860418f63171c1da0ba5d638ab8604a2b740590974c20",
-      "size": 654
+      "hash": "aa662454bed4aa0c46552c1c95c567de517524b46725f62e9983cee47cac4d58",
+      "size": 730
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1068002.json",
-      "hash": "17a8216770fe60ef211f2f870fb0dc32792a6669baddc3db36e7d48d7488042f",
-      "size": 780
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1070001.json",
-      "hash": "9dc843f3dd45dc10a66b2bd32e6c1397b8d57a2900550692bb48508a289f52ca",
-      "size": 786
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1070002.json",
-      "hash": "abe36c22fa15f91a45632f00b90f47aa1203307ff0455c9744f9e1a14c3b49e0",
-      "size": 552
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1070003.json",
-      "hash": "5ea87226bbecd857d75affa0545b82b7081c88a4967ee97405535a35e36852c9",
-      "size": 700
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1076001.json",
-      "hash": "b613e390ff6808c290f4f474048d374793b59de8a125ab42cfb596c0b480cefc",
-      "size": 742
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1076002.json",
-      "hash": "5b5494ea79e732542bb40800c6e73720fdf14a19e1bcbdb2b5a7ded7801d98db",
-      "size": 829
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1076003.json",
-      "hash": "411f0ca8af5eb3f13d658dd9c2c7c42944c10eb409da5ad16302b9ff22217a6d",
-      "size": 817
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1077001.json",
-      "hash": "eefceb07fc1f53dd5302cd2ac069696912f3b4d7035c03cdb0609e88305400b4",
-      "size": 710
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1077002.json",
-      "hash": "ee51a77eb19076716568c9204ca8e653cb17370b5faec28a7e9451ca7bd7c5a4",
-      "size": 759
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1077003.json",
-      "hash": "6cf4a58e8d08b279158d6f8cc28f89b54ab8ad3aae3c2cb2d4a9a9b80a3977f3",
-      "size": 655
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1080001.json",
-      "hash": "f3fbd01a11339abeb5b1b6f63b314e17a80d4df42d1889ff65f44cc432f7766d",
-      "size": 692
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1080002.json",
-      "hash": "d61f79dbfc112a88d733c850c3599c258a99286fa709112796fe5cb046722ea7",
-      "size": 642
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1080003.json",
-      "hash": "8fd7be722374179e7233c101d035135b5a2abebf9025cc6f6dd67ac9fbe51ad6",
-      "size": 681
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1083001.json",
-      "hash": "7b70dd864274a5a0a97d3e5da066f7d1c8e79dae7b99c9e708032cf4f48cf4b8",
-      "size": 743
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1083002.json",
-      "hash": "6c5891f9a3e0cde9c9a3ccc9ad36482584ea5f17f02548792ca4ea230112941b",
-      "size": 758
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1083003.json",
-      "hash": "ff25a76b742bdbbd0b9903bb7e2576114746b1ef0e592f3094c0f8945ab397df",
-      "size": 814
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1084001.json",
-      "hash": "25f5947690b01d5ef743de2c86726657e7b79c017aa45fb200903c5d9ae0f805",
-      "size": 950
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1084002.json",
-      "hash": "2b2b97339f15bea61bfdd09e05f3174bb1e2440ba818c186a99a3e82b7d9b231",
-      "size": 798
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1084003.json",
-      "hash": "a3d73ad410cfe0f5432119dd225271e28e0c781626e08bdf85b0e3645cfbf92e",
-      "size": 743
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1085001.json",
-      "hash": "2d4e530fbe0f7868932a2619f7eed389bb2260f6007483648e2707fd7143956f",
-      "size": 630
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1085002.json",
-      "hash": "b974c7d55df277844b60b2796a011b839438a72d835444164ea2b840b82901b2",
-      "size": 830
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1085003.json",
-      "hash": "2b30614b4671daada2c3d18c83d45fd03ff2bd7ac4995001512fc6dfbfc93091",
-      "size": 494
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1086001.json",
-      "hash": "a381e7d522fdd97111812a4e49f7623ec74f22c8b42776a9e349f8484ef9f82e",
-      "size": 573
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1086002.json",
-      "hash": "f1004e3f215a42968122d4364616b9aea46fb979202fa182e69db76942712cd6",
-      "size": 647
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1086003.json",
-      "hash": "522915b4558d090c8a86d2d5a49b95f11df04ae1c9fd891fe09a9911472d25b2",
-      "size": 589
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1093001.json",
-      "hash": "1dcbc34c6024adc18bd65c66a0672a896ee2202ce350b5042158c0c307e529a4",
-      "size": 780
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1093002.json",
-      "hash": "d50fb1c07e9b2ce901c02c9173f5bed38df82318ee6f62cb4ea58408c6b1ea21",
-      "size": 628
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1093003.json",
-      "hash": "72acbc17afbad9916ace045e34f695930cf870db28a28b4cdddbfa2d1f803d9e",
-      "size": 700
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1106001.json",
-      "hash": "94297c2b00e4f45e0cf0070c4d88513e754f9979ce38aabb530e450410aa86a0",
-      "size": 670
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1106002.json",
-      "hash": "c1cd9c0ef62577284cd38d41a7b7a1b0e0921c56f87d2bf93085bc8a2a7480e5",
-      "size": 737
-    },
-    {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1106003.json",
-      "hash": "f109b028d1238553a5a2eb3d578831fafe3c746dec352ee1d53be198043b596a",
-      "size": 698
+      "hash": "3c6d8f74b1993155c3e7e3a76a4a8b083d1943709345a2ce7ed290538368f7ec",
+      "size": 748
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1004001.json",
-      "hash": "0fd8429769b3c0270767690505371838bc8679c065102ab52b521211ab2f88c0",
-      "size": 1496
+      "hash": "bd72df6646f63792ba4c4ffc4fd25a849dec68e8866ed408e5b2b42eec3502ae",
+      "size": 1453
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1004002.json",
-      "hash": "b59bd581918ed771951103b5f21b7bb0f9780d0618f52cb125ff5d3532e7aeb2",
-      "size": 1436
+      "hash": "70d39c5622d4fb6680cc5946c305f613f5ac321967b42ecbf8351a61c8fd46f9",
+      "size": 1399
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1012002.json",
-      "hash": "60f603018166029cbeb27e39cd14df27cf3be4881112df1db831e8cb8f8dc458",
-      "size": 1379
+      "hash": "53c81e45d6898f3e32d08311753ffff606d392b39b4b0dfa939bf00686d41de1",
+      "size": 1345
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1038001.json",
-      "hash": "0ca61cbde4dc1748a991bbf5a11cc3ca05ed435241663b4f26d999cf95e2a64e",
-      "size": 1297
+      "hash": "fbacc9c004a6fd2b15ec53797a7464bca2c757dc7f52500869a10d49f422bc5a",
+      "size": 1267
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1038002.json",
-      "hash": "a744ea6a29757023f3e80e0246f2c732bc93d7e17f8af17019e63224252ef924",
-      "size": 1426
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1055001.json",
-      "hash": "ad770af46270d0abed90b75ff8bf8c988d290875f3f4a164993bf2656fb23295",
-      "size": 1886
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1055002.json",
-      "hash": "3b163b13c4e17736f7712423e06179949d94fa28542a984da4209843a916db65",
-      "size": 1272
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1057001.json",
-      "hash": "35d99d9b3a38a5ab410c71ec9597d7822b235b5643916eebd0bba2b88cfeb8b0",
-      "size": 1827
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1057002.json",
-      "hash": "bf4658ff4109521577942c811028b89e771ef354538336416fb7315c1261ac16",
-      "size": 1431
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1066001.json",
-      "hash": "d0994e1a690b48db21172ad0d78bc2770481f0f856653f329e74e5ad6c389bcd",
-      "size": 1940
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1066002.json",
-      "hash": "d0fa11663fa59301080409fbc87a50cfb3b006c60bfa0bce0788f5105f12e6e8",
-      "size": 1736
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1070001.json",
-      "hash": "d613c981afaf6381b1df7e09476b0f5408cbcec7ea03455b3a1d6bdf06fa3c28",
-      "size": 2170
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1070002.json",
-      "hash": "a415ddc438996b14aaa2be3d8c296e4a9aede99d5327b99b5f16c2535590a05c",
-      "size": 1900
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1076001.json",
-      "hash": "872e6c6dff6ea1438e56e2451ffcd087e96ee454bd211eaf40cd2cae1e0fcc54",
-      "size": 1967
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1076002.json",
-      "hash": "f22ae3f9a72f7f3b5dfd6bc666250e6d34324e1e9007cf3b94a058aafb6f777b",
-      "size": 1735
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1077001.json",
-      "hash": "e6c96544ed2912b191ad699875f99e42147202489d9c1494d155d5b034e9ad08",
-      "size": 1595
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1077002.json",
-      "hash": "60c791174fb0981f7e5b7ae157b459de3e7d8630eb378a131885d295503dd02b",
-      "size": 1508
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1080001.json",
-      "hash": "0ce0d8dc098abf910361620bf1a95225e4b85e6e033a1457e443d57758dcbc71",
-      "size": 1680
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1080002.json",
-      "hash": "b77a24b532a2d868d8e0654f6151c6fb406657aa260e21d403cd91116e2ee759",
-      "size": 1738
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1083001.json",
-      "hash": "e75afa0e50aeb508dbce8891b631a8c2f718286b90777367e0abc8021d3021eb",
-      "size": 1954
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1083002.json",
-      "hash": "fd79aa938a55cba8c86ff2a01a302fbdf2e001402a1a93dbcd509e95e27e3ab0",
-      "size": 1816
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1084001.json",
-      "hash": "94c6ba441fa2828828170c837587a991119e4cb00ed3165af973724c0575612a",
-      "size": 1849
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1084002.json",
-      "hash": "77256af49188161992171830021bafc88add0cf22be96ab14ce933e4bd3b4ca3",
-      "size": 1773
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1085001.json",
-      "hash": "912f54b0ce659e8ab9b7263c6a8cd92db30c553b6024e5e735f5666de0a15c69",
-      "size": 1502
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1085002.json",
-      "hash": "b8dc8e8edb4170e16758c69ad5d0c24a3d074fac47b8225bf21ed414c8519812",
-      "size": 1824
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1086001.json",
-      "hash": "e41977bbb193c70acf1ecf24fc484efe6c3b5c17b9de40c29e8928f186daa0b1",
-      "size": 1962
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1093001.json",
-      "hash": "5828d7d56ab397b8d13b6e311f2db335f59eb58ee09e9154cc1c7bc2c36a9c52",
-      "size": 1615
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1093002.json",
-      "hash": "24908c7f6d110876b09bedc80478216644254c89beb476bf8a8f7971712f8463",
-      "size": 1945
-    },
-    {
-      "path": "assets/home/data/00000/02/hometimeline_00000_02_1106002.json",
-      "hash": "1f66100ec6877189c5ac27b8942846917631e4deec87b6fe8f905a84f23dec33",
-      "size": 1906
-    },
-    {
-      "path": "assets/home/data/00001/02/hometimeline_00001_02_1026001.json",
-      "hash": "d2e13c59f4c5714184bbcaf14f5f53f3d9d342c942b1b51fea5cec5c02a07a63",
-      "size": 1737
-    },
-    {
-      "path": "assets/home/data/00001/02/hometimeline_00001_02_1026002.json",
-      "hash": "6db5625b832c786eb2cbb1b34fa31421b93ff41ac1e6b8eb7b21ef1d6deacc47",
-      "size": 1751
+      "hash": "ef78a904ce9aeebd1cdcab1c78b04104e602f84441df8532021d67503128ea47",
+      "size": 1389
     },
     {
       "path": "assets/home/data/00001/02/hometimeline_00001_02_1032001.json",
-      "hash": "99670a4c2ebab94a95e438c473471cf60723c0de2f23d11afdc8176ed13025f7",
-      "size": 1916
+      "hash": "315db38d8b026ffa136e5207c0f5532d1d6e169bdeb5e50a4a02fa1ae09addde",
+      "size": 1873
     },
     {
       "path": "assets/home/data/00001/02/hometimeline_00001_02_1032002.json",
-      "hash": "951e04a17fa6f8ff428558cffba1861f90ec674f057c727cd5c15d36f1485875",
-      "size": 1885
-    },
-    {
-      "path": "assets/home/data/00001/02/hometimeline_00001_02_1061001.json",
-      "hash": "bc49090a670401c8bf37a1bce98568b9a1584d7e2fd09459d0ccfea4286bb352",
-      "size": 1691
-    },
-    {
-      "path": "assets/home/data/00001/02/hometimeline_00001_02_1061002.json",
-      "hash": "d5859f05c44c666812614c323b935b18fa6751fd6634e540f239b28c72d98763",
-      "size": 1674
-    },
-    {
-      "path": "assets/home/data/00001/02/hometimeline_00001_02_1081001.json",
-      "hash": "496e9bdbc55e79b8a62bc368de5fa6428133576e24b3995208a9bdc6b9332fcd",
-      "size": 1814
-    },
-    {
-      "path": "assets/home/data/00001/03/hometimeline_00001_03_1026001.json",
-      "hash": "1e76dfe07ecb7dd4e4105f808cf591e552e10968c733bfcc77f5e284bee0ccca",
-      "size": 1866
-    },
-    {
-      "path": "assets/home/data/00001/03/hometimeline_00001_03_1061001.json",
-      "hash": "7dddadc12b2be054423b15c09ffc17b41f71e14ed1e01266200c0d1109c96339",
-      "size": 1395
-    },
-    {
-      "path": "assets/home/data/00001/03/hometimeline_00001_03_1081001.json",
-      "hash": "f1f013724b5c3cdb56de2d77cdbdb26753af55640587b7d08524f49f7655f448",
-      "size": 1698
+      "hash": "685397555ece6d098705177a751c2d64bfd433201c18e5ee051bbf11ced7aaa4",
+      "size": 1838
     },
     {
       "path": "assets/lyrics/m1001_lyrics.json",
@@ -1892,11 +122,6 @@
       "path": "assets/lyrics/m1006_lyrics.json",
       "hash": "32e7f43f8caffd3a91d4ad786e6f542d9ad82478b8d790b6420682692d715bdf",
       "size": 1098
-    },
-    {
-      "path": "assets/lyrics/m1008_lyrics.json",
-      "hash": "ec2a7e3457b404b24b5fe803e13968d4fe0f1b3607f9a225e2828f16850f5d32",
-      "size": 1404
     },
     {
       "path": "assets/lyrics/m1009_lyrics.json",
@@ -1920,18 +145,18 @@
     },
     {
       "path": "assets/lyrics/m1029_lyrics.json",
-      "hash": "2c4fc1cc33b3d4a6b1d2089e1312ae53b0c358e733332a93426f740ed21bb684",
-      "size": 2610
+      "hash": "75c7b793a95b13c10ca31baa581ffa5d0c5c606f8bbed3a3ec0495274f164481",
+      "size": 2624
     },
     {
       "path": "assets/lyrics/m1030_lyrics.json",
-      "hash": "a3997b0ead0519a34f018b1f4c5f363b9d717864224a6ca2e942f41afcd86401",
+      "hash": "1815f4b487deabac2d43beacfcabd4d3944d360fb1aa00578b4f87721bfb06df",
       "size": 1259
     },
     {
       "path": "assets/lyrics/m1031_lyrics.json",
-      "hash": "a69487f8cf46213ed6eeda2a37565e2ef8a89e0f2ba9a99ed3bfa71e5394b92f",
-      "size": 1248
+      "hash": "a03d39078a7ec9fb98ed433b7186de2c6ab43db1cadf1781960e902ba2a290ae",
+      "size": 1251
     },
     {
       "path": "assets/lyrics/m1032_lyrics.json",
@@ -1944,14 +169,9 @@
       "size": 1514
     },
     {
-      "path": "assets/lyrics/m1034_lyrics.json",
-      "hash": "7fd97de85ab704c4827c53658e9f67d27ed65ef82a11d7103042014d611f0cbd",
-      "size": 2348
-    },
-    {
       "path": "assets/lyrics/m1036_lyrics.json",
-      "hash": "68e7f0823ff03996e180db3934d682b9308ee4c2eed4685a2289ae424e2a2cd6",
-      "size": 1464
+      "hash": "2d32e48da5643da8170256c345b05583273f457ba430198e0c5b2ad242e88f2a",
+      "size": 1467
     },
     {
       "path": "assets/lyrics/m1037_lyrics.json",
@@ -1995,8 +215,8 @@
     },
     {
       "path": "assets/lyrics/m1081_lyrics.json",
-      "hash": "b767386332115ef12286ecf94ad9b4962fba2f5705cd34c06a54a05cee93ad9a",
-      "size": 1459
+      "hash": "683220630bf52e6a9f43f0dc3ecea3004c2d3f04052e30efbef12881ef054c76",
+      "size": 1463
     },
     {
       "path": "assets/lyrics/m1082_lyrics.json",
@@ -2005,13308 +225,4078 @@
     },
     {
       "path": "assets/lyrics/m1083_lyrics.json",
-      "hash": "ab3ba73eb82f9e8cf5ded2c26a60993509cf685519b96901d37c507ae115459d",
-      "size": 3776
-    },
-    {
-      "path": "assets/lyrics/m1088_lyrics.json",
-      "hash": "6df43b62c70cb1d385c85bc23008147dc89bbaec2f7d0978dedddffbfe3334f8",
-      "size": 1914
-    },
-    {
-      "path": "assets/lyrics/m1089_lyrics.json",
-      "hash": "4634ebe98b93b5f7aec127bab095cce17f3033e956cfe85c165769ee4d69d034",
-      "size": 3220
-    },
-    {
-      "path": "assets/lyrics/m1091_lyrics.json",
-      "hash": "fe996cb29ab4beab5aa684381660827cad24e6fa064d323198d468c2af3586c7",
-      "size": 524
-    },
-    {
-      "path": "assets/lyrics/m1154_lyrics.json",
-      "hash": "fedf8ee8f51cd139cde537bf11f45239ed58dc3981a17094a925f030afe111db",
-      "size": 2009
-    },
-    {
-      "path": "assets/lyrics/m9051_lyrics.json",
-      "hash": "4699ae66cdceb5e731cc41a1fc00ec6dbed0f9ebb71695a344a446892552373a",
-      "size": 516
-    },
-    {
-      "path": "assets/movies/mainstory/contents/mainstory_contents_2001.usm",
-      "hash": "10c7ab4057d309cf74e4cca25d7d453709f941147eccd681c8cbd4a004df15d0",
-      "size": 42549007
+      "hash": "e1bd33f5ba96c7f8dfa2801d1b6e8a95b14cd15ae2184e9dfc94096c8046eb82",
+      "size": 3812
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020000001.json",
-      "hash": "276d608b3f398332bcc7d4ae66ce0972b8dd73ebf0bd17a8649d1b4c3bc4a39c",
-      "size": 1463
+      "hash": "eb8ba02aacab46b09ca0e0121082d7de2ac614beb6d346fcdf84f390e72d81a3",
+      "size": 1458
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020001052.json",
-      "hash": "4e46f57ea903ef23d1ab4996742cf00a228aa27d137383c13c2307e872961efb",
-      "size": 1424
+      "hash": "f3d8895c030cde31c5f1f41e954d9086e759f7c1eda55c1fa2183757dee40f02",
+      "size": 1422
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020001092.json",
-      "hash": "ad2be4205553789a66ba4b693986a166a2122711f1d30dc2b9380a72c31770af",
-      "size": 1453
+      "hash": "b82539e634dbc4f298e454039efdac4b9bd6cf49916f595d7b8239f190912851",
+      "size": 1451
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020001122.json",
-      "hash": "f054964ac52844e71fd81785b8c24419f713abbc51973fb3eea31a7b4f703bd2",
-      "size": 1344
+      "hash": "6b3634b2c5a0d5345dbce692b001cb07133e23aa2adcf9b57e21a9300817c01a",
+      "size": 1340
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020002042.json",
-      "hash": "d0c9957b0b5002fffc9a5b22775b0091b24d32cf0076ac8838817a844d1d23c6",
-      "size": 1439
+      "hash": "c4244a065128dfc870aa05c938d9e07af9bb6d58a9573e9847c7975f815b6eb2",
+      "size": 1433
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020002062.json",
-      "hash": "a5d6ce1c58934841babd448b3cb8a87dbd81384827d9b99cce49bc8c66de664e",
-      "size": 1644
+      "hash": "3653c8f8a9e0c2e99bb92127caeee41b9dbb797bc1bf6622e04c31b4dc085743",
+      "size": 1649
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020002102.json",
-      "hash": "986529bb2ebf0ebd0d791952ba4206dc2a472ee70690338acb58c7b1749b28c1",
-      "size": 1532
+      "hash": "027e5259e57f7624e459f19024467a887f89f26c6336ae36c32b6894c349a3c6",
+      "size": 1531
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020003062.json",
-      "hash": "f2ca065d23ef6202f6d57c8d67e171723f4282aab91c2862a9b9a2cb9494eb7d",
-      "size": 1701
+      "hash": "c097bf19efb7c0b8863b03d129a444cb4d57259b5e1046b8bb45126a10b46ba4",
+      "size": 1697
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020003092.json",
-      "hash": "81ebccd8fc50d4b73cb00f9adb873d21904394ad37b7c37169a678c3d7ea0145",
-      "size": 1988
+      "hash": "8d90f160e644141d9e50f449bb5328765c443b457623e945053838b66849f385",
+      "size": 1981
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020003132.json",
-      "hash": "d6e4f05ada845b187950da6a8d4d1ac4c7d9984c94629a1a461f940da2696fbc",
-      "size": 2003
+      "hash": "c23474a1f5ef79a1ef7e22907be9877c2dd614b9568daf8488899889f0118d17",
+      "size": 2009
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020004011.json",
-      "hash": "b62de7ae233fec521da30328b79772e5bd18cb95902193d828c7aaa1924a03f1",
-      "size": 1258
+      "hash": "24ba6720e93728a8f7e1484882df41673be57e9100741f10cd7b77292ddbdafc",
+      "size": 1252
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020004072.json",
-      "hash": "570131ca5b12f28adf6e1da936e037a2a41f9447b03f6a50cb57cea9f6020ac5",
-      "size": 1803
+      "hash": "c22f8bebb4b166f022bdf81b040bc51f987552ee27f11d23d52f8d05622a3ad2",
+      "size": 1808
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020004132.json",
-      "hash": "376fb39a72dbedb436da06d32438228e13be1ce09282b7719ee14d948ee89a8f",
-      "size": 2514
+      "hash": "8ac0584d2de0e098c85b5cc9d354a93688dcbefe9a75387e08c8289490b409ef",
+      "size": 2521
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005011.json",
-      "hash": "178e76ed6e55f41badf17b083a78e760730a97319a5d716676ba9832cd8e3b40",
-      "size": 731
+      "hash": "40431d62b2c22a9873f225b97ce5e042de49aa4b3e80044c8737d68cd20ab76a",
+      "size": 733
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005072.json",
-      "hash": "aa63fbceea8f652181d79bee7a5a633a12f821e53f0f2f761f77ca8c7f1128ed",
-      "size": 2125
+      "hash": "a6bc27dc17d3ab5303f1ab77e0d1ede6fbcd5813456ff5bfd935230e7d59b7ea",
+      "size": 2121
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005092.json",
-      "hash": "7771413c5cfe71da888066f905b09fa93a351d4e2f26e412b5b8e60ce77eb1f8",
-      "size": 1885
+      "hash": "20782b98251cc51fe405de1bf363f398cd5d99fdc69b80f8f75eab815c30850e",
+      "size": 1881
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005111.json",
-      "hash": "9944477fbca95aec1fd8d879de3e44d66cb96dcbbda68cd22bf5e61c42190201",
-      "size": 511
+      "hash": "d2f2d8ac00e717c819a3fef7c2849820b6169e9fb6ce325fd4611bcb4ad0772f",
+      "size": 513
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005132.json",
-      "hash": "1e9191222a7a97e528513f6181bd42298d598fff549d0678d7beae4969329778",
+      "hash": "12b5801138cf734947e5d7ef06999b67bcfbf45540188cb25392515a460d5cf2",
       "size": 2149
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006062.json",
-      "hash": "00633628f4312d9b2369c99ca5a700c19f0c1c723044b8373aa1d5e3c9cb5c88",
+      "hash": "dce7538c29cf9ee47dc47fc185731452d3662945783c4a1965fbcbe5b00a6420",
       "size": 2651
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006132.json",
-      "hash": "aa3b871ffd32689fc5398b64b1906af4933d7592cac990e3a098e7922abe2e6e",
-      "size": 3250
+      "hash": "f83347598ee48b214cb49323e4fa5492066a02a795f57831e578ece30b74a5df",
+      "size": 3248
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006162.json",
-      "hash": "b01f7aef4949d32e008b5f775d8bb28ff6f09cb380537ba0ccaafaca0bda097f",
-      "size": 2879
+      "hash": "758a46576f64f121704e92bb8056a964d797a3be00f688dac5e0899c8ce7c4d9",
+      "size": 2871
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006172.json",
-      "hash": "8c94e3134f63b11bd5bf56b2cf2ba66d22d43a891bf1d33f500deb8ecc71f028",
-      "size": 3205
+      "hash": "243faa29e64983f2d94eb390aaa174af05503010d05b997d87dcefb15c4b82c0",
+      "size": 3199
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006212.json",
-      "hash": "eec32e4308b35139b0b6851c3c07737a1c8774668338ab9f7c55f7f58d04cc1a",
-      "size": 3667
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020201013.json",
-      "hash": "e6da810f254dfb3b1049669ba965a6170248c14c444c2a4628c0129304b16ac6",
-      "size": 2155
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020201082.json",
-      "hash": "372c860b700d43d4a5e8849f02e8c126f3205b9a2981352d11e76b1be170e8ea",
-      "size": 2250
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020201132.json",
-      "hash": "f8d112e88ec8bd9dc62001ad5d550ff2467aa5a4f00566ba78bc6605861a43d8",
-      "size": 2527
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020202032.json",
-      "hash": "3ea7628b6a2584eb080899d246fead33e95940c045f7a40c57b1af2ad89e5d36",
-      "size": 2928
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020202062.json",
-      "hash": "ab798fc949c762a6017b23b8044216776414dc6536119498ab6d9dbc2357b3ca",
-      "size": 2198
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020202132.json",
-      "hash": "3762e0021dcf131b82c6f314201c4fc21ffe4b991aa9b6b60aad3c2fd68c1657",
-      "size": 2867
+      "hash": "688df859ac65a5f50a5e8a5b8cb730d61039cf33597447d726aecbf9d4c6dbe7",
+      "size": 3659
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008001.json",
-      "hash": "d6e0ed912298faec5d114e632623bca0624c4a8d4af934b6b4c94241acb6de13",
-      "size": 226
+      "hash": "8f0275bbf5d12b06140ee2769fab149e2f28ee787608169fb7ef9bb8efb4c899",
+      "size": 201
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008002.json",
-      "hash": "605bc758c5052e31feaa8a5dd767cd3c868a3f75e4092fe8824b62d2af3725d0",
-      "size": 268
+      "hash": "c7c2ae50f06b248ad3f440c0c3e0aa5cf9e11078421b7421b21bae570da6ffaa",
+      "size": 241
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008003.json",
-      "hash": "16ea34e6152a21e8633d158d1b2865deefdd4e3dd3c180d8ae36783e4a5877a3",
-      "size": 221
+      "hash": "ae511f26437f4e3b8ed73676015755360265049ae414ffd701ac079baa713e82",
+      "size": 196
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008004.json",
-      "hash": "20ecdd1612d8e572312fdff9ced48d11507411a4fabd9a2e06fc379b18796165",
-      "size": 278
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008005.json",
-      "hash": "3162043c0d10c38c861e4f7443da8cfb8531e6b5da9bc6211203b1d48ff65777",
+      "hash": "7be5f3625b3869651aede6ddefc195d66cb77512c9704c8b2c904bf14b4313f7",
       "size": 251
     },
     {
+      "path": "assets/story/data/00/0008/storytimeline_000008005.json",
+      "hash": "2841788dc611ba2d4f2b5510de5903a29a69c68343954ba08010d0dec51d9609",
+      "size": 228
+    },
+    {
       "path": "assets/story/data/00/0008/storytimeline_000008006.json",
-      "hash": "0e53ff117a56c9d23bea3d8c1b3e240ce2e2dddb85154e4f16d329df08da936b",
-      "size": 302
+      "hash": "56f763a7cabdc16452b09c198cd700438fc07ef95626c0fc2a4c2779db41869c",
+      "size": 277
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008008.json",
-      "hash": "14c15b2ce6cf2d80c878e80ae0e149539d819ca60a77df8bf20a63c718cf61f2",
-      "size": 989
+      "hash": "00bbdc5663c00b05a98acfb3b5cb234a0f59ca841ce0788c00d0bbb9960b150a",
+      "size": 955
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008009.json",
-      "hash": "52e7adc293dd38b1fe453f6fc4e353a799ca859513a87185ffa6b44d9ea6efd3",
-      "size": 712
+      "hash": "29267d71506cc0e22981a7cb1e42e74775ea9fb0da4c469518093a05dbefacf1",
+      "size": 681
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008010.json",
-      "hash": "47c0f38011476bde663502b5fedf24b42a80abd2fd0b0b5bb7edebcd2f01a7b2",
-      "size": 743
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008011.json",
-      "hash": "d368f7a9c87e329763d254e69c5a44c978987d0123c50dd891cabe1bb35fe4c1",
-      "size": 708
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008012.json",
-      "hash": "99a90d0a46eac83bb37797a67774eaabceab2245e24318749139843bacce7ff7",
-      "size": 1014
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008013.json",
-      "hash": "3c24934cb7cdbcd8e4bf7eed747fb01af11ef664223e3deae83f90b33a4b004e",
-      "size": 849
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008014.json",
-      "hash": "089c2618dc1bee770992ea33c759a25ec3c62f060ced12e0570a7bec1cbcb0a8",
-      "size": 731
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008015.json",
-      "hash": "96eced045b4e1d00547672f031abed13585430cbe5388e8088e8e2943eeabce3",
-      "size": 724
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008016.json",
-      "hash": "aec8ff006c20f9f7f140cd41929403aa2904b653e1db75e566cf63d30a061a81",
-      "size": 886
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008017.json",
-      "hash": "d88af47d7352c81cec4403009f67f48c920b76dbb0f048ce611c1083e1cd024e",
-      "size": 924
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008018.json",
-      "hash": "bd32a88e017b88230442342cac1b91a0caf7d093ae2d94bf0956b019a2bf63e4",
-      "size": 583
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008019.json",
-      "hash": "fea02323b664b848bcd67f6a81f7018b72b77b4b77a3a1a8fc1351ab0cec4aa7",
-      "size": 695
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008020.json",
-      "hash": "342ed5cce4749ed1f171594a464444f9906197f3fd960a68fecd26b9ea128c84",
-      "size": 811
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008021.json",
-      "hash": "835bf66b78a0be965f1d3a4c816061b0779463d7e53c21b153f507b277b9bfe6",
-      "size": 811
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008022.json",
-      "hash": "ad4ea162332a6d00c2db5614b5acc78e21b8b22a2dffca979ec07f0f7785c687",
-      "size": 732
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008023.json",
-      "hash": "58b817bf15f964cad33b62e2113fc04a89446c1141daf9fe8d26f01311b67c6d",
-      "size": 748
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008024.json",
-      "hash": "e4fc9d1384bea977d448ea3338aca19ff6560ae8374ef4d0b14eed88d3ef382c",
-      "size": 970
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008025.json",
-      "hash": "9b88c0f582ff552ec798fe83be25a57ebc2f0decccc49de79619593905468223",
+      "hash": "dba9248552eee55827d6027654dd9af393296a69fd6e26169f3afd5fe5eea7ab",
       "size": 712
     },
     {
+      "path": "assets/story/data/00/0008/storytimeline_000008011.json",
+      "hash": "a73054df3bf75da1bc236056c0520642b4a4bd838e23f1ba4ae2432ba78c1a75",
+      "size": 678
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008012.json",
+      "hash": "d1409933d19d80b4a430463867ffe6609d0456d6d280e20eb87043102ce8bc82",
+      "size": 973
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008013.json",
+      "hash": "6fffbd2c5a0403aa8245ca74291aa764dbc8d0a603ce1ccdcb06d9933fa206e4",
+      "size": 816
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008014.json",
+      "hash": "ca1bcda5eb05a9bae46efa854daaeed62502b32564105cf2b382053977f945ba",
+      "size": 703
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008015.json",
+      "hash": "8224de199af438e14e740ec319b2f3e73a0f9e94cf963925c29af9554ffe5526",
+      "size": 695
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008016.json",
+      "hash": "88f0eed6315073a6c4fbd827c361c64a0a1b3697b7d3302491f3122a236d2038",
+      "size": 852
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008017.json",
+      "hash": "4d00dc18a814082071e4824978fa1d2347ffdf4ccecb50fe9bf9eeb6e111e3cb",
+      "size": 890
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008018.json",
+      "hash": "84dd314ec93531dd957993a2d7c60e6299fde9ac69302e3d74994754b7e927f1",
+      "size": 552
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008019.json",
+      "hash": "0d344314ff273bf33a31e91900b92bb473dc9e22e5c7cfab9feb8f179d757130",
+      "size": 668
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008020.json",
+      "hash": "993ba1acd9f0a8423f069506fcaeb568353c28235ac2876756f60bcacf537172",
+      "size": 776
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008021.json",
+      "hash": "956ac22b70d606872d828ec7094bf2a8bdd709444cf10a91313ad039eeb3c560",
+      "size": 780
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008022.json",
+      "hash": "890e46b79f90ae3a3aa62da097124458bcd6f6be6422bdcdd9c02d93614b29c2",
+      "size": 703
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008023.json",
+      "hash": "1006acb13361b9291d601c2b4dcf9d6a2ef3c4de02d99046ec8855722346a783",
+      "size": 719
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008024.json",
+      "hash": "49d84624f632f3efabad7254e835aee9337685beeb543b0c100b48efedc7922c",
+      "size": 936
+    },
+    {
+      "path": "assets/story/data/00/0008/storytimeline_000008025.json",
+      "hash": "3e473566a2ec32a77239794336f2fe43780f92daa12c894b3c0b9fbeb92d6b6d",
+      "size": 681
+    },
+    {
       "path": "assets/story/data/01/0000/storytimeline_010000001.json",
-      "hash": "b2e84337f20493497cba597c2d8d51300a14bbbfbc58a9a204e015d46dbabbd5",
-      "size": 1898
+      "hash": "010787f9ce82cb5f54f53bc30e4c931fc9ae8b686a6733f91b0906e8d4371989",
+      "size": 1858
     },
     {
       "path": "assets/story/data/01/0000/storytimeline_010000002.json",
-      "hash": "e6fff55bd8ef3c937c132c1c03efc67a6e398fba8eebfabb1bfe5523a709b35d",
-      "size": 1575
+      "hash": "9f2295934ade1349ff7d969e3545438281354cfaee515dbd04cb212c5d24faf0",
+      "size": 1534
     },
     {
       "path": "assets/story/data/01/0000/storytimeline_010000003.json",
-      "hash": "2b017a3fc3a3372d6503ee878e368b836c70ae8ecf4553c1616808138b902a15",
-      "size": 2675
+      "hash": "70444cfb1e300bc141c1308ef1e8a652ddc979c459b1c6bb4ea5f2a510068f1c",
+      "size": 2622
     },
     {
       "path": "assets/story/data/01/0000/storytimeline_010000004.json",
-      "hash": "52bf1421d67af3f1736c3f32dcb08d94f6c7cf1e4cbde047aa5838b4179e3d7b",
-      "size": 1031
+      "hash": "d815e509414827e7d6136482deea2c734ac2b4a3d9a3ee22cb3ed46803717c50",
+      "size": 999
     },
     {
       "path": "assets/story/data/01/0001/storytimeline_010001001.json",
-      "hash": "587cb24c21597cee158c51ff7e149a94926e2aa0a4530a91846fab56537c9e17",
-      "size": 602
+      "hash": "6bd9aac9e1560be49c3e7e3f715f51ff9dc819c8fc7ec4b199126576d241a1a6",
+      "size": 571
     },
     {
       "path": "assets/story/data/01/0001/storytimeline_010001002.json",
-      "hash": "907ac02374f29be423a449cbfe9c65dc5ab74da0abdf3b86bb92f6ee55c1cb5b",
-      "size": 815
-    },
-    {
-      "path": "assets/story/data/01/0001/storytimeline_010001003.json",
-      "hash": "18064b43074e9cd006d5aa13380dc4e4180db9879c08bc1ae146108ef5240cec",
-      "size": 344
-    },
-    {
-      "path": "assets/story/data/01/0001/storytimeline_010001004.json",
-      "hash": "7053db6192c681c4c86fde86f0ebd34903c390873c471cf7ffa969206f97f1fc",
-      "size": 535
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002001.json",
-      "hash": "f87586faf14cadf1dd513691f96c2c5a866f2332508a16572224dbe35c464cc4",
-      "size": 217
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002002.json",
-      "hash": "15377cc6c350de72792c8ada867332e06dbc2810789e24f1f7f4ade4b0b53b74",
-      "size": 1038
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002003.json",
-      "hash": "5ac8e9e89dcdc38a42bd8b0fe6420b636117c06ec6ea62212e9528add58f0615",
-      "size": 557
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002004.json",
-      "hash": "290f2f32e8220d4d23d76af02efafa13918aec3a260e7d022f2f660a5272fa45",
-      "size": 363
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002005.json",
-      "hash": "ef6ca7bb144ca37bd42cb3d4c6de576267e67d88c77e8c7a7180d02a7ba79e37",
-      "size": 307
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002006.json",
-      "hash": "89ebdd9053cb12e4b2e7fd6fa442f37120f55f8a75d1f54dacce4d978055a8b4",
-      "size": 366
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002007.json",
-      "hash": "1b2c404fcacf3d10c9993b4bb1d03ed67f96eabf71cf9ca4b6b3461d0cd425e7",
-      "size": 421
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002008.json",
-      "hash": "9bc8e71c06433a7150d2630c38dce70bc3b7a75edcf09d4dbeaf7efe18abad4f",
-      "size": 1396
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002009.json",
-      "hash": "4fdfde27c16649978085a463e4ebf503bb434fd6132f9b450242a4e5f5e17108",
-      "size": 1265
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002010.json",
-      "hash": "9ee6d83f9461963868c6e6ddf34c2167d22676fc07eb7d57437c33477e99ef04",
-      "size": 436
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002011.json",
-      "hash": "24c1bedd4e632e4d7d3efa1cbc27321d1343a507b54e2741d134e27cef683b15",
-      "size": 834
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002012.json",
-      "hash": "2086adbfe7a3bd32f9aaa83519baf3535935c6666887eb4994e898fb4e8aedf5",
-      "size": 721
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002013.json",
-      "hash": "1dfd5210abab447f1ba5e5600359420d48fd31f845e223b3581c3c46a904f179",
-      "size": 619
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002014.json",
-      "hash": "68f86567c68e24ea20b64521ee20c88579ff94c83c7f6a9dc2e642be908155f7",
-      "size": 754
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002015.json",
-      "hash": "e33958d4d1ef3205809303264948ff1c5fbc4815729ae8f9aede97ce79ce1238",
-      "size": 747
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002016.json",
-      "hash": "b20bf9116d3b8c28557033443e46beec7cb17d802fe3bddd4325e5454691bc36",
-      "size": 732
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002017.json",
-      "hash": "7f6e75f6c6317e478c0097915db19f3d9403ed88818ecd9251440949c515ea63",
-      "size": 1007
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002018.json",
-      "hash": "b516a0f51efc02d998ec0bfdb6cce4d1d12183987e03242a6f734bc117a66b32",
-      "size": 379
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002019.json",
-      "hash": "a482cb5509cfe615e868db05ecf81952e177a041a30b65b8f39b8a54e1bbea1e",
-      "size": 990
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002020.json",
-      "hash": "f12319fb33f0fc02705324fbd1d1f39cff1529fc40d5c2a14145f9de6e2c2e99",
-      "size": 710
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002021.json",
-      "hash": "75f4101a4c585901f9a50fa4f5b11e4eb572525343f6469d730217fdedf57d9f",
-      "size": 675
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002022.json",
-      "hash": "457e93e315cda5051af9265bcbf64b7bbbd8ec0cd852221d4f6d27a32f78090e",
-      "size": 487
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001011.json",
-      "hash": "2d6bca53a6c8ab1a674645d157f987d9533cb56d2a1ef1ac5fccd6c34b7d6d84",
-      "size": 7319
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001021.json",
-      "hash": "35c35162b2c3969dde6ef68f10466b07512d7de1f8e42d056cc9052f3f8fc106",
-      "size": 9341
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001031.json",
-      "hash": "62be640a087d2d8ccc37fb9249c3684055f9883d1f08ee404a6477d1f84f5938",
-      "size": 8909
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001041.json",
-      "hash": "1e9dff6eb396d711c07d3c077fc1c6135b55bab7e7472e31ff373e1aad0de68f",
-      "size": 7386
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001051.json",
-      "hash": "9a66210bb3b3eb4fe10cee750956792bba674ecfcf7cda926a3b133a294a49d5",
-      "size": 5386
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001053.json",
-      "hash": "d401da045e71f0ea2d49258b2674ed71b4e16ecd988188fab9c5bbf5a66ab370",
-      "size": 2320
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001061.json",
-      "hash": "82512d2aaf841c30e17dd4ed184851198d77bb90b1fa0d477c411a9fca59b1f5",
-      "size": 8738
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001071.json",
-      "hash": "b81cde17e92987efe52a954d2780b96f6d502f7b63dd72f472e50a81a90536fd",
-      "size": 8663
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001081.json",
-      "hash": "5bbe12be871a0ed85bf2857096044189844f1e59dc8f1bd02eb454fc8c2bb913",
-      "size": 8023
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001091.json",
-      "hash": "aba2b1f45353943a0f0da227cea79fb279ec3674ff760f4c4792076384d1445f",
-      "size": 9040
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001101.json",
-      "hash": "f02bccaead0c693cc4ea5a29b5a3b2309d4e251fa7c5c1180e2ff2b0c8cc5cf9",
-      "size": 10132
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001111.json",
-      "hash": "9f782650582c14dea163757b3e0299eb8e1a96f9aa57e34b22fde6c9671d4def",
-      "size": 9583
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001121.json",
-      "hash": "cd729dcc71f4bdb78e4c10db5325c18f2950769af075320134f49853539332ff",
-      "size": 10309
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001131.json",
-      "hash": "672a51d379d096882d793f7f0803c3a3973f1ace184636fd9b2d90f7a656980d",
-      "size": 8356
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002011.json",
-      "hash": "84fcdeb1c10e7385ef17c216f389fb516f8c46175029c94d76fe6e035961debe",
-      "size": 8171
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002021.json",
-      "hash": "34110556834c812a02bd650a998e7721d0c83af9ebe64deca01bb9388f077d4b",
-      "size": 8722
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002031.json",
-      "hash": "9c8b974575653a6af3e5e83566cbcedb545db43d71dd0012b1fd318445cb0f54",
-      "size": 6451
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002041.json",
-      "hash": "56a343723fe43ab2dd19537bb40319e6e64f7be87da48bcc55df3b58de612544",
-      "size": 6705
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002051.json",
-      "hash": "f9b8e12fdbc856160933c640e2773126950682e2d1793f8fa6bc0585e7f947df",
-      "size": 7254
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002061.json",
-      "hash": "cac34087f666ddeecb5cd0d7fabb79885cdab3e5185ed3aa9475fd27c758d9f1",
-      "size": 2733
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002063.json",
-      "hash": "dafb6e6f0a469668ea656be2beb94dd5153545bf34ce7926c037ea89575dbc93",
-      "size": 3246
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002071.json",
-      "hash": "1e4c7b1e1c9a6debd74b4c4cda6d31d2336a0ba45296e57206dbd39bab4a37aa",
-      "size": 8573
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002081.json",
-      "hash": "da822057892c87035ffac28e1eedf7f708352249d23be9bb444e957401a601e7",
-      "size": 8495
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002091.json",
-      "hash": "f0196b96ba354f22d098df5c2e5ce241644c2ec811dde5f37052085bfb7f5428",
-      "size": 9438
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002101.json",
-      "hash": "280885501637320f5b869faf01bd8ec11da2672efe896f6d3e5bbf25e0c8ebb3",
-      "size": 8018
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002111.json",
-      "hash": "67febce10c4f83ba5700e740d16d80b2a34dc2e7029d2b7d16d3d24646c34ca2",
-      "size": 8100
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002121.json",
-      "hash": "f84bebe95e6fcfda4a2ca3347285c37bc0771292bd79096bdd42526c2628b802",
-      "size": 6496
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002131.json",
-      "hash": "49aa279087540508982d9c0f3597380ed9be5b862fc709bea48790bd0590e06c",
-      "size": 8258
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002133.json",
-      "hash": "3c75f609a4e4f1047afee8191877b3a0d6610ac1cce258a8eaae5ce2da19d659",
-      "size": 1932
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003011.json",
-      "hash": "eabd7e784f4a70052c8ceebf3e4d4f08bf57bc56c26601704e8fdd6fc0d5bfc7",
-      "size": 12221
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003021.json",
-      "hash": "cd0cf97c45ab619baf424c587d82b4e752ba1041a177e0a8a3eca36569ae54af",
-      "size": 13275
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003031.json",
-      "hash": "1d674a1179a718fda7ff8ff55efc9f5fb3f56ad7b8fbb0b416350781c4594f70",
-      "size": 9154
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003041.json",
-      "hash": "25f9318da3f311cfe9c919592d22427c63f51ce13883132b9d95f61d539ff56a",
-      "size": 9630
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003051.json",
-      "hash": "7d994f10aa9ce0eee1e930752a07ae321429aedc426eba0476c062cadb55bd88",
-      "size": 9554
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003061.json",
-      "hash": "85f688b5ce8cfe897ca3129927879912b4e6614105d7a98bcd3c6bc5eef17d07",
-      "size": 6950
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003063.json",
-      "hash": "731262af3720ba20266a7efb26e258e1bb816362511629bd3993c661de6b4c7e",
-      "size": 2086
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003071.json",
-      "hash": "d5e6437f2fd2f79880635d19ebe4ac9011497442f5655c7918967d232e0c9510",
-      "size": 7879
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003081.json",
-      "hash": "2f6e2fe58333ae2a786ccc3fd69dacb08a5e211fa2c3aaa5a7b8e1d5db9dfba3",
-      "size": 10146
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003091.json",
-      "hash": "68336100dd0bc3349e9ca01347cf2ca9fda031c2d54c63ff85e70340fc141768",
-      "size": 11477
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003101.json",
-      "hash": "4e4075f619bcc77575bb0ad9e6b5e0916ca9cedd05b1b9cd0d900c6c44e16255",
-      "size": 6154
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003111.json",
-      "hash": "8b7ca6c2afc83eeb6e788a8f398de067959f89ade6ec6f1bb895f928b1cdd93c",
-      "size": 8824
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003121.json",
-      "hash": "5a8c9ee0bb487b9727b3ebea9a9f337bea06dffc957ba7593920494822268d4a",
-      "size": 12366
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003131.json",
-      "hash": "13be31683a55912e058636619065b919b068da54a985b49cde472dd329511838",
-      "size": 3099
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003133.json",
-      "hash": "350cfeab10713bbdbce02d9508e481687ade941b091e95f73c179342492e08a4",
-      "size": 5165
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003134.json",
-      "hash": "901ac7812707c3276876e454d9839fb656e86f4f1b6dbd4527562c428c2bea0a",
-      "size": 735
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004012.json",
-      "hash": "fe9460f47b845a15fd69c7d51bd62eba00f395dbad21f4066c66b3b804c3230b",
-      "size": 7782
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004021.json",
-      "hash": "a723f8d9a4f35c8581202c99e4c3f7108ca934145137cd9771af3da693de49ca",
-      "size": 11629
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004031.json",
-      "hash": "2251fca2139ad459908cf43770915c4f81493d4d1d02ba82ff09e614f2a831cd",
-      "size": 9799
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004041.json",
-      "hash": "5fbd0021afe84d57c45c3f1af0865e9e2b423756ad86f03470aa4cc3afca2e0a",
-      "size": 8685
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004051.json",
-      "hash": "5df85d7202242e3c3d67f20f9a04f1d59fd7ded0e1c24cb45f3fffb5cee804da",
-      "size": 8785
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004061.json",
-      "hash": "7abc91ec6e1df8ea49eadab325378f570756b7450c5fc45a8b9108c7c7587b3e",
-      "size": 7471
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004071.json",
-      "hash": "828de69f38ecc3085a96edf4f565c975a66a81ff824ce2951423cd5b261282d7",
-      "size": 3071
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004073.json",
-      "hash": "920855a13cf1e2e2d46413190e792cf6c1a74594162ee3e731cd86a5cf05db27",
-      "size": 2504
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004081.json",
-      "hash": "cd29f6061f8f2caff833cd7133f73767ef57d06f1e1febe32f0419b0b4701bbf",
-      "size": 7980
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004091.json",
-      "hash": "c9939e53aba76bf0c9f05395e51358d264695386ab75ac81c43d1321154e1a98",
-      "size": 8696
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004101.json",
-      "hash": "50983ddb490dc61da4bc5cc684b524b4caf27cc8db4beb132a8e46c88969f3e2",
-      "size": 6996
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004111.json",
-      "hash": "d36f296eb538d67a6bd8b3464dd1a46a3f3f5a2a88f48c3e5282b662a83b013b",
-      "size": 12730
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004121.json",
-      "hash": "9932df937cf2f6dc995bc7cbd28e160a25ea079fff59478376abd45719ee905b",
-      "size": 12356
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004131.json",
-      "hash": "af62e4607dfb83edd03423c6f8f09d7109505e6f9c7d107e451ea31da1fe6513",
-      "size": 5695
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004133.json",
-      "hash": "40272e15053fc611775cd5bbfd4a28b7e6a6d0c35b4080d5df045d851457ab17",
-      "size": 1580
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004134.json",
-      "hash": "46f4b0f2f473271c7ddbc74f4a41333708a1de0b227bbaaa94f33bf1706615b7",
-      "size": 1684
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005012.json",
-      "hash": "7e7306ec3a2efbf6c308763d555481c3124c12013210a87de84b4b55f5cc94a2",
-      "size": 9381
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005021.json",
-      "hash": "4489d9d3a73f9428be32eecbf07f45581ec26cdfdb239d04347d911a0e9c6cce",
-      "size": 6991
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005031.json",
-      "hash": "f454a277bbd02716f7bbabb17dfd53f1f7f29441c834a512862b8212a9e83185",
-      "size": 9525
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005041.json",
-      "hash": "f1cd843e1af522dfdeb39ff5ad96fe3ac3ac176368531c95f98fbc736776d277",
-      "size": 6924
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005051.json",
-      "hash": "0569428cc5fff339fd27247c6c9ccdd9f36356d7cafa2a52a01a9885c1c6fabd",
-      "size": 11351
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005061.json",
-      "hash": "6fb94acf1d5ea7a87a6e580409f5bb27c7b419ecc29eaf6e3d6e854885ed73b3",
-      "size": 9491
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005071.json",
-      "hash": "ac6c37f3e87d6239a437e58b7567c01cfaf96f0da5fc3f485680745a7526d3fc",
-      "size": 8765
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005073.json",
-      "hash": "9b0cb7ec5685cc8c422ebab47beb9931fa37b24882bc3f2e79f9c6aaa3b2f5b8",
-      "size": 3676
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005081.json",
-      "hash": "ff8ab7a527d9e8a767753f2df266f1af7d4d24b3fcca168f7f0dd03540dd2d78",
-      "size": 9335
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005091.json",
-      "hash": "82dd6a07d5a2f0be8b38343165495157d3a1ee34b0eb79bfdc1ab63d80f971ec",
-      "size": 9322
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005093.json",
-      "hash": "3872aeba4ab48c8b0d9108d9e42da5d25f80398f9103beafb5cac98b6673d054",
-      "size": 2373
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005101.json",
-      "hash": "86833d71884dab685a592419526d6c1e841e5a15bac38f7f5b7ffa9cbbd6a543",
-      "size": 12109
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005112.json",
-      "hash": "7784886ea0fc548c40fec76e589888df4ea06677ce260cc2481e964245aa4b7b",
-      "size": 11122
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005121.json",
-      "hash": "d52467fa7e8ede04d3d4c6224a1db9e037a91848ebc156fbed0449a0c13baefa",
-      "size": 15902
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005131.json",
-      "hash": "45b093630ce17a1d4355ad52cd19afa5c077a297b1cfcc89e011d82d26bd5443",
-      "size": 3907
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005133.json",
-      "hash": "d6a15568d8d1b0429eb57a527dd17716bceac31de7a9e606407b9e185fb9aecd",
-      "size": 5256
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005134.json",
-      "hash": "3cdf5d5741d6ff99a10d0bdc5d5b83eda2d389ab870d2c961bd0b6c10e0b87d1",
-      "size": 1271
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006011.json",
-      "hash": "9b76f752a37cae4a92e6f316ea3c3be18d8d9999b7f50de8aba4899bcc875ad1",
-      "size": 13607
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006021.json",
-      "hash": "8d3560de523041525b43d550871824d11e6907c7475cb29927fcaa97d02d83ca",
-      "size": 10646
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006031.json",
-      "hash": "c45e228dfa10bcca505e7df6b6b463b60615cb3036cbff2858dcde9c2ea76426",
-      "size": 8809
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006041.json",
-      "hash": "8fd0d616674fa8986154a5835f952407cce027c513192840ec180ffe359a7a8f",
-      "size": 12439
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006051.json",
-      "hash": "2e94818a25ce14fef92857b8634e50e45718522b17c1395e2f8a5399dbbde963",
-      "size": 9620
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006061.json",
-      "hash": "ce73bbd44f0154dd382ddb19924cd906797176d2c5024174634cb7edd3363c10",
-      "size": 11505
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006063.json",
-      "hash": "5795f24ec63f3fa96a020f3f60b9116c8793eafe9ee239b3f9990f606f30e924",
-      "size": 6099
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006071.json",
-      "hash": "91b484db9a1b6c3d414385e5cff4607caab7e09ebcb4301322d543c2bd9b032a",
-      "size": 14279
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006081.json",
-      "hash": "15e41491ebbd6b7d47f719ab2e1560ea3922df3b2d063c3e469fd144a01f37d3",
-      "size": 8363
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006091.json",
-      "hash": "dd4f4c64ab3d54b73594126db0e9b139dc8fedc2e4344edb1db36c5f2caf73a4",
-      "size": 7085
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006101.json",
-      "hash": "ef60007b81d18fa98e586062a09d947e8434803120f3216b1269cba3fbf5d6ac",
-      "size": 14820
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006111.json",
-      "hash": "883b0df8ead22d85ee65f7aff8ea8328b0c5961d315d6a85f8123b6e1c7a4714",
-      "size": 7943
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006121.json",
-      "hash": "bcc344d123685011b5ac57942ae5e18ff08ffd4b90e40df2fe042afb6741ba98",
-      "size": 13017
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006131.json",
-      "hash": "dda77d3a2cd27227af9f6e8c29f4798364d854c3aa5402637cb19fc1917520f3",
-      "size": 6555
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006133.json",
-      "hash": "0476857278c811cdcddc17637b6c431e85baa9b486127602be3dc59e444d4377",
-      "size": 5496
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006134.json",
-      "hash": "fa34e7e9ec306707b9bf7731409a4bab970c2cb078753efb39c026aa7f67579a",
-      "size": 727
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006141.json",
-      "hash": "e29d5267e60056a1f6176529d4bbb7de8a0c45c86ae3fadb4fe425a2d52c53fa",
-      "size": 8519
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006151.json",
-      "hash": "37faa49b26247db97aa733e13dc8b5664b345dd44705fa6eddebff7fbbc39d10",
-      "size": 12748
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006161.json",
-      "hash": "4136a970db4a915dbae3e494acc2ba18c1572bcf7d80bd167262211a29b07c7e",
-      "size": 12492
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006171.json",
-      "hash": "e85942540a448f0b64ff45d1cb7b142088d90dc0ad5f4d2f419fd25a1efdfd22",
-      "size": 11641
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006181.json",
-      "hash": "4b38bd510faeb902becab7405edca9e93923a96b065b0dcb831c79a29b4ed1a6",
-      "size": 9612
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006191.json",
-      "hash": "7bc5fa8ee6c5a3359d59409738cd4896f4324723eaaeeb826d4344d376f07d9d",
-      "size": 21449
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006201.json",
-      "hash": "ff2d7c0a2f75d6c993c82f208b02c2fde471cfb3a02a9dd9b0b581902780abf9",
-      "size": 10755
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006211.json",
-      "hash": "e91b8f7e7461684bd499662515ba56c496c411a825f1fd92c62c93f87025204c",
-      "size": 14932
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006213.json",
-      "hash": "bcb4849050dbe2ccd680523d6381c1cf40fb2f97216de5d0c2f6f65b34d9bb6c",
-      "size": 7880
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006221.json",
-      "hash": "a573753dbc2aa8831e51c97172378423477585e67aa0282755d136a99b7ac7ed",
-      "size": 10162
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006231.json",
-      "hash": "f37f06783261fda64d4c5dbf2a6cfee46debae90869fdc9b1adabb6a212f692c",
-      "size": 5350
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006232.json",
-      "hash": "ae27a5e853a8fb42566d6d59f86faeca35668082a39c3f6a192bdbeb66db1bc4",
-      "size": 4492
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201012.json",
-      "hash": "5e33cb6e3b2da102689ec8df8da849509156eaf3567f40fc85857e56f02b5b9e",
-      "size": 15691
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201021.json",
-      "hash": "42174f741d862afea9e752e905247e8340692810f8ef143360662b195b17b308",
-      "size": 11470
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201031.json",
-      "hash": "4c6240c5103cd6376ffd33c92a4bba600859bec8c9f2f142951e6ac1a6cbec27",
-      "size": 19025
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201041.json",
-      "hash": "c38b28a991df24c6ff9e4c4e703f078a14a11a00932314db1ab9f3e8b1b2365d",
-      "size": 11537
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201051.json",
-      "hash": "64762647ff04bcd3dfd875315887c04d76a783b5f78fda71a38db72b60e1e7e6",
-      "size": 11425
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201061.json",
-      "hash": "ad909d11c838993d8096d013ebfb93d70f3d8cb0a200d3ab638a154fec8a2964",
-      "size": 16001
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201071.json",
-      "hash": "cc66ab5eaa20e0458ffb22bd8fa756d3dbd37b879c91d71f46d127bd0f03dea6",
-      "size": 16563
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201081.json",
-      "hash": "ddc08a829c9ffa9cd27c9887f34d7a2e0bbe34b28c8abff10bd4c30fa8607209",
-      "size": 9754
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201091.json",
-      "hash": "91197b4163a611c14c40aa4636153f70931507d5f44b2073b924f4b59880be5c",
-      "size": 14518
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201101.json",
-      "hash": "9fe54344300c63b9b8899bc8d79287621ffeb0731492cdc75e6a77b733391b10",
-      "size": 14481
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201111.json",
-      "hash": "62d6f86028a41fab0ee9e7f32044526c8989b4f976b1ecbb926a81780d1263c6",
-      "size": 13014
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201121.json",
-      "hash": "867eb19c8068f58919ad54d348e23dad38bd172f12f383cedc8ab19af89c9888",
-      "size": 10289
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201131.json",
-      "hash": "9570b28996f5dde5b01658e00b86b25d9e86912b1341af3ad217be6cca614e72",
-      "size": 6283
-    },
-    {
-      "path": "assets/story/data/02/0201/storytimeline_020201133.json",
-      "hash": "c4355e96f1a06bb2a29b89a6b2907a617132bc3fa6442b70daae88450f76cb98",
-      "size": 4355
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202011.json",
-      "hash": "3423baa2d618c4d5d6f797a71f9e489e8aeb621683f86dfd1bfd71b9365930a0",
-      "size": 8165
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202021.json",
-      "hash": "6b9f4e73919c1c2b0ffbdb30f4d041a18b5f3be12387de5c5e1ffd3b24d1dc70",
-      "size": 8804
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202031.json",
-      "hash": "685b011e966fcf3b4abdcbaf9d69f6e06d605e2a6954b72655eebcbca48501ea",
-      "size": 6170
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202033.json",
-      "hash": "9f35463dfc9f0ce81a339b931685ff66a8f9eb9d2473cfa2fe803075f07dada3",
-      "size": 4435
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202041.json",
-      "hash": "1ad8c902c37fa60e7692ee88f146761aca1a0ef3458c87fcb7782d8a37eb8c55",
-      "size": 13092
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202051.json",
-      "hash": "cb9aa310af062caa8b2ca2a2507b05e6de815ea955b679099ef8f6995a722d76",
-      "size": 9815
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202061.json",
-      "hash": "488ce429f38cda4c9bf62d8a0c91037596f1b6f8a66968dd903fe6663d1561da",
-      "size": 8085
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202063.json",
-      "hash": "cc128d00b2c15760edaf54841f6e9a8dbfe3360278ee0dd4606b9bce8c72c84c",
-      "size": 5264
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202071.json",
-      "hash": "40a7f1db8c484cb70873611cf6ac7f9ed88f9346e53edcc9fbac59cbe0e2e050",
-      "size": 11405
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202081.json",
-      "hash": "3cc07e0c1dcfbe9d5c2b4d461b307aa57c350fc06b297da170ffc0473b11b162",
-      "size": 13938
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202091.json",
-      "hash": "8925108afd57e820bf36a8bc25f83477639587c0b095251571bf42b8b34e959d",
-      "size": 8609
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202101.json",
-      "hash": "3957c6bc9fbadebe073fc878db1c1ab728a6e1bc4edf14108246a79a2366acf3",
-      "size": 12739
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202111.json",
-      "hash": "583ae08964c304375a62dc5bf71e9d984f360c0086bf91ad5ae06887ae4d1f27",
-      "size": 7872
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202121.json",
-      "hash": "ea491940b94e9a5256164b70f466792958f921fe6877d3b0e803a1cfa5dd97a8",
-      "size": 19853
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202131.json",
-      "hash": "024b8546d07424d7b1608225e5fea341ffea440618c3ee9112f7da55bc1511cc",
-      "size": 4684
-    },
-    {
-      "path": "assets/story/data/02/0202/storytimeline_020202133.json",
-      "hash": "ca80ef94d321366988b3bceb1ea13356d78bb38415f9cc2867a3bab126bdf713",
-      "size": 6188
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001001.json",
-      "hash": "ab0677d561853f83c284ac4567eea961acba19661085b2f5df3f81ec41cc32c3",
-      "size": 9735
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001002.json",
-      "hash": "1f5cbb407189e060e4badd771bf4ea384d6a6e606fd7715d417f8d39facc8a0e",
-      "size": 9313
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001003.json",
-      "hash": "1c416c025bda0a9d5de7e2bbfa4606d6b4a99a4b44917e16d01c9f358b6679b8",
-      "size": 8904
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001004.json",
-      "hash": "7f3e432e75d396499e3c85e05ac261ef0342eb356727b6257499a22a7f07ee9a",
-      "size": 9937
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001005.json",
-      "hash": "e69b762b6ae7b99a24f96d9966f18c62c52df2dadce08ef4c2f93be2df58a202",
-      "size": 6065
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001006.json",
-      "hash": "fde4400c1181952d7774891f30cb94d0945e5167cd9ad7cd9d4d1409205eb84d",
-      "size": 9521
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001007.json",
-      "hash": "6a93c4ad8ecf2530593c03df63dd010723cfb7b5794f7d201b1360b2bb32a31e",
-      "size": 9273
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002001.json",
-      "hash": "ad167d7906801fa86744cf10e748a22b3761f8b0fd132c90aebd3ceea5600691",
-      "size": 8334
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002002.json",
-      "hash": "bf21ffd6f78b6bdf44c56c6d6c35944c3f4fafbeb7de4c8d9ecb531ea0e3ee30",
-      "size": 6740
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002003.json",
-      "hash": "db84a7a0e54ea2f4ee114c2deeafdf597be28b323d0f94fef82e0282babba51a",
-      "size": 9353
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002004.json",
-      "hash": "395b1cdf94e4df64b192522fb66d61eefe990f45e3adbcca5830894358389f40",
-      "size": 9308
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002005.json",
-      "hash": "d510d17cfee54c953f144cff095af867d881e28c1e11e2a63651896c69d636b1",
-      "size": 4794
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002006.json",
-      "hash": "82b0d5af8e2b33286e62918e7eda6c4ac944bf25bb2958ab123d77f526c88035",
-      "size": 8093
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002007.json",
-      "hash": "4bfe98f398d8bbd29b4ad9f88c953758c6c40c167b1ba9d4fbbfe983b7c99e01",
-      "size": 9554
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003001.json",
-      "hash": "9101e1d89593857508b59d0a346a9bf1703159b81658f368d7a9f9a39c3b0267",
-      "size": 8295
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003002.json",
-      "hash": "daa4f8531e1cdb819ced0d46fec2334dfd634fdb5cee84d72b76fb0a02d55f35",
-      "size": 9583
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003003.json",
-      "hash": "839696a166b66601b771e15f8749843cc345404022583d169c769d63e615645a",
-      "size": 8455
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003004.json",
-      "hash": "14571714d4a64c12518ba31c9b00a8c5a1a2f6a0cd47e38ca2da1ada0c6f49d8",
-      "size": 7767
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003005.json",
-      "hash": "e74306c1f3e3e6f6e3c0028909a2274c616799909c2a1350c9ad82da69af77bc",
-      "size": 6188
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003006.json",
-      "hash": "026c980958b6d0c87e3497d40b91c40b5fd73b2acacce776fd71fa0e6871af23",
-      "size": 9276
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003007.json",
-      "hash": "bd68fd3326fd22586dbc6a285b14a78aa4f5751a460793c8767c590da628a42b",
-      "size": 9908
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004001.json",
-      "hash": "1335d9586426b6f4256b92603fc24d4963cc1de9f090a0a11cb354faeb44acd3",
-      "size": 8513
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004002.json",
-      "hash": "ef94ac3c46d1cc3cb956b6511d88e3b44f8289e951359a223b47d27f2384e0e9",
-      "size": 10734
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004003.json",
-      "hash": "f8cbc046cd90e8a42f8dfa1ce278312cdd8d0ca1dacdfd47d7a9a82884db6872",
-      "size": 9824
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004004.json",
-      "hash": "11f9c3a513322a9fba162de71830ac2b780f5dbf2c717baab0d7ea27e7fd689c",
-      "size": 10436
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004005.json",
-      "hash": "422e1cc2af2296f5d518ac6f65249c27c9b5ce72f4d0449a4609ff40ce6090a7",
-      "size": 6561
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004006.json",
-      "hash": "98191685955f905877734f907d57734835cf28cf50ef34ffa5e95f7194eb9608",
-      "size": 9949
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004007.json",
-      "hash": "514d5cbfea3a702461ae597721bd6e669f04dc6c6df57a79ec49284e3344ce59",
-      "size": 11588
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005001.json",
-      "hash": "9b7fe9b0f94a8144290ec04ad913247d65311ccf769a98e532174950c727b875",
-      "size": 8879
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005002.json",
-      "hash": "18b9c88677d076b6d129334f7935a7c4b12233c493f43103b3a49da86ff72bff",
-      "size": 9897
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005003.json",
-      "hash": "85a4484f51f9b330d6045b5d3f12da6db1465b49b0112dd9b403284150b2e513",
-      "size": 9259
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005004.json",
-      "hash": "cd8bb4c8cbccf6714c569013bae736a6d95c2c115f671cb1394c3228ad41971e",
-      "size": 10685
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005005.json",
-      "hash": "0cb62f7799f6762658487ebbfb23d25fac6b1b745de9454a8f3d29bd43688680",
-      "size": 5240
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005006.json",
-      "hash": "33f81d0301b56793e0adee994ffb18b86db9915c139ec1aa994ea4c8fd071dd0",
-      "size": 8742
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005007.json",
-      "hash": "a9777c71b52adfe29633e337e1e06326cf1dd78a1274123014917bd5c05115c6",
-      "size": 8742
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008001.json",
-      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
-      "size": 3
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008002.json",
-      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
-      "size": 3
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008003.json",
-      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
-      "size": 3
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008004.json",
-      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
-      "size": 3
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008005.json",
-      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
-      "size": 3
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008006.json",
-      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
-      "size": 3
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008007.json",
-      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
-      "size": 3
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009001.json",
-      "hash": "a965d43d93329a634004bc217f324e836a117365376a541cca32de1e71280ba2",
-      "size": 7113
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009002.json",
-      "hash": "bd751251dcc711fc0ebf09fedac630c31845d9b3ebbb6bf6f0fb9556536b85b4",
-      "size": 7576
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009003.json",
-      "hash": "d1a55b551ae2bea43a59c70b6a0cbf164cf055d4a8ea9936ad5e7b2463fb41bb",
-      "size": 8825
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009004.json",
-      "hash": "860af9684012d440010c28316905258a1fb3692d60e21506edb3c9a74aaf47b5",
-      "size": 7781
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009005.json",
-      "hash": "28a73b5d735dc701bd7fb803830b1ffbac14a662485fb0fb51c00ea98e55a055",
-      "size": 6071
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009006.json",
-      "hash": "8d29a16a9bce2ae06b0ff0d8f37ebf7607c633ed1830d95efaa933b4d820a529",
-      "size": 9644
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009007.json",
-      "hash": "39a80faec3095532e7e06ebfaf2059e12e1a5156ccc2daa024c17e5f4faa44fb",
-      "size": 9516
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010001.json",
-      "hash": "37027530a681f4fd254515f89c3f518ea4e7f910ddbd93a206864d0287d2011e",
-      "size": 7545
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010002.json",
-      "hash": "f94ab83d3b62d7028d932d9989fcdee14ca7d9db0f5a3248ee0db9193e2afa67",
-      "size": 8951
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010003.json",
-      "hash": "b9373bdcebf9b8cc2b611f0ac563668094c9e05b5feaee9843da6db5641f6645",
-      "size": 9378
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010004.json",
-      "hash": "3e90ed0349eac551ac3e0435b05c89807e64488f1c9d7936ef218378c910ff97",
-      "size": 7349
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010005.json",
-      "hash": "6598b3bcf987a80c8f1bc5c8cae5dda592892b24a3a45bf03ff9b841cd7ce7c1",
-      "size": 4845
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010006.json",
-      "hash": "975c9d0eea0e25343492b73637e7a7e0bb461cb614e1b2427277674cf6eccb39",
-      "size": 7980
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010007.json",
-      "hash": "c6c190064fcc4100d38846b2900e1cffe9819cfac1fc3375d70aac3802e99862",
-      "size": 8776
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011001.json",
-      "hash": "ed77375159e0eec86f01f44c44b10ea67865d3bde20209e888438105bfa728ff",
-      "size": 8652
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011002.json",
-      "hash": "a9fec0dcf97cf750214c2c093f46c377d16cc3ebd5dbc4940ec179366e013c3a",
-      "size": 8482
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011003.json",
-      "hash": "c943243f15393a48b1882ad5dc0fb50e59b272913c465636e76acc792c84b1c4",
-      "size": 7489
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011004.json",
-      "hash": "48437538f41adf7e0e07eccbd59997963eb58f563d9d44f7c11c120306cb57a1",
-      "size": 9612
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011005.json",
-      "hash": "d9978f430a83d32324a9bc88e553cb9690fa7edbaed5e8685f062edc9b6d5a05",
-      "size": 5516
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011006.json",
-      "hash": "df50a142408d5b242a03b71cfc9059e1a29ebd1cb7d70a3a586694d9c3c0e41b",
-      "size": 8120
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011007.json",
-      "hash": "1cda466adaa2a31b0ce9ad240c77ee097ae8ec5a4913bd726f197e6824bda056",
-      "size": 8296
-    },
-    {
-      "path": "assets/story/data/04/1012/storytimeline_041012001.json",
-      "hash": "eab23a18eb9d4c237561a7ef3aa6b5b13e9a5e937f848bcb28b63265c70335b7",
-      "size": 8772
-    },
-    {
-      "path": "assets/story/data/04/1012/storytimeline_041012002.json",
-      "hash": "0560f5e2762cab92651427f47f622f774825199aa4ddf5e139562acf5e59589c",
-      "size": 9214
-    },
-    {
-      "path": "assets/story/data/04/1012/storytimeline_041012003.json",
-      "hash": "d99a8d3ed5d48789b5e642d76ae6534ad91c7fef03f5a2698d6020ef9c88257f",
-      "size": 8990
-    },
-    {
-      "path": "assets/story/data/04/1012/storytimeline_041012004.json",
-      "hash": "2b29f315d7b5d15b5a047dc94a1d906224aa9205b856592f192b7f11c5b89ba2",
-      "size": 8997
-    },
-    {
-      "path": "assets/story/data/04/1012/storytimeline_041012005.json",
-      "hash": "a3096b27b0afedb25a9caa218d7d7d35bfc9df17e5d6548557286f4a06e96887",
-      "size": 6115
-    },
-    {
-      "path": "assets/story/data/04/1012/storytimeline_041012006.json",
-      "hash": "25205328404bcd67cbfb185f8a6375e0ae94a25f816f7fd5e859261616130d1a",
-      "size": 11549
-    },
-    {
-      "path": "assets/story/data/04/1012/storytimeline_041012007.json",
-      "hash": "ab3c9d7cc1b384f4ceec7059251b0a5b4888a6f5e8585a63d0645920c733215d",
-      "size": 11234
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013001.json",
-      "hash": "168d64e223a0d0a6f10034f832fd23d2591946b9d4f9995cc1d67df4b43e0cc6",
-      "size": 7225
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013002.json",
-      "hash": "3f4df43cb707bcb8b5c83473c31ea0b5f9ade98518bf0be3ac0fafa28e635b24",
-      "size": 7352
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013003.json",
-      "hash": "eca842e6ecbd55e921ebd2dea6ca8f04d59c1ec6423e1dacb9739b4809410558",
-      "size": 8500
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013004.json",
-      "hash": "8f6e30959998107c40a34fa4b45f0120af4b94e1f379ad1716f5b2aa9b58c35a",
-      "size": 7641
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013005.json",
-      "hash": "4f79682b7a10306a8a0015cdb42c5054d7d162bb8f0e5c8465ec17d7e284f92b",
-      "size": 5102
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013006.json",
-      "hash": "d731d6ae5e294fe6d2c2ea26a36838c860713a12be219198106a7afba9f30596",
-      "size": 8685
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013007.json",
-      "hash": "7f3e15e7f75b425dc2a5559de8047cc88b0e2942ad3297ab7274b01888cced37",
-      "size": 8859
-    },
-    {
-      "path": "assets/story/data/04/1014/storytimeline_041014001.json",
-      "hash": "9a66d211eaa9aa4b2761d42a18164a17227a0640dee1e3665144ae0ad3907b91",
-      "size": 7356
-    },
-    {
-      "path": "assets/story/data/04/1014/storytimeline_041014002.json",
-      "hash": "b01dec0d6d911cb24396e2467ba7b0c570e7d146d6bb6d0a1b7babd929a6663d",
-      "size": 8741
-    },
-    {
-      "path": "assets/story/data/04/1014/storytimeline_041014003.json",
-      "hash": "a2764687ca468b4b2db8c052a6c5d2ea97af19e36b2ed51129e58ac6dfcdce24",
-      "size": 6682
-    },
-    {
-      "path": "assets/story/data/04/1014/storytimeline_041014004.json",
-      "hash": "005be4699d7d1125203319aa31c0a199ab8edef557f8ede1f59e4b30b8955bbc",
-      "size": 8665
-    },
-    {
-      "path": "assets/story/data/04/1014/storytimeline_041014005.json",
-      "hash": "7efb5c07142b9db795b3aadc008bbb750021511d105205b51db8e1311b74ce55",
-      "size": 5350
-    },
-    {
-      "path": "assets/story/data/04/1014/storytimeline_041014006.json",
-      "hash": "aa197b5c022ec790f34da1e2941145b847cf8c08de96f55711aed97432fbf228",
-      "size": 8484
-    },
-    {
-      "path": "assets/story/data/04/1014/storytimeline_041014007.json",
-      "hash": "eb2f39b250b8e91fc97f2df7c074e4b41bd01beb5d3a9f954faafdf887564acd",
-      "size": 9492
-    },
-    {
-      "path": "assets/story/data/04/1015/storytimeline_041015001.json",
-      "hash": "c5d6d5766ed8a6aabac347216a5657ea40ec45a849a25ccfd6648dc73f9225a5",
-      "size": 7617
-    },
-    {
-      "path": "assets/story/data/04/1015/storytimeline_041015002.json",
-      "hash": "06e683a8f3fdfcfc9ac2f3a8c011892d89c00eea67021478a885652b85bf3ae1",
-      "size": 7582
-    },
-    {
-      "path": "assets/story/data/04/1015/storytimeline_041015003.json",
-      "hash": "4577a90583ad2869f5d8e0a0396b229dfc1f7b1635a4cb8ba2ca593381044e2d",
-      "size": 8636
-    },
-    {
-      "path": "assets/story/data/04/1015/storytimeline_041015004.json",
-      "hash": "c74c6b83d6cbe20dbb08fb862680b3bc467adf49abe5084334681f2cbe3cb6aa",
-      "size": 6606
-    },
-    {
-      "path": "assets/story/data/04/1015/storytimeline_041015005.json",
-      "hash": "c37ccbe1d148ef7a38f556deb78f55e33b2cfda87719848798180e4fd5333975",
-      "size": 6293
-    },
-    {
-      "path": "assets/story/data/04/1015/storytimeline_041015006.json",
-      "hash": "399b57da8f3066a3b284cfd9aea7f341295194e4dd63a65d42a9d16cc5b43f7f",
-      "size": 10043
-    },
-    {
-      "path": "assets/story/data/04/1015/storytimeline_041015007.json",
-      "hash": "177cafe1dfb43c7bba3b34c7657f40deef69065a1eba856684a451db5f188e1b",
-      "size": 10240
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017001.json",
-      "hash": "178b30f237be698a172c5dfb971a14e087f1e4c63c3dcf7b596c26aba47cd87b",
-      "size": 6286
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017002.json",
-      "hash": "fae465d26b4ad9176a4f7f234f5f41689b4614c3d4a1d1d185fad2e1d6511ce9",
-      "size": 9127
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017003.json",
-      "hash": "72a5849d335e0b142ba3bbd077c6c615b0f153d694477becfef2d4f7f2b870b0",
-      "size": 9527
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017004.json",
-      "hash": "1894a121110664bffcbec38bb45308a13442e2dcee7f649f19b2e45fea801e97",
-      "size": 8276
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017005.json",
-      "hash": "73967fa48eb1333a3ef3cee0f99bb68a07e4a412a694c3c22102a0da70f7875f",
-      "size": 4891
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017006.json",
-      "hash": "4fa76722c297792ce0973f509969c09bbbfa001131bb697e4e34640b85b82ecf",
-      "size": 8989
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017007.json",
-      "hash": "d0b43ccc1d530529365326673c59de98d1a5fe656118d9afd78fa42da1839e49",
-      "size": 9093
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018001.json",
-      "hash": "d803b8436f677bd82bf576d3d37cab8b850d8210b919e87606932c2d4919830d",
-      "size": 7798
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018002.json",
-      "hash": "f1c287186085f2fa002158337909bbc06f3ca658ca89c00fa9030829fc394bee",
-      "size": 9403
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018003.json",
-      "hash": "c0dbb6f7b9b7b6837d66e85167b782a01b412b253e1f01abcf2238eb13d483b4",
-      "size": 9296
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018004.json",
-      "hash": "dca7635bb6fedeae4cfd1e8dc06674f4fc98a565e7ee2a4fa3259f25f7936eb9",
-      "size": 10188
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018005.json",
-      "hash": "8c6b17904f6e6e9e677aeaf4afa9329b7d64be44cd9554067cf2177b4892ee52",
-      "size": 5757
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018006.json",
-      "hash": "44ef40efa2361ea223ea5339580e3661cc2574cb40405d427083859ab82fbdcb",
-      "size": 9203
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018007.json",
-      "hash": "571838dbf02b798f73428a74e49f53e9487ca0f25d9f02974b64601a0119b81e",
-      "size": 9077
-    },
-    {
-      "path": "assets/story/data/04/1019/storytimeline_041019001.json",
-      "hash": "3393a5ada831ef2c48cd16aec7c3d03fa00549f88584cf1e3d04e315ab397548",
-      "size": 8836
-    },
-    {
-      "path": "assets/story/data/04/1019/storytimeline_041019002.json",
-      "hash": "9dd168e5aac5862b4090d5fc7e85184416aaa87a7e6f5be3684b7bc67956fdbd",
-      "size": 12006
-    },
-    {
-      "path": "assets/story/data/04/1019/storytimeline_041019003.json",
-      "hash": "64c2e3412a0171c1ae7605b5dc557b16e53b86f69022892fc94d08157b3dbd9f",
-      "size": 10063
-    },
-    {
-      "path": "assets/story/data/04/1019/storytimeline_041019004.json",
-      "hash": "0c4e3ff8ca7affe97451f3c90413d62df71d9767bea1e463ce65caeaf963f8c7",
-      "size": 11156
-    },
-    {
-      "path": "assets/story/data/04/1019/storytimeline_041019005.json",
-      "hash": "dfbe46309a243434fa55e0b99b0dc506a1be16958fc490b5e3157b0e6031180a",
-      "size": 6893
-    },
-    {
-      "path": "assets/story/data/04/1019/storytimeline_041019006.json",
-      "hash": "cf18b8e5013e13a25ecda9b3bdb026d5dbdb27a65e069f7d26605ed782c5449c",
-      "size": 9723
-    },
-    {
-      "path": "assets/story/data/04/1019/storytimeline_041019007.json",
-      "hash": "66e1260771605c0a8e33797c68c3d003ad4532b3e3f0b4e77e83bfce62684815",
-      "size": 11081
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020001.json",
-      "hash": "6a63f1c0d08c22ff6c35fe4b665a6488985fcefe6728a17cc53945fd7f2a6dc7",
-      "size": 9374
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020002.json",
-      "hash": "992fcffdb849aefe30ea965e1c999f648fc71582352119f2ec76a5003a46dafd",
-      "size": 9374
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020003.json",
-      "hash": "350eecc1642924f848351456bd7a1b73dd81604f6241ba0979d4f4688ddbae5c",
-      "size": 9315
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020004.json",
-      "hash": "e717cc252fadd07c6cfff95dd67df5322c521ca5bcfb235281375d50cbbe23d4",
-      "size": 9987
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020005.json",
-      "hash": "c4fd087d242fca0dc45ad8f719933abf73c880d3b10f8e7f41e7fbe40a0d9e3b",
-      "size": 5350
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020006.json",
-      "hash": "c026f1c59424e287eee99d2f5a240a5c575bf905674f366e0f2ed5094d20e2a5",
-      "size": 7062
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020007.json",
-      "hash": "422779ad47e0a80c5595bf4f201ca759b88725bb35af950f1b38904231cd3483",
-      "size": 8087
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021001.json",
-      "hash": "6bb55ffebc350a4ad0a1df32b8e3c94f4ba8e080f866aa117003baf24c9ed669",
-      "size": 10628
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021002.json",
-      "hash": "4b32a02a58a0714dcf8cc3a3a539d104b748a3a8a2688a9c9850bc51c10dd6e5",
-      "size": 8910
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021003.json",
-      "hash": "6c4010b39916e1ca8f409a7b4816a681ef12014c10a5195f81605765ba107b13",
-      "size": 8767
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021004.json",
-      "hash": "f35b99c2452dd31c98b4ce4e3b2ccc8d15940231bca211d0d7c119c643ab6baf",
-      "size": 8572
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021005.json",
-      "hash": "d18a5979fb9e1ed33575dd2fab3c960af97a00056fcbb442d051d928959a3edf",
-      "size": 6492
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021006.json",
-      "hash": "2b9d436635216866f1d009a92c6dd79f5a51476da6d17ed7bef7cd76741ef678",
-      "size": 10175
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021007.json",
-      "hash": "991369e44412e687ed784ec64d6e009c3447c6e24e1efdb0dc7b16bfb142d577",
-      "size": 11073
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022001.json",
-      "hash": "59f4c303bc0b9717d0b409bbacf1a2ff39629f9c8f344f47e31c4851cb4240d7",
-      "size": 7349
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022002.json",
-      "hash": "48099fad8035927cfaeba74ede5bad227d7934955478b75934d785c43b839e6d",
-      "size": 10026
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022003.json",
-      "hash": "9f9e6ed565cf2f349f0a6b22fcce1738cfa5dffe3327162adb411a7165bab4e0",
-      "size": 9631
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022004.json",
-      "hash": "db20ccca60d032d904e186ee853d4998d314775513a7d3448ec37a2a5b9a2b27",
-      "size": 8409
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022005.json",
-      "hash": "eb8a06a33857010f89fd017aac2bc12e4fed79bf2391ed5429600356e9f2f65a",
-      "size": 6142
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022006.json",
-      "hash": "59cf9510335aaa864aad5642c71894d2eb0d42f073834228d65989210e3376f2",
-      "size": 10359
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022007.json",
-      "hash": "32985f24b5c911717d54dea419c9a54643d80cca9f16f6bca57773d51128a911",
-      "size": 10207
-    },
-    {
-      "path": "assets/story/data/04/1024/storytimeline_041024001.json",
-      "hash": "81dc61f9f297b3e558da7ab4360a9fd58dfa2608249fbf3439eb2335903f4b95",
-      "size": 7445
-    },
-    {
-      "path": "assets/story/data/04/1024/storytimeline_041024002.json",
-      "hash": "49c06e0090f870f1757f74394e49f1265b6a75b9ac4dd4d85dd3bfab6746cd51",
-      "size": 8446
-    },
-    {
-      "path": "assets/story/data/04/1024/storytimeline_041024003.json",
-      "hash": "7451bfac30d493c23d3c7264c18269cc46e1f17722239c68f6a8e7ac78585940",
-      "size": 8411
-    },
-    {
-      "path": "assets/story/data/04/1024/storytimeline_041024004.json",
-      "hash": "b29b9325d2d71a37483f2bec8e036aa85021553aa9211908b47591b810c875d5",
-      "size": 8660
-    },
-    {
-      "path": "assets/story/data/04/1024/storytimeline_041024005.json",
-      "hash": "fcc03f75cbe151ca2b4456df685df9d8c9ff207e84f35b31c72aec54403d3b04",
-      "size": 5290
-    },
-    {
-      "path": "assets/story/data/04/1024/storytimeline_041024006.json",
-      "hash": "d5d2bc03ac36499982e837f8f4ff862c14954c692bf4073b5c1ab6dc23730320",
-      "size": 8562
-    },
-    {
-      "path": "assets/story/data/04/1024/storytimeline_041024007.json",
-      "hash": "ce7a8485e9857616d194bd21b6292755553e6d5d179a9365b7967683eb93caf6",
-      "size": 9263
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025001.json",
-      "hash": "968bdee5c50547a2a05a4ae01484c887bdaa6e4ed4da580e84da5072ab47c893",
-      "size": 7602
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025002.json",
-      "hash": "b0fbb383ac214980f34bc08b031ceecf5c861965bfac38acbce18b39896f94ce",
-      "size": 8166
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025003.json",
-      "hash": "c19c8afa1a19266ccd44e5963dfeecfcc270e4df55f36251fb3b64df24a136bc",
-      "size": 9577
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025004.json",
-      "hash": "06151cc5d04a5d3bbf9630e13632f419e61469699f4dd7c73b5a1dae1eb57ab7",
-      "size": 9519
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025005.json",
-      "hash": "f800948680a31bce81beb156f6c1b3700af6fb5eeb45d6947217b9e79e1665fb",
-      "size": 5230
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025006.json",
-      "hash": "44da94506e9f869fc10756608d1e2c87e055f95fc5b6c80a00f9404e42585682",
-      "size": 9135
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025007.json",
-      "hash": "f6350e1ef904e5564b3b1da445522a941be789079834720858ba29523284f1a8",
-      "size": 9324
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026001.json",
-      "hash": "89885fbfc6e8c4d2acc6cd90d2d8576231d74ec9d46355dd6101eb0d8f635429",
-      "size": 8497
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026002.json",
-      "hash": "24e24e8fc90c73135c7363618ad3c674e06b4ec978735023d7303f40398b47f1",
-      "size": 10448
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026003.json",
-      "hash": "f7162bd99ec67b7e91f881035e68a255696ba01b7eca50e115164981b504848a",
-      "size": 10700
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026004.json",
-      "hash": "6ceae82351e9838a3e9fd40ab609ed05a6cadbaf036f5a4c350f1e49480927d7",
-      "size": 10907
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026005.json",
-      "hash": "d39917654d090be9a3fd99b870bc7d039ce98ed2efbfa164a1d2ee7c53f6c7ab",
-      "size": 6579
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026006.json",
-      "hash": "da23adc0b94acd6bfd21c6be2b45b78983d9c699e1fbf8812f010bae16561ee7",
-      "size": 8668
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026007.json",
-      "hash": "4aab93a9aa71b6a3e4bf4b1c35778263abb491edcdea414a8f82635dfe3c9371",
-      "size": 10017
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030001.json",
-      "hash": "ff2338fcdcea63d765f4dc83de5ebdae188ae1093ff76ab496ef55394da6a624",
-      "size": 8371
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030002.json",
-      "hash": "e5cd554807d56fcf5efe0983b49a85a8abb1f4d97bcdd66ec918f3b8bd19037a",
-      "size": 11462
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030003.json",
-      "hash": "b8e05ea721c224466d39173656ae47b09a7c61f6714364c9e1a808a6bff77fd9",
-      "size": 11798
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030004.json",
-      "hash": "b780dfe89413bead136d7eddc0ac01c7fc886297452de0f5a4633c2fff609941",
-      "size": 9749
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030005.json",
-      "hash": "0276e85397217a5deb03f3f27b2164f802cb2a468cf9c45897be7ffb49829125",
-      "size": 7046
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030006.json",
-      "hash": "8d88376018af48a18c9b58db8c17b06a595bfbea10515805c479523bae683b06",
-      "size": 11330
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030007.json",
-      "hash": "9fcd0e48f7be133aa6f8a5f4c4e1161cc72a886655c493c05c939f208f346915",
-      "size": 9336
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031001.json",
-      "hash": "c89da1d575bdd92cbf33102a79ed5484098ef57d24906d522e3c21b9a4765a61",
-      "size": 6300
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031002.json",
-      "hash": "6e7c78c8dd631f3b975ba0b04d3c9736fd72f9e725cf090e45787535d970e107",
-      "size": 7902
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031003.json",
-      "hash": "041fb20c876825f614e6bebbe99a1d585a37f7411f24802d21752264d53e321d",
-      "size": 10174
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031004.json",
-      "hash": "d9b40cece60664ff778b76ca1dfa3e8d56767c23075659ff9b37b7d5c8b2bfac",
-      "size": 10135
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031005.json",
-      "hash": "71a9e7e337cf8dade03fb62005281fefe85ea47adf082f712aff072217b558de",
-      "size": 6116
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031006.json",
-      "hash": "af7beb192e9d1b15c2f14dc7002185f7bca79b2320e063ff5d13dd36d4cf50db",
-      "size": 9384
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031007.json",
-      "hash": "65d61c24c144d144749cf137f74d6e80f6f06e7995717d563ab5a0a4c70e3af1",
-      "size": 9280
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032001.json",
-      "hash": "c901be4ce9d17607d8358cb15e4ee29305c894414be68466a385114fc093f148",
-      "size": 9863
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032002.json",
-      "hash": "bcb8bf6abe339f5e78f22d884700dec4665b0d07893d6442ceac70e6ce57ddac",
-      "size": 10904
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032003.json",
-      "hash": "24793d73e1061e09677f8224bbf0a06ada6349274b8061144839145562c81db0",
-      "size": 9847
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032004.json",
-      "hash": "974ff9dfdd4b6e919f4c49b133363fca23dfbc171dfc1d63c7ad85059ae6600e",
-      "size": 9674
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032005.json",
-      "hash": "605971aa3dea05908a8b66665279321efbe3e0cb4d8c9d5bb30892a9ad9c31b2",
-      "size": 7253
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032006.json",
-      "hash": "e8b57e826f7498f418c09c941db7bd2698239a2da7fe1dce14f202cf7a64a6c4",
-      "size": 10117
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032007.json",
-      "hash": "8b5807f19ea3c17628553ce625c9bc3525d5eebb0e653e6560600e00683e7d1a",
-      "size": 11642
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033001.json",
-      "hash": "953fb2714c11855f1b8e7ce716a8b8643f4b3be20e1e72d994be1b1aa420c62c",
-      "size": 7591
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033002.json",
-      "hash": "e000f91c5ed9be71c79b394ef42707e76ca9bd72a1662e34bc943b6a2f923c7c",
-      "size": 8192
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033003.json",
-      "hash": "978663cfba39c8779fa829a48467820f03f924af1b5a43cca7c911dfc5c9393d",
-      "size": 5718
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033004.json",
-      "hash": "d8ed1e4048991d93c295c39546ff3a870a870bd445acf0df9e2dce374fe4a344",
-      "size": 11139
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033005.json",
-      "hash": "104a0783a98b459e7e7fb652b77c7eaf12ba88a59c5285de06ce2288e4488472",
-      "size": 5084
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033006.json",
-      "hash": "f7af526d41467192947453ed2cf25cc1b55bba9320bb5354922e322be37bd7ec",
-      "size": 6086
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033007.json",
-      "hash": "14787fcf4c7c773c1a928172a4e75536593d0552cdd7446907e41265b13fc94e",
-      "size": 7417
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034001.json",
-      "hash": "b0a502722805fac13a70579d4923dd9620ca09bbaf25310659b5818efe8f5392",
-      "size": 11865
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034002.json",
-      "hash": "3461179c2008b629bf0397c8fa824470b99b57f866e3089a31431e532190b9a7",
-      "size": 9184
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034003.json",
-      "hash": "da4df44914f11fbaac2c9866309616e069eae1f42047ec7083564c32964fb701",
-      "size": 9133
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034004.json",
-      "hash": "a0f465fec7c08584320a84b7378d49876b6413967c20c5ff9a599ec9bb78464f",
-      "size": 8124
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034005.json",
-      "hash": "6a0e73339ae3a12d5795cef3a0cce4e44ea9a911e8cddb9c97aea0c9f10aa206",
-      "size": 7528
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034006.json",
-      "hash": "c0ef17784f6100481f43c03d44a6e87ab30ce8925b88a4bc514b302c110c834d",
-      "size": 10636
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034007.json",
-      "hash": "c6225f25e2ff8b6c1fe423e9740e90fba43d62d33197c831728f709c1f3a19ad",
-      "size": 10995
-    },
-    {
-      "path": "assets/story/data/04/1036/storytimeline_041036001.json",
-      "hash": "ab0108a2e6e05c00d1a631a5dace17f76aba8fd2f3e7403658314a1b9bc55758",
-      "size": 10661
-    },
-    {
-      "path": "assets/story/data/04/1036/storytimeline_041036002.json",
-      "hash": "1da7da62ae8f3e53a25ff2b4a86cc118b57eb95364a10e34df02806e1e20c53f",
-      "size": 10019
-    },
-    {
-      "path": "assets/story/data/04/1036/storytimeline_041036003.json",
-      "hash": "bf6a289b1457f1b8b42f22a7805d80c8ed2dfff5fc8c66da89f129620cebc908",
-      "size": 12133
-    },
-    {
-      "path": "assets/story/data/04/1036/storytimeline_041036004.json",
-      "hash": "951ac62182c0de0d339435634e46f2a3caac4a166415dec29e6a6fa087ddf130",
-      "size": 10896
-    },
-    {
-      "path": "assets/story/data/04/1036/storytimeline_041036005.json",
-      "hash": "4ea0269d1f3b2db4f45de0528670a1332ce277f4525a97bf3f850f4121a107b3",
-      "size": 7158
-    },
-    {
-      "path": "assets/story/data/04/1036/storytimeline_041036006.json",
-      "hash": "11e211b43193eb4612bf65eaa33214cd1451ac9924678d17fa1b2ae0940be3f4",
-      "size": 7978
-    },
-    {
-      "path": "assets/story/data/04/1036/storytimeline_041036007.json",
-      "hash": "098c749afdd9bb83abad663ba6b4f54f8f1203c734c10a15bf8496cd193d7cac",
-      "size": 9214
-    },
-    {
-      "path": "assets/story/data/04/1037/storytimeline_041037001.json",
-      "hash": "f40a3a4de47f8e19f31f6543a77161bef9bfe2d236ac46c15edce2ecca858ebe",
-      "size": 7162
-    },
-    {
-      "path": "assets/story/data/04/1037/storytimeline_041037002.json",
-      "hash": "a7f1b3915c7f080f92b8577e79db5f18c226541bab1c93daa523f6f73e0d5c1f",
-      "size": 10150
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038001.json",
-      "hash": "54ade6d98ab6c6040a6f495d8a5cc367bade3c967373128121a4f5d5f334e42d",
-      "size": 10929
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038002.json",
-      "hash": "efc2334307d57f4a173cb701756c4c0a0960910e42fbfd046516869996be3a56",
-      "size": 10547
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038003.json",
-      "hash": "018fe74366561eb0679f293af6b7ff5196333440e917d1feb16a76c64a5058d0",
-      "size": 11242
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038004.json",
-      "hash": "d3de2bd4f53533051c09109b8871d1fd8cdafc98c15ebc11da43984564d35f66",
-      "size": 11536
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038005.json",
-      "hash": "a653d2dc0c4136d3d2d5062ce8ffb62631904912bcbc0e85dfb35c990ca1bc6d",
-      "size": 8069
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038006.json",
-      "hash": "4285a00ae769a928372821763c11f9ec42516dbea497550fb91624cd658710b0",
-      "size": 10434
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038007.json",
-      "hash": "ec8b356097d408026385da66f5fc736cc42cab550cb754ca86ed9fac5f253d60",
-      "size": 11273
-    },
-    {
-      "path": "assets/story/data/04/1039/storytimeline_041039001.json",
-      "hash": "fa2832b30bcb4311174dc31c0b930c0d404845266f6003b0dff1d440b068129e",
-      "size": 8685
-    },
-    {
-      "path": "assets/story/data/04/1039/storytimeline_041039002.json",
-      "hash": "2e405a3abe742ef8ad960f591d4076aa7b547ba58a29e5a5dc4ad69ce69e815b",
-      "size": 8734
-    },
-    {
-      "path": "assets/story/data/04/1039/storytimeline_041039003.json",
-      "hash": "29f274b2435273820e706aa7b733f16f0c5c576d62e90e90fb8d6dce8419f22a",
-      "size": 10481
-    },
-    {
-      "path": "assets/story/data/04/1039/storytimeline_041039004.json",
-      "hash": "9999495380db1c2e537c32d158fccf857685e6fbbdce6ba9a85ba428ed5c6555",
-      "size": 9059
-    },
-    {
-      "path": "assets/story/data/04/1039/storytimeline_041039005.json",
-      "hash": "226ad6fda3803cb1fdb9104ded8a1408bda3d94f26be29d6d859d322984b39d6",
-      "size": 6267
-    },
-    {
-      "path": "assets/story/data/04/1039/storytimeline_041039006.json",
-      "hash": "349506af18aa9811a75fd27f8c05bff0e86031b5390df722eba23faa6978bc3e",
-      "size": 11578
-    },
-    {
-      "path": "assets/story/data/04/1039/storytimeline_041039007.json",
-      "hash": "a21f15d1efa5ec73c3b40e3ed450b48e257cab4090eedbd7ac2b1ba9324ebbd6",
-      "size": 10300
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040001.json",
-      "hash": "6ababdf22a44f2891ae5dfc0ba4a9792afb88a7a6b720fd9db9cc10e0066f406",
-      "size": 8210
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040002.json",
-      "hash": "549ad02f21c30709c30445f4b8271dd55025b7472d878f284fe8022d32c783a6",
-      "size": 8166
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040003.json",
-      "hash": "a03453cae099dee6e9de916f75e0ade9925d7b31ae61b794167814e39c9b2f26",
-      "size": 8883
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040004.json",
-      "hash": "2c88793a241542faec5a614038cb5e91c789e53c821ec11e52c26298493a9f5b",
-      "size": 9791
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040005.json",
-      "hash": "0dfe3a669de3f15bc22c344f34443decbb68e72c02b1a109ca36eba254f23cfc",
-      "size": 5892
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040006.json",
-      "hash": "45466b7f0ffcf9c406e8ee808be51850cf5a8330b3aa65a65f5f97788c54634e",
-      "size": 10768
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040007.json",
-      "hash": "335a93a6909587210a612871ab9f50397941b0bce78d3385cb745c9f2cbc19bc",
-      "size": 9515
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041001.json",
-      "hash": "ad7c4c5f70c480ab52cdbe09d1cc448290659fdc174971977c4881bbb98defdf",
-      "size": 9126
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041002.json",
-      "hash": "0d7df8d6232069817d9c9a3e0d979e5b374e1eaa810278247b7c212b0582d3a6",
-      "size": 8922
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041003.json",
-      "hash": "919391d2dacf601c13b554b55ff1d3da7037987607e93ffcb4e051b7854797f6",
-      "size": 8172
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041004.json",
-      "hash": "a0022d3acd4b6400602d26b67a0fe4cc8e6789797cc9c1fa1a1e1a6e633f09a4",
-      "size": 8779
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041005.json",
-      "hash": "9e9f8a2a879ebd4902fc5c0ec70f7c94384ffd537515bef7b91a766c13e4c9a0",
-      "size": 5926
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041006.json",
-      "hash": "ba28ac3e20cfa521836fad99821db34b75772bf3a802c687ebd13ac55f99995b",
-      "size": 10375
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041007.json",
-      "hash": "2786a594e2d061843bf76df6af791b5c44438c6ffb3b7aab354b86e7bf52ce0f",
-      "size": 8398
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043001.json",
-      "hash": "39a717683448bf9a921174d5a76b98bc72f7c33f68f0d2aece3b562c54bd2c7b",
-      "size": 7952
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043002.json",
-      "hash": "6c1e8074b51af33d0fcf1ae90545d1345a70b0ac0dd2272d42dadd64fb7083c1",
-      "size": 6726
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043003.json",
-      "hash": "fbebd6cb1bf8c4df5905c43a1796e8859553bee06b7eee527e9c588d97ce980d",
-      "size": 10030
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043004.json",
-      "hash": "2c948a182214c76cb214be96f85f0e67da0b84bd99a55db04fe6bda4f2a4ac38",
-      "size": 7879
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043005.json",
-      "hash": "7f42b5c7608d3d3734ee73262ef1d6ab4d226f04997f4cbdb764bd8a16b4f0b8",
-      "size": 6171
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043006.json",
-      "hash": "e2234a74a9b688b2af359ec0fc54a25674af2592a809a62b7d125ee143aca45d",
-      "size": 8216
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043007.json",
-      "hash": "9e9ebde4104c15e49210ca0907d1830fc57271bcf95f246b74586065161d9b95",
-      "size": 8307
-    },
-    {
-      "path": "assets/story/data/04/1045/storytimeline_041045001.json",
-      "hash": "8b3af7019a4d68db2711f00e860520db459b964be51da963e8a2bbe086d2152a",
-      "size": 7645
-    },
-    {
-      "path": "assets/story/data/04/1045/storytimeline_041045002.json",
-      "hash": "d11bcff6c41f818c2c4e1537310f223b8448627d25c2e3d147310ffd14d7073e",
-      "size": 6619
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046001.json",
-      "hash": "772de4f8b5f41fd358a28074d249e00c988892f73b5a535960e06eb0d093dbb7",
-      "size": 9198
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046002.json",
-      "hash": "08d5da6294f5ebdc7a4fe46785e3f9e1a3937d3abe12c37638ea77de2ab32228",
-      "size": 10020
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046003.json",
-      "hash": "86a45f5ddd93f55db0bed2bb2c89f4c0f89ebbb581d7e36d56c02e61cc790219",
-      "size": 11277
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046004.json",
-      "hash": "d18cc6c43ded5143e0955ccf2a915854486673fb485b2f3f568264ef1871f698",
-      "size": 11260
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046005.json",
-      "hash": "4e46f8167887b512f4edd2beec8f8d56fe62df101a676d8ce0996f6b86c72237",
-      "size": 6504
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046006.json",
-      "hash": "a3102e565717797fca9efa9f4a5d7f78424da671f30bfe8aa9908353999d2b70",
-      "size": 9719
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046007.json",
-      "hash": "7c5e1163d448f9952953b09bd2972f5f3e5e4288e94e55906e0b1a51875ed838",
-      "size": 10406
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047001.json",
-      "hash": "ea06ef77785057667315d53433f02facb8aea00e06eb7bd39be16c466c869f2f",
-      "size": 7177
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047002.json",
-      "hash": "d72869fb65e17c2de0785ea4f685c9a49b46eebb44be47795b2ea6b7759ca513",
-      "size": 8897
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047003.json",
-      "hash": "0badca2bea793fe6058e3a58ab1b17bece207eab390c11a07e5b6901d4b536b4",
-      "size": 11116
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047004.json",
-      "hash": "f8478e6cbb55ed4e3d03d1162378e591952a0557aacaa72b04f9988f300d6110",
-      "size": 10438
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047005.json",
-      "hash": "14e9a5733e4574a0e502fa0d8d39b11197be2484e848a0f7fd4bff55a4ebe349",
-      "size": 5475
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047006.json",
-      "hash": "94d34c8bf350ed8c7663405dffb7375cc4a5e70b35ec1864eaa25ed0b3690500",
-      "size": 8980
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047007.json",
-      "hash": "a9f097e3fd0906cae3a34f545e8327085bd4be2d9292af845db54a35fd500cbc",
-      "size": 9791
-    },
-    {
-      "path": "assets/story/data/04/1052/storytimeline_041052001.json",
-      "hash": "2c464b5672f7c68cddeccc2959d865de691bf3962616bfe2739ad37892a0ce94",
-      "size": 6042
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055001.json",
-      "hash": "067522c18266286e692ba4ee5e4197b1c90307f97fc4bccca204fb783be50bc5",
-      "size": 7637
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055002.json",
-      "hash": "458fcd0b1b7107a01bbddd6c60d711f80960b4d6a4142aa8be635f9b8ca8be17",
-      "size": 8658
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055003.json",
-      "hash": "01725fe6e771195216141ab9e4e7783b429e29521c4cc86003f793b7ac9d4aee",
-      "size": 10912
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055004.json",
-      "hash": "f1382f18245f208e9fe96fd1e24a22322e79b161d7cd7d44bb6280744ac8b4f9",
-      "size": 10599
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055005.json",
-      "hash": "36b2ac9d126ca7ad10a44ee22bf2a081d0798b4c90b11e1712518873c79cb4a6",
-      "size": 5645
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055006.json",
-      "hash": "7503dcd7eb7b037049cdf8824d5c184be6db17ba125aaaab37af9d70f004ffe5",
-      "size": 9651
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055007.json",
-      "hash": "b24bf491d82ab380b42e355dacf37c8a3eda73e5f8a8eebc6752653618fc5769",
-      "size": 8764
-    },
-    {
-      "path": "assets/story/data/04/1058/storytimeline_041058001.json",
-      "hash": "3693568a2faa8d6f9439e838b9a55d21ba7b12f33ac65f1a0ab0b8046530be02",
-      "size": 6568
-    },
-    {
-      "path": "assets/story/data/04/1058/storytimeline_041058002.json",
-      "hash": "161a2b56f9da767384a588c5ed722c40af28feafa04fc30d374709c6d0914056",
-      "size": 10463
-    },
-    {
-      "path": "assets/story/data/04/1058/storytimeline_041058003.json",
-      "hash": "f13c771fa5f98fbcd53f83e2cec65a53ca58f5109363a1437d2bf92322319907",
-      "size": 7390
-    },
-    {
-      "path": "assets/story/data/04/1058/storytimeline_041058004.json",
-      "hash": "47a7f4585d9d59593b1726ca17e0f2b695bc96781118dd56e2891dbd68a780de",
-      "size": 9832
-    },
-    {
-      "path": "assets/story/data/04/1058/storytimeline_041058005.json",
-      "hash": "e99811b9bab4f4baf7c44fb32481278183953cac93c12c446203634a4795649d",
-      "size": 6325
-    },
-    {
-      "path": "assets/story/data/04/1058/storytimeline_041058006.json",
-      "hash": "cc13988bb2e128aa75ef71d8c60608073bf861ea1814e9b7a68e056c133076b7",
-      "size": 8020
-    },
-    {
-      "path": "assets/story/data/04/1058/storytimeline_041058007.json",
-      "hash": "2ebe77ecc8f7a82eacfe06fe78f840f1aeb883624ce4304069222e22766b35fd",
-      "size": 9918
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059001.json",
-      "hash": "bb050d6615cded978dca3f5690fd3ffed508bce2327e43da8204ec72042461de",
-      "size": 8959
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059002.json",
-      "hash": "4f6f1bd7a167ac417d90a6db51d820346d92c900375f11f1ef177cef559ebdd9",
-      "size": 12736
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059003.json",
-      "hash": "5ffbdaabe6b5bb10669d6af5f623c6982066d73727fa3c445a0876719e45ce35",
-      "size": 11451
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059004.json",
-      "hash": "ef25265cee38ef12a390cd0fdfd62fc0f18f54669ee0726ce7b540536cbc1ec0",
-      "size": 11275
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059005.json",
-      "hash": "9c536de10b88e628455359910ffd821b926b91fec88c74b3912e11d469e2b4ca",
-      "size": 9594
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059006.json",
-      "hash": "da5e5a2357f3b1fcb552de5e823bdcd4b07e7260a99d48b27a18b8b9ed86375d",
-      "size": 14880
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059007.json",
-      "hash": "b28a43ca325a62805aea14f27fc28fb8f539618b79f005efc68b9490afc7b84a",
-      "size": 13728
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060001.json",
-      "hash": "50b3ce182624e6645978525d3e02b804abc03aeea036c605b08f6a6f84bfa9c5",
-      "size": 9353
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060002.json",
-      "hash": "cb71f992db7cdef18489a7e6a394dbd4169abe78f7eaff5e87cc074adfb304a0",
-      "size": 10136
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060003.json",
-      "hash": "6b178c91853c79783715614229196bba417411bb79754836ff9ed1b74da54757",
-      "size": 8854
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060004.json",
-      "hash": "7270f82476d7e7c57251daba1ea796ec1c7c4a5283bf705cc841386bbbe9f975",
-      "size": 9124
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060005.json",
-      "hash": "bd22c7aa5834e923998c4a42100e358ec3e5791021d451d3d8c55024e24ea160",
-      "size": 6492
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060006.json",
-      "hash": "95783ba5861667f782bdb973a6062627739bde0c2ed2b44597138ef05d6054bd",
-      "size": 7769
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060007.json",
-      "hash": "ca903fde356656557b2abdd580757b8c57cc830e6fdcd79038f11c7ce481acb9",
-      "size": 9526
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061001.json",
-      "hash": "6370cc6c18e93b353658ba47a907911e199cad684bf93f7fd2aee963c3c18e51",
-      "size": 7845
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061002.json",
-      "hash": "ae951910f9979324da8be71dbc7b7b4a8ef05fae2162f48c5b1f8de9cb9fdc7e",
-      "size": 8247
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061003.json",
-      "hash": "0b4ec5582abc671fc743eaafe7155645d9b1f7cd40648bbbe457970f35aaf9b8",
-      "size": 9009
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061004.json",
-      "hash": "f98432c1967d2755cbff0bd1065c0ee6ababb79d0757ff9eae151ff01fdff862",
-      "size": 9444
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061005.json",
-      "hash": "c4db242cada7475bfa8161f56ccabd33fed3a8b2ea2756142e9053ab23518f47",
-      "size": 5561
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061006.json",
-      "hash": "d87f1c66f0a998f32edc029dd4a1925996dd83052c14b487a6bb49b25a5a993d",
-      "size": 8630
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061007.json",
-      "hash": "6ef96a4f8980e7d00eb239c9cad9bc0ca07a66b4f7b712ff883378de2b72443c",
-      "size": 9362
-    },
-    {
-      "path": "assets/story/data/04/1064/storytimeline_041064001.json",
-      "hash": "953b20f1eeb2710ebc098de6f546b13b15b61e607924ce4201ccdb2ded7c77c1",
-      "size": 10416
-    },
-    {
-      "path": "assets/story/data/04/1064/storytimeline_041064002.json",
-      "hash": "66640c42dacac6291c77817fd7e9f2707f45f14ed55d6dab3d1d50e0d613a41c",
-      "size": 11012
-    },
-    {
-      "path": "assets/story/data/04/1064/storytimeline_041064003.json",
-      "hash": "f5195e9ccb537a7715a32ea73de4f70a75a481c470a6614cfb8ef753aa055a38",
-      "size": 8005
-    },
-    {
-      "path": "assets/story/data/04/1064/storytimeline_041064004.json",
-      "hash": "db8098692602eae92fbbbeed5475288c0e515229f94d57b00d19d95436fa2bf9",
-      "size": 9587
-    },
-    {
-      "path": "assets/story/data/04/1064/storytimeline_041064005.json",
-      "hash": "7650153a996e9ddaf1b94a443f1a127e75f63027ea910aee78c973df6f84a854",
-      "size": 6297
-    },
-    {
-      "path": "assets/story/data/04/1064/storytimeline_041064006.json",
-      "hash": "d61f4ef8dfc7fb9a0a051b9149eed00eca9c7a2fb4fa3414c8b69c51137c7087",
-      "size": 8465
-    },
-    {
-      "path": "assets/story/data/04/1064/storytimeline_041064007.json",
-      "hash": "82d73e05995130f25abb79aeeb7593471f9c44a81a46e54e20b05715fb1bdbfa",
-      "size": 10261
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065001.json",
-      "hash": "6103f579c5ba6b78e0ba22b62499ee175de258b444d0e182003a318dc35f7d69",
-      "size": 9009
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065002.json",
-      "hash": "df1a242185a2e25b6a36d5ec208971cb0ed7d4fc8da2d75e87d432f0fbce6054",
-      "size": 10465
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065003.json",
-      "hash": "5c1ba57df6dd0fa8b86ee0fdec1a74096fa6852a529c5f5ac801c43a700133ba",
-      "size": 10829
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065004.json",
-      "hash": "d46629a5fc0db42b910b0045227fd582aa10e4fd131dd6b3c19fb9c615433c0b",
-      "size": 12459
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065005.json",
-      "hash": "711c9f908b12dd463207e5d97f4a78a9e9484e82c0cd83a9a1a336e36014c400",
-      "size": 6264
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065006.json",
-      "hash": "1997fd54aaef54c60be8732dc220f832b3fa9febae56b6da70ea2d60b441a884",
-      "size": 8504
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065007.json",
-      "hash": "339d82b253c52e16ddf6351260bb0f9a8019571c5c49ce623aa1574f1f278b0c",
-      "size": 9555
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066001.json",
-      "hash": "d1d8a6ebf0bfbaed37cc3c6f223c19d54a3278bd4f0bd85e1ac01b00a87a67c6",
-      "size": 9008
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066002.json",
-      "hash": "ca674af14cbe7a2fd45f523410fca5d8dd749c29cccb4470e0d7a185ace861d0",
-      "size": 5990
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066003.json",
-      "hash": "8669d37a2dc52bb04e46fcfc336588be5f8f8e11523a9c5dffc7098c527d10b0",
-      "size": 8596
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066004.json",
-      "hash": "c2fdde26706da16dbe53e97c60be1cac77b3c784bf65d3ef3abaea78b6671334",
-      "size": 8720
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066005.json",
-      "hash": "a069b5da1ea1c0690ecb7ddb9d02983e2086c1bb57432f13fe23d9596407b730",
-      "size": 5072
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066006.json",
-      "hash": "5357f4600302a7ce5a2bf09589024facf74aeffd2dd84519473951de88aba470",
-      "size": 8206
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066007.json",
-      "hash": "29fb5f16c94467ecdb2373b4f41c467a80c1a7390fe4baae76dd1600552b8ba5",
-      "size": 8555
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068001.json",
-      "hash": "058002e4ceca7f54c456960b0bdc09a4d23c4f070db40e1b5a6a83cb33afe675",
-      "size": 10156
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068002.json",
-      "hash": "cce4638827921e2a49af7f8f8c5f50bf525253021a7a7a7f34538048fb988877",
-      "size": 10114
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068003.json",
-      "hash": "1e6bb118583d5f129288ef78506a36a0a24cc37aab895f2d7ecbd10ce3dcc7f3",
-      "size": 7577
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068004.json",
-      "hash": "a4d1966f9321c411165922a8fad281b60d868a64575522d9befca920a70c572c",
-      "size": 10519
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068005.json",
-      "hash": "3d52d45ff2bbcf2b0495c63fd7df27d66df788c9d7219fe3cc16a66e55c36ae2",
-      "size": 6167
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068006.json",
-      "hash": "a9cd7338928db91ce7a9f1d575c0b4b7eda55b32f5b57ba4188ee2ecb658484a",
-      "size": 8102
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068007.json",
-      "hash": "b9155035592789e2d6ce5b6b0c31fc7335dec81fdd1fec2e97deb70062536dd1",
-      "size": 9246
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069001.json",
-      "hash": "6d62f100771eeac05f13e08edbc483b2aa47b0696b4eaca4c33584cc9f43028b",
-      "size": 8587
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069002.json",
-      "hash": "3084baad9fdbbc748a2d805df4faa6411cfd4140d530630d688030a8c5435362",
-      "size": 8046
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069003.json",
-      "hash": "5e2615dc50a4447ac6b25571de283c759d2c2766dee55d3ae4803d9a158e2b9e",
-      "size": 8100
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069004.json",
-      "hash": "90767d6a12dbb45d9810abfbd62d0a3a032bb23a3c5c38faf883065c1a172357",
-      "size": 9116
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069005.json",
-      "hash": "d689bfcb28f90f383f47542509cbccea99dbaa7f96530307c59d73171eb7742c",
-      "size": 6470
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069006.json",
-      "hash": "e40b09838c363fd5f847413588d51d0602b0225626a2c44304da9b909b8b727b",
-      "size": 7153
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069007.json",
-      "hash": "7b5a4dd4dc3e4c20a8a864c1575c6b7fcf1b08657d8bf06a71c06f53adb6f644",
-      "size": 10566
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071001.json",
-      "hash": "51e95d8a0265f0b33ac5fbe88b168e9a43c1f1a7db9c55b5cdbc837efddd6625",
-      "size": 7870
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071002.json",
-      "hash": "e6a3f4ab5131ed1eb9fa7462bb670748710fdf52ae86a441252f61a4006fc9ff",
-      "size": 7844
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071003.json",
-      "hash": "c702fa339e4d064d233e7a7edd30397c7881a12600bdd831a4662bbdcb4f1e02",
-      "size": 9875
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071004.json",
-      "hash": "997825077cedd0c218cd14fa20e039c69dbb8b2227da1998393629637859c589",
-      "size": 9905
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071005.json",
-      "hash": "08c33fa6a2a9a5c56d0e77024dad201df57a5efc03f9b319ea248cd6a2022a59",
-      "size": 8130
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071006.json",
-      "hash": "7cf7ee708a34d0573cb57f3874914b6abe54c77c4c58df0f2f30180eddfe82d9",
-      "size": 9934
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071007.json",
-      "hash": "ec84c45ff2a2a391d4cbe1fd934e589366bb5c6ec3f3beb2168d4eb0c324ba94",
-      "size": 9431
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072001.json",
-      "hash": "60a6a9acb699de613d14c4f532f830acbafa773718c205ff91ed890574a619ba",
-      "size": 10447
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072002.json",
-      "hash": "8856d04fef9a348db9d4771bac6b9b555040dc0e00df67956be03f58864d2e24",
-      "size": 10050
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072003.json",
-      "hash": "26a79d4876c774806948c90dee833e83dfec23b0e42928b2fb1429aa981e24bb",
-      "size": 10097
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072004.json",
-      "hash": "93d8b8eaea9794af644f60a9aebdeda71f575fb2926bacf6ec9da20ea3b8fa2a",
-      "size": 9165
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072005.json",
-      "hash": "2a90df135f96722d8be7b5b20c4e58ae7189aaca974b4816086deb04c9ffb3d5",
-      "size": 6017
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072006.json",
-      "hash": "6f5d2d0ab6fcbb511f0e483a4a311e8e7d8bb034534a0be40fa9926a51441900",
-      "size": 8562
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072007.json",
-      "hash": "e11fb364145e7aa1e9ee1d913d5a8ccaa7267bb75c6376e4beef201cac94e16e",
-      "size": 10154
-    },
-    {
-      "path": "assets/story/data/04/1076/storytimeline_041076001.json",
-      "hash": "88f371997a44b3be5921fe19cffa5392a741e7a76dc3cd37c7b00a928e9d215c",
-      "size": 6866
-    },
-    {
-      "path": "assets/story/data/04/1076/storytimeline_041076002.json",
-      "hash": "995c5a8f4eac70e70efd7f681e01dc2b50f1eec6dc55427e92c9c272bebe212b",
-      "size": 10821
-    },
-    {
-      "path": "assets/story/data/04/1076/storytimeline_041076003.json",
-      "hash": "5c488bdb1d8d39b8cd07bd14d8e7af18d85dcd6b780c61498b5c886817c571ca",
-      "size": 8417
-    },
-    {
-      "path": "assets/story/data/04/1076/storytimeline_041076004.json",
-      "hash": "acd4d6ada03170fcdf8dbd70a388fc0ef22bae5a5ef11365429300b8b5084913",
-      "size": 7802
-    },
-    {
-      "path": "assets/story/data/04/1076/storytimeline_041076005.json",
-      "hash": "3fff59dfaa857d94b4bad2597920f27c0db939096359af9ede418845c5c29a08",
-      "size": 6618
-    },
-    {
-      "path": "assets/story/data/04/1076/storytimeline_041076006.json",
-      "hash": "995b0a4fe0ded752dc6edfdfe3aae03621904b231dca85fc8fb09700a0db8f9a",
-      "size": 11240
-    },
-    {
-      "path": "assets/story/data/04/1076/storytimeline_041076007.json",
-      "hash": "85fefdfe7185a3af22cfdcfe58114942b0f9b1ee521ce80cf2c86333ccf1ba72",
-      "size": 9374
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077001.json",
-      "hash": "9096fb3177b75efb9eb5b3b6567a83b72105ee5bff0269f42bd8420623b01607",
-      "size": 10281
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077002.json",
-      "hash": "4a5327ae49b2ddf1f9dbdfbb78cf11f877f7b249178fac12d2d67b020416825f",
-      "size": 6838
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077003.json",
-      "hash": "af365fcfc2621dbfb6222bbea72c200f4b4f989692f0d99166292aef9e538ac3",
-      "size": 7795
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077004.json",
-      "hash": "4d1636d38551d3e163ffdded4a5bb04a2197744b4daf505023c5ce456fbe591e",
-      "size": 9981
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077005.json",
-      "hash": "b00b2b4e9be4acfa3c89581668df8231e422b11e2992517586be41b4eefed4f9",
-      "size": 6357
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077006.json",
-      "hash": "705254de82a0a62c6063575d26bff058b84bdc7e5df5c0ae03bf1480e4910366",
-      "size": 11599
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077007.json",
-      "hash": "67cb31e9c1394bfa35e85899afd0dfae44b0494778219c540cbd7e5845d2676a",
-      "size": 8674
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078001.json",
-      "hash": "bcef0973e27130aec9cff3c22d81ee087bc7beb04d8eb01e74c57ff2d7244754",
-      "size": 7683
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078002.json",
-      "hash": "59f95f1db1c5654e521e953f3aa7343bbcb0bac25aaeb2a11b3961da7362bc01",
-      "size": 7849
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078003.json",
-      "hash": "7d5df3f5822b102ccab6f89d4c67ef5fa350b014024ddd2c2212f1cec4c4a7c5",
-      "size": 10821
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078004.json",
-      "hash": "b0430813092cf2804f7594e658539d38be2f32133a2067ca2a0b899fa103e438",
-      "size": 8743
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078005.json",
-      "hash": "401d8cb6faede81b3774f2e453dec6dc377ae0231b80822cc63dcea1537a5a47",
-      "size": 6369
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078006.json",
-      "hash": "fbcd063bf6fe237e82aa9dc69788774f1b84ce0ba9bb6a082c65161a8aa27c2f",
-      "size": 7567
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078007.json",
-      "hash": "6a7b8bf5d7abd851c47acc02a41bcc8483381b0d5d4a6e46478d62095f44f5e4",
-      "size": 9434
-    },
-    {
-      "path": "assets/story/data/04/1080/storytimeline_041080001.json",
-      "hash": "4ec1e740b7de95ed53e7575b0f110cb177f9710508fa2de8f4d601445daa5560",
-      "size": 6710
-    },
-    {
-      "path": "assets/story/data/04/1080/storytimeline_041080002.json",
-      "hash": "24bbc5f70a87df3f720ab9d2ebdf74bbf0fd75c131ab166d32124c4092a072b5",
-      "size": 7576
-    },
-    {
-      "path": "assets/story/data/04/1080/storytimeline_041080003.json",
-      "hash": "8ddac5b6e8ec5fbec8727b24b0fb2b4b60b517f971ebd29d494bfa40610c7fc5",
-      "size": 6866
-    },
-    {
-      "path": "assets/story/data/04/1080/storytimeline_041080004.json",
-      "hash": "f95b7b81baa77fbcbd81ce5c6c8bec6bd6174418103410dad807dd5580af2a41",
-      "size": 9769
-    },
-    {
-      "path": "assets/story/data/04/1080/storytimeline_041080005.json",
-      "hash": "d76b95fdd0644bb3b209db7d7321221581679fc4c470c2fc2084cb6b74459219",
-      "size": 6341
-    },
-    {
-      "path": "assets/story/data/04/1080/storytimeline_041080006.json",
-      "hash": "5824c786ecb05a3b36dca148df4a591571912f0a134f29100b4aadd9f843bea4",
-      "size": 9756
-    },
-    {
-      "path": "assets/story/data/04/1080/storytimeline_041080007.json",
-      "hash": "1289b162fd8b428d3448cf225c717df02845666d0c2787ce82f833f188f5a6cd",
-      "size": 10246
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083001.json",
-      "hash": "b1e0f0e6a2c2aa2f0425408d80db81d47e629cefebb21b383a20b0cd92326f28",
-      "size": 8435
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083002.json",
-      "hash": "92a1ac9adbc6ac73de9a6079b2499d9bcb9f84cf373923997c2de7978ff69fd1",
-      "size": 8055
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083003.json",
-      "hash": "9f92bce583e38be8d2f085fcfdcc9f119f04fd143574a2470b1081c9cd52f98b",
-      "size": 10542
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083004.json",
-      "hash": "e5fff583eb1c3647e5348402909a0d923ff3a379b145d35d2d69823554f11f70",
-      "size": 7891
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083005.json",
-      "hash": "dec6b202348a0b310746ed73af36ebaa0c7ad94644251067c0d90b522bfd74ab",
-      "size": 5546
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083006.json",
-      "hash": "44e190e629fc8cc5e8c3656ce02560a38e72e98592908b2db9200a710c944e99",
-      "size": 8267
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083007.json",
-      "hash": "3b74d4c9cf4eb954ceccc9995aede244b98ff8e732445c03d024e5b10918cf28",
-      "size": 9323
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085001.json",
-      "hash": "dbf7ad322f7d091cdab12767b8214a637610067c7af86001c55be74dbd0808d5",
-      "size": 8834
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085002.json",
-      "hash": "f5fbee32e9fca69b274d6fa711170ff2eb1e4917384843dbd989f9a481cda147",
-      "size": 8955
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085003.json",
-      "hash": "a26dba73dd61fa2073eb9d41b9992d4d0cbdb58cae446b4d6765897a0b4b4292",
-      "size": 7712
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085004.json",
-      "hash": "08ebe78829ef832332066ab39405cf695129b89ef08caa99acb677eccfc6be23",
-      "size": 6927
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085005.json",
-      "hash": "2d3f2476b38a1b7bb7810ac85ad4a64240cba91cae0dfeb663a1d610f0dce743",
-      "size": 6083
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085006.json",
-      "hash": "e6cfac5a74102e53fa3b4481a784dcdc91f741bc9ec10ea1c441ad94db1f5ed7",
-      "size": 7547
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085007.json",
-      "hash": "8933b80ffc58fd76e0653939a0dbe44a33e164d8b4ce056c08ee5c75f985def2",
-      "size": 6298
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086001.json",
-      "hash": "2c3438dbe05b1de29c2ba825c98ce222ef91c74315ce36bae1ed2f03220ecc9a",
-      "size": 8553
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086002.json",
-      "hash": "7e7457137e687b750dbaba227278b7e359bec7f8924e2fa63f1384f906d719a1",
-      "size": 9782
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086003.json",
-      "hash": "bbcf64b684049f160c764862bad4347bbd565e2e71f94518dbaac04734498a81",
-      "size": 8603
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086004.json",
-      "hash": "ed9b1764041b7ab37c8bc4169628d61c58b51d92cc2b2ceb2f938d3ea86f0f72",
-      "size": 10433
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086005.json",
-      "hash": "496965e337057481cb296e3646ed54702a0b4881bc5c6426110ff21b31f27a73",
-      "size": 6173
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086006.json",
-      "hash": "1ae64c1e56384ccfa761b30b1571ef56c97a1185b1a972fcb6ef897752c4f9bc",
-      "size": 8405
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086007.json",
-      "hash": "cc3eead711f135f3b7672c4d15790d97fb8d8aefefdb1af1c673b6fd02d1c4d3",
-      "size": 10232
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088001.json",
-      "hash": "16e8b59083fd4ecd9bdf02711b15613b8102b76a1d1238c019644b2e66517671",
-      "size": 11244
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088002.json",
-      "hash": "2744126e0c9d6efd2d28d365386b96379581706a54f93dad788316feed7f0297",
-      "size": 7628
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088003.json",
-      "hash": "82a493c454d7b5abdbe09ef891d20b2e32e78057f8466c7a2688b5541eba2d61",
-      "size": 9942
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088004.json",
-      "hash": "b4c0746266cbb410ca8f14827ca4b9da231f411fb51f5938d0f8833f9e2a1f8f",
-      "size": 8821
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088007.json",
-      "hash": "9d231576dbaadb4a83be9b37f22ec8414a0552f01b1a8c46bdc556325a0a70ad",
-      "size": 10029
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091001.json",
-      "hash": "8e361e92fb9309c96b51c6afbb6e02cd6a9e87879c86dd41be8d37d3b00c15f5",
-      "size": 10186
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091002.json",
-      "hash": "9dad2b0625c690f7fcad024a19ad80edb1efa62bb14e74d06b67eb671985ab8b",
-      "size": 9445
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091003.json",
-      "hash": "fa01de8066447b9dd396e36d6ccf46f3b432804fafc007a9e2c9086eb946f22e",
-      "size": 10812
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091004.json",
-      "hash": "b8aab607fbbea41914d98ee12a1e95fa360730bebacf6984b783c727f23194d2",
-      "size": 9797
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091005.json",
-      "hash": "756a416d35be3d85f3f474f283f2189fc02fa9cb17887bb352d26653d11e8393",
-      "size": 5746
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091006.json",
-      "hash": "01d992e90da96fe2ad6ca439b78ecf53bb43018bce0242d790e57f48580fe438",
-      "size": 9665
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091007.json",
-      "hash": "f645347354a4bb4a7dcf4e6559c75fb4dc8465678f1cff503f4018a971318a31",
-      "size": 10089
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098001.json",
-      "hash": "d2d02908b676dbd3d7cc7ca8bd6aa787a6945ce99309ec4dae0e2ccff250b781",
-      "size": 9137
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098002.json",
-      "hash": "9e80f7c1885878508635534e84cbb189431ca0fd69e5865bf1f2a65ba575561c",
-      "size": 10049
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098003.json",
-      "hash": "0c0f9e25fa404648648e8f523500c3754cc83f0f606aaca7a1433087925eb915",
-      "size": 11681
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098004.json",
-      "hash": "86d83afa3eaa32b7bf65259b75d240a2b0bf7b081bc6cb8869fde1ffd53d170c",
-      "size": 8583
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098005.json",
-      "hash": "92a625580ce66544a589f6204e6d3ac746843ec8a5205bce3e1f4a394149ef46",
-      "size": 6771
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098006.json",
-      "hash": "7216b6d278bdef4b3c1e24e31876443c91bd3336e5d75ffd57d76943ea246fdf",
-      "size": 10164
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098007.json",
-      "hash": "785e6dcfc36c6082865863bbb6b7104470d3d15f9c757de53de0405205e36b98",
-      "size": 10371
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099001.json",
-      "hash": "e954e420fd92c1e26d731716d862e6c014edf76ab0cad8afc788eae651dd992e",
-      "size": 8460
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099002.json",
-      "hash": "4ab41b5b70fee4075b2b0dcd6339ff47f8b4b64a411401bc9c0e36d038429be4",
-      "size": 6928
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099003.json",
-      "hash": "bed492282e8285ee858fdf2557ee13f8826e88bb4df4bd5e449ccc6a75d30122",
-      "size": 10482
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099004.json",
-      "hash": "b79786f2cf1ef1809b707355b6c71fe6ca89a881b7cd6e0590956c20a9388830",
-      "size": 6461
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099005.json",
-      "hash": "7f2c2a3c38f1be3956fbcd8d1cddfa2650c1e9e1ae189424f4e738b06c12115d",
-      "size": 6484
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099006.json",
-      "hash": "b19bc7baad9d8b91d231a7fec53cf0cecaccb0bce816dff64961951e20d6036a",
-      "size": 11242
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099007.json",
-      "hash": "d914fed0ea4afe6b2d6ab5f61f9db5551e2f1fad9ac71e00da8e178a6291cfe4",
-      "size": 10430
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104001.json",
-      "hash": "0776520c7eae54110fb3319a2c5647d9d92721374f4941c80a9ad2bba0de712a",
-      "size": 8852
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104002.json",
-      "hash": "cfb601d15568a134acf7f8f3d8307b3778a58f9be2beb47e4f64f19e93f1e380",
-      "size": 8684
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104003.json",
-      "hash": "2da5d694958cfd4d7ed85b65bc66135a2d5835def8dd0a8bfe6128a8ba970d08",
-      "size": 7861
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104004.json",
-      "hash": "2cd54f563ddc4b7eea82dcd1a0f5792b353c4e55b14cd32c71002a543b5ab68b",
-      "size": 9155
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104005.json",
-      "hash": "e9006833544c3f4abef7f24f3ea0852884b56deefc6f1f0fa7f97e58d53f987b",
-      "size": 7586
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104006.json",
-      "hash": "ad9eb7bd94ad912a6cfa2cdb59e62c91aeb15867b89f0bb79e6d5ba9031b5c47",
-      "size": 10614
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104007.json",
-      "hash": "adc247aaeffe1477e4404245acf434daa03ba4b5603b6ca58f380fefd0a1b422",
-      "size": 10011
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105001.json",
-      "hash": "6fb4b64881383704bef43abc64efb83f05dced5619a4b0d9828704e7d26d7a38",
-      "size": 6153
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105002.json",
-      "hash": "3235eaf520bd17a6fed539bba70b9629827fde7dd6aaaac6327c6ad9f83b87b3",
-      "size": 8578
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105003.json",
-      "hash": "a9e5a4874fbad66571bac2e7eb22453088d4b5b035ea0b2a97af0ad8bdbf1c2a",
-      "size": 10365
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105004.json",
-      "hash": "b8470e75b8ea09994edde43d81f37a89a4c644ad338c247e48f549809b7d6c00",
-      "size": 9228
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105005.json",
-      "hash": "8973f0a6ea167ae3a7f59ea87bb87d9b1118bef1726ab46ad56612de6d016d21",
-      "size": 4773
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105006.json",
-      "hash": "07200a251085e0a14e6944dcd818789b6830fec67eff90f96dc44c03f1f5a449",
-      "size": 9256
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105007.json",
-      "hash": "dbb1746eddda9d642fd21b1f2d90cbd9efe9b8ac5c691d371d570bcdecb2a7a8",
-      "size": 8787
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106001.json",
-      "hash": "f34df4db66c5f399be4760e1e06d520d1941179e9c3b5c13590afa566db3235a",
-      "size": 7765
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106002.json",
-      "hash": "3c7ed827b8d8b3883dcc7e9f9f7055cd43eb0c223f8d786a63e1c8b98fdfa130",
-      "size": 9078
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106003.json",
-      "hash": "deb4705cf69beaf6b95fba92e1ccef88697c863f037447a0694b813fdb1d24ba",
-      "size": 11185
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106004.json",
-      "hash": "5dd5e4108a80f3d8266e09544b6fa261adc4e60f1cfc2bb27047a408c2b7e3d4",
-      "size": 9275
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106005.json",
-      "hash": "d052eb2b17b2e39e64b51b7e4d7d8c7a8c3f924bb4d5532ec999b1c800442615",
-      "size": 6419
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106006.json",
-      "hash": "11bbe4eb30098e003a5e163bd5aca6f7ca5f7949c69f6166b87bd9fa5734b5f1",
-      "size": 10613
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106007.json",
-      "hash": "e59dac1b8957f15aaf9ea14d6e4cf9d9cd2863dd0adf7558a1024164a3ae7e6b",
-      "size": 11037
-    },
-    {
-      "path": "assets/story/data/04/1107/storytimeline_041107001.json",
-      "hash": "153c785a2f9623767a91414863a29410dd5a6995c47f845eb74d69d98a2c9976",
-      "size": 9519
-    },
-    {
-      "path": "assets/story/data/04/1107/storytimeline_041107002.json",
-      "hash": "cd22760047f9f7140507e74923826b700dc3adf34917ba8db3aec2d7b42f5f7f",
-      "size": 11497
-    },
-    {
-      "path": "assets/story/data/04/1107/storytimeline_041107003.json",
-      "hash": "c98d8d1a43a722f55b09b6a613d447ccdee143450cce6d422eebd59fd5446d95",
-      "size": 9088
-    },
-    {
-      "path": "assets/story/data/04/1107/storytimeline_041107004.json",
-      "hash": "3b5632bed95a8268c32b839e8c55f20489f1371a4408b9bd8dec019234e23a1d",
-      "size": 9656
-    },
-    {
-      "path": "assets/story/data/04/1107/storytimeline_041107005.json",
-      "hash": "4ce9f669c21e025e62ae2a1af694c2e0feed0beded80391de0a888b8faaac60e",
-      "size": 6524
-    },
-    {
-      "path": "assets/story/data/04/1107/storytimeline_041107006.json",
-      "hash": "c89c9b3eea7c4d82f711bd0bd461ed7b16c8b72b428b33c180812864b6d7e82c",
-      "size": 8399
-    },
-    {
-      "path": "assets/story/data/04/1107/storytimeline_041107007.json",
-      "hash": "7fd3a4ba64241810f29262dbd46f16ddb22c20934c6ce68a77d239a0ad815f26",
-      "size": 9207
-    },
-    {
-      "path": "assets/story/data/04/1109/storytimeline_041109001.json",
-      "hash": "573669f4e62f1dd10d8b92cef137b47dd841a7e30d7bc15a9fa30f0d9ca9b3e5",
-      "size": 10356
-    },
-    {
-      "path": "assets/story/data/04/1109/storytimeline_041109002.json",
-      "hash": "2e32ff40e8a4fc59be23b438db1dc2ab539e63a7cb486bc94fb73d2c677ac5ec",
-      "size": 8875
-    },
-    {
-      "path": "assets/story/data/04/1109/storytimeline_041109003.json",
-      "hash": "d71ae98d8f3411b8cdfcb9cb13d931c9b46f05d1bbe785ae2b7fdb3b48f842c3",
-      "size": 12074
-    },
-    {
-      "path": "assets/story/data/04/1109/storytimeline_041109004.json",
-      "hash": "6c35c72edac0826ad7f99b7556244b75c0c52436398e88fabee72ea11c2cfee5",
-      "size": 8581
-    },
-    {
-      "path": "assets/story/data/04/1109/storytimeline_041109005.json",
-      "hash": "2045437ba28732d93b5594bf8a0dee2181876102c2a5fd17b794494cbfee7031",
-      "size": 7121
-    },
-    {
-      "path": "assets/story/data/04/1109/storytimeline_041109006.json",
-      "hash": "a35de31c20181b6e38cd6b07b549b7d28de192f4295bd44b3c8ef21ebd5f52b5",
-      "size": 8982
-    },
-    {
-      "path": "assets/story/data/04/1109/storytimeline_041109007.json",
-      "hash": "4b01c9c33fc26fcd38a0ac64fe569135476ac56f1a9936f8e486524b0b74630e",
-      "size": 10322
-    },
-    {
-      "path": "assets/story/data/04/1110/storytimeline_041110001.json",
-      "hash": "a6a7007395afd4219b976c4ecf9940b82610a05fb59c162c464f4b641a4ddd14",
-      "size": 11231
-    },
-    {
-      "path": "assets/story/data/04/1110/storytimeline_041110002.json",
-      "hash": "580e1d379d1a4e1fdd41432faa65f329f81ddf050992c00e2458b571512e5ddf",
-      "size": 9481
-    },
-    {
-      "path": "assets/story/data/04/1110/storytimeline_041110003.json",
-      "hash": "0621aa8aba9471bba40caf224586ea609bf71e5cbc46bee5b01d0b71c039db2f",
-      "size": 9561
-    },
-    {
-      "path": "assets/story/data/04/1110/storytimeline_041110004.json",
-      "hash": "c1db60a559971cb88044797c9e79352fa656f6a824b77a7b2d296191b6268986",
-      "size": 11863
-    },
-    {
-      "path": "assets/story/data/04/1110/storytimeline_041110005.json",
-      "hash": "5ccf1115b99233b62355aadec8b414d6fa08def62a08ba67fe4a82a333d23a6e",
-      "size": 7479
-    },
-    {
-      "path": "assets/story/data/04/1110/storytimeline_041110006.json",
-      "hash": "3cb154868dcb2e189a482fc2a9d3ab61ace820967f558c32543a565ba1fef3dd",
-      "size": 9699
-    },
-    {
-      "path": "assets/story/data/04/1110/storytimeline_041110007.json",
-      "hash": "4b23f32ba80ff2d851b1e6b147d5878f2bd25dfa6742093d9a61f5884a60b0ee",
-      "size": 9303
-    },
-    {
-      "path": "assets/story/data/04/1116/storytimeline_041116001.json",
-      "hash": "8c6d2cf681044160ecf988dfec24d1a2ad7e34f6a0c184e53dc982afcd2b4294",
-      "size": 9792
-    },
-    {
-      "path": "assets/story/data/04/1116/storytimeline_041116002.json",
-      "hash": "4509c4e9ad052faf5fc6f787f1ec9dfc6e4c8379b41c55080d92946fb135355a",
-      "size": 8545
-    },
-    {
-      "path": "assets/story/data/04/1116/storytimeline_041116003.json",
-      "hash": "70e285ae4c1f1172cc486b7ac814c6ab955fed80c8bdc432d3121686c4f2206f",
-      "size": 8808
-    },
-    {
-      "path": "assets/story/data/04/1116/storytimeline_041116004.json",
-      "hash": "29bcaa27270e9be1f7b3915eb5ef8151ba99fdf455a32434bf9aba39151cfc09",
-      "size": 8672
-    },
-    {
-      "path": "assets/story/data/04/1116/storytimeline_041116005.json",
-      "hash": "6ff50797552b357e173b89ecf3c1c5be042b704d9d8061cb0b7e4abdaf287c6a",
-      "size": 7527
-    },
-    {
-      "path": "assets/story/data/04/1116/storytimeline_041116006.json",
-      "hash": "e2f7daaafcb2003fe2938a89c74f3b9f4dbc3b012a4236e5e459902bd3f5a11f",
-      "size": 10061
-    },
-    {
-      "path": "assets/story/data/04/1116/storytimeline_041116007.json",
-      "hash": "75a6e56ffc8c2f3ee1edd41ef877b49270ddc16346059167347a5b39f27c5f0a",
-      "size": 9917
-    },
-    {
-      "path": "assets/story/data/04/1119/storytimeline_041119001.json",
-      "hash": "ac71b065dd82981e0b668f6df581178cdc1dfe7c7b85120f9bb029addf4407c8",
-      "size": 13266
-    },
-    {
-      "path": "assets/story/data/04/1119/storytimeline_041119002.json",
-      "hash": "7d495c574ccf749bed14c330f655092ca49bdcc4df6260ff0c8eb4a7c6281b79",
-      "size": 10459
-    },
-    {
-      "path": "assets/story/data/04/1119/storytimeline_041119003.json",
-      "hash": "34f4e2727b8d9052bd91212cb16435bbc71743b171c082bd4ae8912d63515438",
-      "size": 10727
-    },
-    {
-      "path": "assets/story/data/04/1119/storytimeline_041119004.json",
-      "hash": "0441454cea435495cc855737d1c3d7a7bccb7e67552b7da186bf59a22b6ffa99",
-      "size": 10806
-    },
-    {
-      "path": "assets/story/data/04/1119/storytimeline_041119005.json",
-      "hash": "55005c41ed96b6e5eeaa6f96215fd73ebd415b6bf33d342bf4af4e5a7ebc8f67",
-      "size": 5597
-    },
-    {
-      "path": "assets/story/data/04/1119/storytimeline_041119006.json",
-      "hash": "62944293a00031c34712af95ee0cdbb6cb7e383a6dac6a0743d9a565fff2614d",
-      "size": 10080
-    },
-    {
-      "path": "assets/story/data/04/1119/storytimeline_041119007.json",
-      "hash": "55c866ac038ac4f7774c9e47de00fbcf9e218b6a0e5253b7b36d510168e78381",
-      "size": 10677
-    },
-    {
-      "path": "assets/story/data/04/1124/storytimeline_041124001.json",
-      "hash": "37e61962bea7e972358fb7a61165f5f89fad798a7dfeff9edb05cc0b187154d2",
-      "size": 9816
-    },
-    {
-      "path": "assets/story/data/04/1124/storytimeline_041124002.json",
-      "hash": "1d4304b33a787895f24412661e2206a603fcf1ec81fc2d2874823773efaa526e",
-      "size": 8832
-    },
-    {
-      "path": "assets/story/data/04/1124/storytimeline_041124003.json",
-      "hash": "40f743f269e34af7650d29de175b6fed248b4a31112816ad577e1e642f79c560",
-      "size": 10973
-    },
-    {
-      "path": "assets/story/data/04/1124/storytimeline_041124004.json",
-      "hash": "d0cb23b9e51096451d48ddb1137bf20f35784530b6f5f7ba5236911396693b4c",
-      "size": 10064
-    },
-    {
-      "path": "assets/story/data/04/1124/storytimeline_041124005.json",
-      "hash": "381588268e5eec190759f08d172dc293e6886dc8ae115440c575dd1cee76f6b4",
-      "size": 7473
-    },
-    {
-      "path": "assets/story/data/04/1124/storytimeline_041124006.json",
-      "hash": "234af58558c443bfd270e8a4fb476bca9c0438f873474d2667fc1c5358b85978",
-      "size": 10981
-    },
-    {
-      "path": "assets/story/data/04/1124/storytimeline_041124007.json",
-      "hash": "606a4100b058df8578828cd08d2e98a0223116b233a8496b1c35bf18f5f4ee4a",
-      "size": 9454
-    },
-    {
-      "path": "assets/story/data/04/1127/storytimeline_041127001.json",
-      "hash": "37813e1335bb64e803591514fd0c24bd643a1eb71e7269997a0c77c192d4aa05",
-      "size": 10254
-    },
-    {
-      "path": "assets/story/data/04/1127/storytimeline_041127002.json",
-      "hash": "da960820ff3405c4ed87674ddc43a2924b5ba6ceba4d58b54f39581d91b6cb82",
-      "size": 7858
-    },
-    {
-      "path": "assets/story/data/04/1127/storytimeline_041127003.json",
-      "hash": "e2a13cb52c4821215db0dae5f43e925ea451a776afcdf57e9113a9d501fa88b8",
-      "size": 8725
-    },
-    {
-      "path": "assets/story/data/04/1127/storytimeline_041127004.json",
-      "hash": "c350af77ec90850f16e114faef3cc78c950a5d557920bdb0297abd01db533774",
-      "size": 8764
-    },
-    {
-      "path": "assets/story/data/04/1127/storytimeline_041127005.json",
-      "hash": "35e23ae880d5308b68d61753553f2d0a9f4fe641bbc81fb1e776c23ab1a0ed2a",
-      "size": 6991
-    },
-    {
-      "path": "assets/story/data/04/1127/storytimeline_041127006.json",
-      "hash": "609ac09aa2f0fb8f703da9073bb496e0bd7a257952d35763c5edafe4e7476854",
-      "size": 10567
-    },
-    {
-      "path": "assets/story/data/04/1127/storytimeline_041127007.json",
-      "hash": "27cab865ed9172765a78f0799bdff6497e1873f67673a85d555a2d1994cf5c87",
-      "size": 10009
-    },
-    {
-      "path": "assets/story/data/08/0000/storytimeline_080000001.json",
-      "hash": "ce2d98f46423dc5483a064bd03a95c2dc534b0a137731877f8c762a8d2e6aed8",
-      "size": 3385
-    },
-    {
-      "path": "assets/story/data/08/0000/storytimeline_080000002.json",
-      "hash": "bf0899db918757cdb0f9d782c4e3676a7b83f328c0407b81b32f09395e1327fa",
-      "size": 2045
-    },
-    {
-      "path": "assets/story/data/08/0000/storytimeline_080000010.json",
-      "hash": "570b55d5998ebdf882f81e15b486dd97d3f3bb608dc42f74b0040c75dd8598a9",
-      "size": 2275
-    },
-    {
-      "path": "assets/story/data/08/0000/storytimeline_080000011.json",
-      "hash": "2917584c1bfd9ed9d8ecef69198bc1a9b1759f676e0790c7ae9bc6c2da748976",
-      "size": 1779
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002001.json",
-      "hash": "cbc64315916cd4dcbede3e493f2a05f407a4433835392eaf7fa5748f6b8f8ba9",
-      "size": 10022
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002002.json",
-      "hash": "0055b8e857a85c97799d0a098b366999bc430066518ced2b826cd08123ebd8f4",
-      "size": 7164
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002003.json",
-      "hash": "ccafb9886bfe18fa627bb140d537332796c58a29fdf5b485555a3d84ef2dbcde",
-      "size": 6491
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002004.json",
-      "hash": "7471d6fb9967c64ff366fdcabf0d7d4632c33ef22281097f4e69c89e2a220c38",
-      "size": 7013
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002005.json",
-      "hash": "b064e7a65ac3233c711839d83926edc69b4a8e104d66b21576ddc84c2a8ce3bd",
-      "size": 6881
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002006.json",
-      "hash": "140eced39114c3b895d743e14d6b21d51add146486d3952c14f1aefa330c3ab2",
-      "size": 5444
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002007.json",
-      "hash": "f974347a3aa23e15ea54c7a2ad06c28d69936f053854889ff9a114c61c98b779",
-      "size": 7667
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002008.json",
-      "hash": "7fcae757c64d5947ee2a96afd7abf6f7ad56e3c3b86f44ccc57482607bd7dd30",
-      "size": 6556
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006001.json",
-      "hash": "8b803cab7bec9115448064f2eb1f5408b0ef21714f40232a0c35c06e12112c5e",
-      "size": 7706
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006002.json",
-      "hash": "3cf7abaa8406bfc3881c973f4335a04e006a8a10c954b76b07e96c349aa38253",
-      "size": 6308
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006003.json",
-      "hash": "bdd6ce6fdcb5c7f7a204dd38ddcab82d919bb9c6f94cfa2a3d66da599b3fd451",
-      "size": 10664
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006004.json",
-      "hash": "fe23b3458168e752631912ad04ac3d61d9489c396018a3f176507232eed899de",
-      "size": 6472
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006005.json",
-      "hash": "69cf1fb2da98114b815835f2dba2835f4eb57db15c9d3916ce69016d37f29fc1",
-      "size": 8024
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006006.json",
-      "hash": "d654631b5af7ce54e16b0125b4450e9e40d4daa3c6f6a19be008899026c35a41",
-      "size": 6517
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006007.json",
-      "hash": "3fd07d3b0a898b077cb972bb4589d870530ee40c476f91aea32041b103cb9273",
-      "size": 5718
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006008.json",
-      "hash": "8de1b59e7f83dca04fdfcc567dfb96a2d33a9b25fd81a05f7cf4c17025382051",
-      "size": 10779
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007001.json",
-      "hash": "998e82a91991b9d45101d2723099f3e0846f9359a576afae3e595fa4bef25474",
-      "size": 7593
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007002.json",
-      "hash": "0701ae63702e28692637956322cceff38bae59a5786ab8a162f90ea66d4455c8",
-      "size": 9098
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007003.json",
-      "hash": "8b71a9124164f4b50fa8f9548aedbe963d7cbc614b82f4e2ba7fd743eb0e50c0",
-      "size": 10254
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007004.json",
-      "hash": "e03eb7295dfe5261412d7a4c8ad602090e739723b89199dbd6bff9317ec26f85",
-      "size": 8136
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007005.json",
-      "hash": "07b6969fc4c8d43b62dcbc9b847ca4d8ea15e000fe7633321c39f1dcca36fb9a",
-      "size": 7702
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007006.json",
-      "hash": "37016ed733650017f51558d5662e012ca58d2539d7e8fb53ff0bb23dd835b8a7",
-      "size": 6401
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007007.json",
-      "hash": "cc338065906f0c69f8d0eb169ea17397156f91a153e1604fadfab4c0682f2b69",
-      "size": 5981
-    },
-    {
-      "path": "assets/story/data/09/0007/storytimeline_090007008.json",
-      "hash": "9c05b91e3e8610a3f2e736a3d9382c8344a5881b4a6fcb43e2a43096c75c9871",
-      "size": 11124
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008001.json",
-      "hash": "80236af367bb6b38b074b819e08a7519f30876a7fce1268f05db66b86bf241be",
-      "size": 9426
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008002.json",
-      "hash": "17bd1f0a9e8bb99e44b4f6204bd661987668cbd579833fa3817715f905cc4a05",
-      "size": 8843
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008003.json",
-      "hash": "fd41d975e3cfd5c10aee16c818c88bb4f0483d2faf91926080455a3d3e7fa160",
-      "size": 7314
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008004.json",
-      "hash": "d107566431d5991ae4d3e9249dd48e84fc0a704cf46e20f9995693c3402404d3",
-      "size": 7681
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008005.json",
-      "hash": "664f2c40effa45c057a27a38e90e5f6455ba7bea75749bf21023c0a9e461e92c",
-      "size": 8481
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008006.json",
-      "hash": "93776b73f1d083e862e94277170fb4ebd99d4fbc6c18edc11b7cf538df15355c",
-      "size": 10721
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008007.json",
-      "hash": "d2ebd7e89cb2be47dd7616275f8a1e7fee6b755629bd38cb07d8320a80126ade",
-      "size": 7606
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008008.json",
-      "hash": "2d6903b4b1fae6c0a26df5a949db8976c3e99f16e20b7b38ffdcd936d18d467a",
-      "size": 7229
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010001.json",
-      "hash": "a9c9a3013babbcd2d9579de238a936960378a427e5ca7b626d96637059c92518",
-      "size": 10215
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010002.json",
-      "hash": "9be69e6c63eb0b2f0263b4aa20cf62620d4ea4fdcce383fda360024055c80a3e",
-      "size": 9678
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010003.json",
-      "hash": "68de43f0ca7170b49c5393fd5ab06ae790fc4027d4ca669eea85ef85425b829d",
-      "size": 8930
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010004.json",
-      "hash": "96302cb84b19bad0779da0420eb9764ca112bb663beadccfd13a233c76e5608b",
-      "size": 8917
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010005.json",
-      "hash": "15a45a966dc81d1e26e08c80ba8c0caca19c0e5fd24daa3f459f47d2076dc900",
-      "size": 6792
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010006.json",
-      "hash": "f455402fc0926a8cac9c75757593139834dffff5cc7946eecab31436932822fa",
-      "size": 5362
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010007.json",
-      "hash": "0782755a6aab4aa06c2b686fef7206fa31fef15fd75297f9d013933bf54c9fbb",
-      "size": 7213
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010008.json",
-      "hash": "e34990af8b43e5ae9fc8425118800a94ff228085d862eed792fbda737f26c7a6",
-      "size": 7630
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011001.json",
-      "hash": "347ed6f1c022c6963d972de2841a3dc03b2687fde8cf5389768d2fd0fe2c9a08",
-      "size": 6995
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011002.json",
-      "hash": "9b50c467c1e3308b8f4c3a548d100f5b944c2efaf20b844f948aeda5488cfd64",
-      "size": 7998
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011003.json",
-      "hash": "91428f8c10b809d10a47cb24215a6b049490ea6546c07120fe4984716f94e150",
-      "size": 10564
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011004.json",
-      "hash": "0f05e992d9359654654f424e3e9e9c6f40dd885a5ab8d9aa7a4ddb0a83c1b043",
-      "size": 5695
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011005.json",
-      "hash": "8b7690722dbcc273ec99d9d412aef227fce2d364735ed7236984fe5de2034554",
-      "size": 9102
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011006.json",
-      "hash": "e8aebfb914280cef9afb7a5f42751f70ed4531aa980ebbeca1bb0dd286de43e2",
-      "size": 7288
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011007.json",
-      "hash": "eb322205ca0b675b56c655a1dbf199ea16bcc0df777cecdbd2f4f1690e9d1444",
-      "size": 6083
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011008.json",
-      "hash": "30dfecc4db7c3713ae91541ef01d551fe83e81d934e0d9fbb9a1ad0709a82974",
-      "size": 6150
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011009.json",
-      "hash": "22b44b42926cc009e133ee5d7fa327bc6e1155bc588d7e431f25a0bbeb10c882",
-      "size": 9002
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011010.json",
-      "hash": "e0278a786c19ef564639030da198faef42024723a6734b292cef88564fce53a9",
-      "size": 10843
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012001.json",
-      "hash": "984263140ac1973058ad0d4988fe58cd97021d099b750f5139e61cecfd996b3f",
-      "size": 8763
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012002.json",
-      "hash": "a8c11361b2219279c1e1299818c6cda224e62fe82fb685a897826f64209713a4",
-      "size": 8647
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012003.json",
-      "hash": "05d23c11e82b74b4a00329eba3ccaabf5493b197ded5aaaf7821ed136fc7842c",
-      "size": 7796
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012004.json",
-      "hash": "677286648538f72f7030d44ab41556e9cceb0b03f2f13d060572e3241e17a046",
-      "size": 9109
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012005.json",
-      "hash": "6e3cec560504ae34782e49b04638e5954d4a1c16a0d4a9c937f64f842cf982bc",
-      "size": 9406
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012006.json",
-      "hash": "8cfed0a2771f3b596b698607da193c7d595362df5e3436ab49c3c4feb013d257",
-      "size": 7774
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012007.json",
-      "hash": "502bac5bd17885ce819c9e7d7d4c3609faf9a98055f855d4650a5d16eb280566",
-      "size": 9642
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012008.json",
-      "hash": "a3bd44d9b6a3bad0bf7966ab9f7f7c777922eaf0dfe9078ab533d80255d940bf",
-      "size": 6404
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013001.json",
-      "hash": "7ea89a9d8555e9acf43650b11ec64617fc19b5e38cef67331e9f0c021b467a80",
-      "size": 6951
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013002.json",
-      "hash": "04cbfa8eda28a8d8c9ba2836ec162056bdad9b5835d181b39dad6b55a8af7c09",
-      "size": 10308
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013003.json",
-      "hash": "4ae52a2530f669c41fe0063d4d3d373771e2ce99b1ed7ee1048474159baa420b",
-      "size": 12052
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013004.json",
-      "hash": "67e79819591b20938d6c41edde64c666ee2ae1a193ecd2d342289533cfbe5a46",
-      "size": 10248
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013005.json",
-      "hash": "4c54c8cff0563e1214d76119feec035be9451273f6e3816a9bcfc1cc01b393a3",
-      "size": 8500
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013006.json",
-      "hash": "b35b3ec31b6308ca9608c75bd6d0185c6c6c7b1be42d9d4c5f1b1648bd6d291b",
-      "size": 7900
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013007.json",
-      "hash": "e9b392b7ec123e56e04f4a1863651f28c4e5c39feb127efba61f38e909bff4b7",
-      "size": 9983
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013008.json",
-      "hash": "7a9765a77e717332eebc7f1df77dd7facfbd19e6a685ec8e76907f1d354518a4",
-      "size": 4249
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015001.json",
-      "hash": "d88cd64426a275e2d65b554f0e10d949c95e622bed784506695e1087fe320847",
-      "size": 7752
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015002.json",
-      "hash": "6fd5f16d94f9b7e1d902751770f919d853a2e6ba5e13a092ea35c5e5e38c962a",
-      "size": 8448
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015003.json",
-      "hash": "e58786c96ee4d0ab9ef03f6aa080301099909eeb8d19ea73e954f068fe091a1a",
-      "size": 7672
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015004.json",
-      "hash": "bc713e5a1f4ca2311bf452ee0d42ef75672f4c88035004c2f820f87f2d5a3e4a",
-      "size": 6493
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015005.json",
-      "hash": "eccf09b9db4a24bb3867de9149c7c2f0290416c12bbe15835bb2a07b97886f55",
-      "size": 7811
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015006.json",
-      "hash": "7389d3e2a6219670cf3c4cfb206fc9b2a6cf5ccdca9b58918b4a8ad903f74ade",
-      "size": 10075
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015007.json",
-      "hash": "4bd921417a520683b8f48c57f5be0867c5bc8701cfd3c073086fbf6ec1ed1166",
-      "size": 9624
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015008.json",
-      "hash": "c0a91af6c668a964df3cd0605a4307e187a5dcb816d53064796d95ff45a0da5a",
-      "size": 7801
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017001.json",
-      "hash": "c6aa55633fc7c21a58b036ca51f4df09a03f0743fcb2c66a4bdf1e3b0bf34c0b",
-      "size": 6718
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017002.json",
-      "hash": "307dc63dd7938cd72f7e711a660d2f4ebf7a1b219fc89a2ad0eae012e766bc2e",
-      "size": 8495
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017003.json",
-      "hash": "13b9ce0c2955c8447af76031fd8b136631e7776e23fde08748abd68b48b7f576",
-      "size": 10508
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017004.json",
-      "hash": "d43582f1f0ca1cf0b56b527234a6e1e6cb5d6cfc2853124c728884757f384ec5",
-      "size": 8085
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017005.json",
-      "hash": "245978e9b480107a104ca7a842f24a0e502867e81e49bdb70cd8e705aa390fee",
-      "size": 8166
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017006.json",
-      "hash": "a91af623f062fb10421b5f2ee452a0631f1d124aafed9b49caec0aa5c5a77e90",
-      "size": 8292
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017007.json",
-      "hash": "f0b5520fb951e58f0eee961c948097771821244eb0886c6a9a9cca28badf673d",
-      "size": 7990
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017008.json",
-      "hash": "168dd6815f023a776a6454b42eb2e6e16121e8123af31ffccface82d90ce78c8",
-      "size": 8538
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018001.json",
-      "hash": "fa85de3027f1a836bb1bcf00fb9c88e766bc523da1c8a756ef3687085764f591",
-      "size": 7587
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018002.json",
-      "hash": "c6e753045a08ec2250e4a4f90757d3c2c86da78a9b13e308725263f70bf9105f",
-      "size": 9298
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018003.json",
-      "hash": "800f2de315606e95e9da6c8e65b90eca6aab403ff685f9069d526294cf24283f",
-      "size": 7174
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018004.json",
-      "hash": "f3c78ce091a1b2d045b057390147022537d3e2c8094ddbcfa59fd788076dcaa2",
-      "size": 7426
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018005.json",
-      "hash": "98cfb4033b016141a551dbd51d3045f28469680645d851921aadc6f98dfbb2f6",
-      "size": 9447
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018006.json",
-      "hash": "619c8ef686b7c924c11c66b968cf150cd0eaa37bf07789145c0cdbb4859c1295",
-      "size": 9231
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018007.json",
-      "hash": "57b450f12aa841a92b3f6b9e2d98e7221fe25bafc401e15b3eb6456fd0b5d7a0",
-      "size": 7843
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018008.json",
-      "hash": "23c75565f935f03f2072064c5fca13fc0b1c6ee965b59dde43754d97e0f158a4",
-      "size": 6641
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019001.json",
-      "hash": "2fe1ad8a99c2b37e71bb4bc1f03177f3ceca65812199a8f90cc2e1898d936edb",
-      "size": 7875
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019002.json",
-      "hash": "290891f25b700217c75a6da9e9b9e4009dbc3513ea433e1165b30700c3bd6591",
-      "size": 8874
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019003.json",
-      "hash": "953afb8f4aae2467b98a38186a0a1b391e9576ca6f97acac3037d890be085679",
-      "size": 10157
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019004.json",
-      "hash": "90d14dc6c49739cadeabef8c33decae6df95b4b45cb19e49feb079a60e556861",
-      "size": 8002
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019005.json",
-      "hash": "1fbc68c50c5e8ec7b24c18006ac5f2a8104ef33822ca735441f22fcc6d90b165",
-      "size": 10229
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019006.json",
-      "hash": "55a88df6aeab1c2d6026c502ebcb3697d4490806a45ea2d32942428f4f830a0c",
-      "size": 11120
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019007.json",
-      "hash": "f1731b1995e783791843cc5dbf7619124df4f7866fd2317dacd075af40595eaa",
-      "size": 9691
-    },
-    {
-      "path": "assets/story/data/09/0019/storytimeline_090019008.json",
-      "hash": "efc1400a9cb62886b291f3f21c7fe04738a4135b5e8abae39f636dadedd5ba16",
-      "size": 7796
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020001.json",
-      "hash": "164b3a2de196f36ca74cf5aafd6164bba8e08bc419647cb4ab26e2a035af1c28",
-      "size": 7391
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020002.json",
-      "hash": "565f2cb41031afebd85116bd6ebf83f975bc56bd8121e85f46b060cda4f8008d",
-      "size": 7418
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020003.json",
-      "hash": "32cfdc5c259883f0a21e47cad3274e1e24cd486e7f05cb11d9f6097cd3767fc2",
-      "size": 7227
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020004.json",
-      "hash": "f2c92d1016278170a737e2f0b32aede10e07709db061de01ce2dba09ac0e1930",
-      "size": 7330
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020005.json",
-      "hash": "2ee2ac2188b876a2528f25322c3445047c48618b212745963a2e4d2abbf7576d",
-      "size": 8376
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020006.json",
-      "hash": "68582f286b259f1465d003025ccf15203529fec34ab127baae43194624e6d055",
-      "size": 7239
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020007.json",
-      "hash": "d61bb7c2ec58c012b986d0340b2cb658f930bbdf81231fe4379f26c19636867f",
-      "size": 6389
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020008.json",
-      "hash": "5c55646ce261f45381b220b7d7e3fa68b207c5f717e0339fd1a5024dbb7bc47a",
-      "size": 7356
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022001.json",
-      "hash": "4144f5db47b79663e788c64fb53dc7ee442989987dabf394f61e6b0c0a76f690",
-      "size": 8513
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022002.json",
-      "hash": "c50a129680de40855ae2eb4e9244321169a7a47840e57dc73fe10c2823db5454",
-      "size": 5844
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022003.json",
-      "hash": "8cf843d9f77bcb1a56e76e9cdeaa5dbc785f6ae38dddee09e07a0ae9e4192dee",
-      "size": 8378
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022004.json",
-      "hash": "1e6bf5a121e0e9ff2024b1726bbdd3f5f65c73af1131b1dd7784aec11ba47b7b",
-      "size": 4900
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022005.json",
-      "hash": "8d646e2ac9b2ea1ca78748e9fad124e892665b58fd47cfd38e66839f82906214",
-      "size": 7929
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022006.json",
-      "hash": "41b8c02316f8c9fd4bc20a28636ac91441192ce72762a0b6ba908213571918e1",
-      "size": 8275
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022007.json",
-      "hash": "952db26c0c4e9dbee9eade982ac4b175c79ca2372a11ed12c3c5307b6be3105c",
-      "size": 8552
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022008.json",
-      "hash": "777452afdb3f8ed51b0b8c8b599ccdf079dee76352b6133d39f1f8dded69789b",
-      "size": 4706
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023001.json",
-      "hash": "db30b6065c87aac3abec3e694e14c55d416b9ae774df649ae65ae22585772d7c",
-      "size": 5611
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023002.json",
-      "hash": "aeab10a97a2c223e426b1217ce4f75a63eacfbf16b939558df1dca44405ef502",
-      "size": 7239
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023003.json",
-      "hash": "935abbf9cee00c9ded00fb441a5bda9676f4834cc43b7507f11b936d941cd85f",
-      "size": 9250
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023004.json",
-      "hash": "29b404e42505686b0c97943def6af5a72f632d582f8f57e3b754cde7ea73d723",
-      "size": 7037
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023005.json",
-      "hash": "cb2d4d5d3f25361e0a77d81484f923a0f3fc0cfa7a9fb7f309f5b9f2900a92c7",
-      "size": 8312
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023006.json",
-      "hash": "4b694ab88c6088a295fa1777746da19be6478e286f40415850e544d572a429e7",
-      "size": 9482
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023007.json",
-      "hash": "75237b804477c1be129e7c277bba5c98b6a5738fdc1afe9a9f4725bdcff6d94c",
-      "size": 7486
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023008.json",
-      "hash": "4b8bb1eef32eea23a79635c5b56d72c053bf47884eacf7cddf8dbbaba63edbae",
-      "size": 8453
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023009.json",
-      "hash": "c27c6142a0eacd0d85d76eaed537577772a90bbb360cf6421b898ef498841fc1",
-      "size": 9648
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023010.json",
-      "hash": "3bcf6832bca12b41a8a5bfc854bf11b10e25ff0b12c26a9f3b8517c735b152b6",
-      "size": 7519
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029001.json",
-      "hash": "43ce8827aabb7b0be19977cd50881435612836d0155bc693eee46fdfd0e6bf7e",
-      "size": 8375
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029002.json",
-      "hash": "19f834a112c666e15634ffcc5a93552a77680b496786d445ae7863bccfbdf55a",
-      "size": 7456
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029003.json",
-      "hash": "0ee09770598f14e83ace5ffbc720b63b1b0bb227b91cb441fc8f5da9c4e17eb7",
-      "size": 9135
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029004.json",
-      "hash": "6807d733b5656de7a218cc70d8066a65e9ba26c51213366cf8dbc64388cbf169",
-      "size": 9572
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029005.json",
-      "hash": "042821578dfeb997e25c8903fa72104ccd08b23973b8e5c9dd9a45f5c95068f5",
-      "size": 9306
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029006.json",
-      "hash": "b6355f13353ce6f0d2ed6215e3616af7f3a3f04abc5da4570ba14b838a6b0a3b",
-      "size": 8486
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029007.json",
-      "hash": "91bdec7c7b2ef133be1c75882425426ef59b9096eefdc0ecb214f6e77d7ac7d3",
-      "size": 8191
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029008.json",
-      "hash": "4fbe51b2302ed1118fd61a1bbb106df6e72f51e3d7654b346581f39ca8be862f",
-      "size": 7657
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030001.json",
-      "hash": "83331546f509d0de9573fb599ecc9fc1d40e931ce1ceb28b40c88e2a10c1d572",
-      "size": 8557
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030002.json",
-      "hash": "5d2d6f3b2123ede9cff39eba2f2a2b67da4140ec0488a695c7b111041ff5c2c1",
-      "size": 11559
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030003.json",
-      "hash": "9427c9d4dcd503c3ac19954eedc67322b60eeba54c932bddfe827df7c937c5f5",
-      "size": 6635
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030004.json",
-      "hash": "28a68db6d5a6d360fb0b9f5b5114ee73765750a32d3ad631906e36b731505b26",
-      "size": 7675
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030005.json",
-      "hash": "1c62efd007049e969040b7e1a6569348e35481525fb8aad1a83c778ed2f6bd6b",
-      "size": 8020
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030006.json",
-      "hash": "237a1ba9de2340e1ddd943445842f9e090730cabce453606d6c0980bd41fbec9",
-      "size": 10067
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030007.json",
-      "hash": "f0fa3563eb7b8e814ba24daf84b146eec07ecbee2f3bcd3a087af7d6a94452d3",
-      "size": 6808
-    },
-    {
-      "path": "assets/story/data/09/0030/storytimeline_090030008.json",
-      "hash": "6669fb0314be0bc2158625cb25878e1bb48a7415a0687fb3ecf3d07aa53ccac4",
-      "size": 11065
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034001.json",
-      "hash": "cfc7a6a2216b5244a68e1cd845b4a6bd079ff4605e0ec78151981fcef48a81d2",
-      "size": 6906
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034002.json",
-      "hash": "cc3d3c57dc586911f8b7c5b8519ec95ba9fb260326043d614d8ab103bf9e6451",
-      "size": 9274
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034003.json",
-      "hash": "1a6042f75aa1eac6e236bcea11544f663d313506f22babae6beb5a086ebc61ad",
-      "size": 8568
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034004.json",
-      "hash": "2c5016753e526ab330e70c4704aa6719f257531b0444f120079ba5f828ed79a2",
-      "size": 8313
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034005.json",
-      "hash": "5a6f04e5884b0c9df5a55e07c9596edfbe04696532b67707118022ab3961a3d9",
-      "size": 6833
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034006.json",
-      "hash": "4b34926d385b83dab04ebb6d63443c63ad50f19335514f49638258594c3334a3",
-      "size": 6320
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034008.json",
-      "hash": "84fadebdd29abf50e4591f75344aa1cf0852547b707a950283eca7b35bc31d1a",
-      "size": 5197
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034071.json",
-      "hash": "5825e5baa1b7323b46c7dfad19af703f1e788694bbe716aa6f743ae644a9b6e7",
-      "size": 2606
-    },
-    {
-      "path": "assets/story/data/09/0034/storytimeline_090034073.json",
-      "hash": "c37b8da9f670f2d380d17fb06a9e1d723bdd2b0e1e313c81551535863d39d171",
-      "size": 3402
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035001.json",
-      "hash": "ace50dc7e623463ca91fcb36b5da8cc1186e7b39da82a0d68a77cab21f191a90",
-      "size": 9582
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035002.json",
-      "hash": "5d35f1e6178b4e663fc744dece2373bcc08fc84541be81c04510144c8d6db313",
-      "size": 10465
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035003.json",
-      "hash": "6c199dd3477c34362b92f3c31a38a4e781daec5dcdc2d32729210e4f00546270",
-      "size": 6420
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035004.json",
-      "hash": "ed22122d1d6a80368e8d0edc934c051b56837ae109a33bd598fc3ec2dc271038",
-      "size": 10198
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035005.json",
-      "hash": "173f1e2d7ab4daa3c70384e68550f765223b4e85570442d56436142540aa35e4",
-      "size": 6872
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035006.json",
-      "hash": "b65c695c9f2a1ae1ab46d37b04f225d10eb2f7e7c387f6ce6ab911c992641429",
-      "size": 8051
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035007.json",
-      "hash": "b3bbd41c585aabf7e7106f52d4b3d6a8a2181a2069a58d4fd68ee9b1172cab5a",
-      "size": 8624
-    },
-    {
-      "path": "assets/story/data/09/0035/storytimeline_090035008.json",
-      "hash": "c321c79f69c6bbf34f60625414d1cb3ef7657b99ebf6eadbad512f6ce8fdf7b7",
-      "size": 10399
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038001.json",
-      "hash": "214ef16f22664c504709fd4027ca2e45d694ae3e235cf68941f3c729fce9f2c8",
-      "size": 8252
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038002.json",
-      "hash": "69feff29875ac91fe974f153c0c36c4df2038f2cea62d622d060d5ef889b703d",
-      "size": 5717
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038003.json",
-      "hash": "b64f5c1da1ef6d29b3fcba2be8e6560e7a6fb69d5ee7997a260c6ccb9bcd198a",
-      "size": 5922
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038004.json",
-      "hash": "8520862a833b28eb4ffb4052a873414e04ccfccba78dba722ffb39f17f42c9a8",
-      "size": 10288
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038005.json",
-      "hash": "5f8352a7882d570f920e20687060e98912349783c0e61087a6ac646c20d6071b",
-      "size": 12399
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038006.json",
-      "hash": "f9998cf4eff3a9e55517695d292098e89e8f53fe3bff3cfbcae8e62e8c82f5b6",
-      "size": 7705
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038007.json",
-      "hash": "d022fb9fb62577c1cd5a0ef31aabff29c16be8cc8cc227d24c50a86627f78920",
-      "size": 7625
-    },
-    {
-      "path": "assets/story/data/09/0038/storytimeline_090038008.json",
-      "hash": "ec7df11551f3d664c7f59e8ef6336b4a962cfc9731d21b8c86dbc743f7539355",
-      "size": 5320
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040001.json",
-      "hash": "e9b87baa2d76c08cc51d6f24f81c8b5086ea34528ad0767018544ef7d65c4e1e",
-      "size": 8579
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040002.json",
-      "hash": "aac6ee4f8415e102fdb4c351d464bfcd8de86d64b2771ca8aa193b6baa5bdf59",
-      "size": 6142
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040003.json",
-      "hash": "288fd1e2f89fe40f168104150e1d59bc2ee84eb4440e97712baa5a1d1e268ab9",
-      "size": 9662
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040004.json",
-      "hash": "847b3a2abb90275d7e5435dd7e82c1adaf6193504fc5bd51a74f805a19804802",
-      "size": 8133
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040005.json",
-      "hash": "204367c76df5e68678cd17e9206185bddc5ffb509b2261ae9fdbd4e8b7cd080e",
-      "size": 9233
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040006.json",
-      "hash": "de19409140308f31969c01d403a63373c28b158df3da64c0439de4e215771bf1",
-      "size": 8234
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040007.json",
-      "hash": "678405edacec9fa35961b3d43aaeb69497c6ac8b552020f733474dce8d007513",
-      "size": 9851
-    },
-    {
-      "path": "assets/story/data/09/0040/storytimeline_090040008.json",
-      "hash": "e9d85bc201abfc9d9962d43ff8551f4e188339a20f974e8316e9bcb92c93b008",
-      "size": 7407
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000001.json",
-      "hash": "20f721ad763b6af1ff66c28e73896502744306a9872fb4ab04a505275b62f9df",
-      "size": 2088
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000002.json",
-      "hash": "f137bbde26d5bdaeab1542517775a4e30a039c87ffaeb30e95c33d4abef36257",
-      "size": 1602
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000004.json",
-      "hash": "a4117f64e3660a22872d9a57a8063961ac3216203f52379ae6cfaba34dfe8424",
-      "size": 1653
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000005.json",
-      "hash": "ea3da625a67654ea952b3e693f9313c8c5428ee76feb000304cd58c922b50287",
-      "size": 1966
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000006.json",
-      "hash": "9d69e0986e1a0ea67a450c3e7cd44dc8fd510942b177a1953ce7ec16b0a2206d",
-      "size": 1812
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000007.json",
-      "hash": "167bff73cae1619891b5f8312e970d4cd0eae5d42fa506568c1bdf01b10731c9",
-      "size": 3436
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000008.json",
-      "hash": "7c478f5f0b40444663212f44e953178e6627e71a1caf1c669e5f43adc19d8517",
-      "size": 3274
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000010.json",
-      "hash": "cef74773014d029eef83bcf8279f26cb86e056502d025592f7489fcd4070bb3c",
-      "size": 2765
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000011.json",
-      "hash": "ebd61477210c8edee6765687a5e34249da4351c7fc820c031f2be35a14dfab8c",
-      "size": 2896
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000012.json",
-      "hash": "df7b946b585370b71d75cc4e4ec7330b4699f764ba24f8da811eb3efd0c89e1d",
-      "size": 3874
-    },
-    {
-      "path": "assets/story/data/10/0001/storytimeline_100001001.json",
-      "hash": "e0db88f496f46578d3c8f547331aba0de2110e6939062560e053c10def295ca0",
-      "size": 7818
-    },
-    {
-      "path": "assets/story/data/10/0001/storytimeline_100001002.json",
-      "hash": "f54c5b59fee5f5569753b5be65fadb3d6d8dab3a960e137aa0ef3f4ec010a732",
-      "size": 8131
-    },
-    {
-      "path": "assets/story/data/10/0001/storytimeline_100001003.json",
-      "hash": "b6d4fcdb5ca33d9c7fa84129bed3e93b19f344cbe444235b49e001a4e85bcacc",
-      "size": 7758
-    },
-    {
-      "path": "assets/story/data/10/0002/storytimeline_100002001.json",
-      "hash": "4ca680f9e00544e7a799c414f1b78a29445d3a841aad51b33d96aefed78f4445",
-      "size": 8732
-    },
-    {
-      "path": "assets/story/data/10/0002/storytimeline_100002002.json",
-      "hash": "0c10da5da29dc12de8c04aef825081fd4350447e6942ae5ba170a765fc719c75",
-      "size": 8283
-    },
-    {
-      "path": "assets/story/data/10/0002/storytimeline_100002003.json",
-      "hash": "25b53b219c976420886f3e0d4ac0fb44752ce64ffcd3ff3b4463940bd6e50976",
-      "size": 8627
-    },
-    {
-      "path": "assets/story/data/10/0003/storytimeline_100003001.json",
-      "hash": "9093b4938ef3458b1b56fba8cac142e47aaaf3c435ff701ffbaaed6494461661",
-      "size": 7853
-    },
-    {
-      "path": "assets/story/data/10/0003/storytimeline_100003002.json",
-      "hash": "6faa047cbf380dc7ed299c0986b12e0eb46a396bca87821e8552ec0558a4bc08",
-      "size": 9087
-    },
-    {
-      "path": "assets/story/data/10/0003/storytimeline_100003003.json",
-      "hash": "14e0b9ad42efa184dc8113ff1bd47ca687347037d411e996c937a4ef7a932809",
-      "size": 8129
-    },
-    {
-      "path": "assets/story/data/10/0004/storytimeline_100004001.json",
-      "hash": "4adaab95d630a65411244d2cc8a2ba870cd0655efec8a54df21b8c6e8b1f1500",
-      "size": 2551
-    },
-    {
-      "path": "assets/story/data/10/0004/storytimeline_100004002.json",
-      "hash": "43aba5f4553ea7fcfcf1108d46736a1a4fd73512dc1cab48a9e031b57d069f71",
-      "size": 2305
-    },
-    {
-      "path": "assets/story/data/10/0005/storytimeline_100005001.json",
-      "hash": "793ad0d44ca58bc1786f537c5b7ef6eb57ddd24129b4fe275580a330fa691c64",
-      "size": 8328
-    },
-    {
-      "path": "assets/story/data/10/0005/storytimeline_100005002.json",
-      "hash": "630da64128bb1222b63f719518d673e4f3db0fdad17ae519601af052d5da72fa",
-      "size": 8933
-    },
-    {
-      "path": "assets/story/data/10/0005/storytimeline_100005003.json",
-      "hash": "46991c6a3f45276195d2fbb8a6b19d0aa4b38ca7545e326aed456fb14317718d",
-      "size": 7980
-    },
-    {
-      "path": "assets/story/data/11/1004/storytimeline_111004001.json",
-      "hash": "42403f06b1e13bb561ab40ba856077df736c3ce9a8aa3393c923b1719dff3641",
-      "size": 283
-    },
-    {
-      "path": "assets/story/data/11/1004/storytimeline_111004002.json",
-      "hash": "21c9a8fd96f43ab8d92048bbb98d85dfa6191d1a297651a0d30e0b343a3ae142",
-      "size": 264
-    },
-    {
-      "path": "assets/story/data/11/1011/storytimeline_111011001.json",
-      "hash": "66292f9fef01d29b55cf16e33fe691972423e30027d2530a7f5658582c07ad90",
-      "size": 265
-    },
-    {
-      "path": "assets/story/data/11/1011/storytimeline_111011002.json",
-      "hash": "fe8d0f6afa4803beacf640b9b811f5cafd19c2a78ab4be81f563a06c981a2428",
-      "size": 269
-    },
-    {
-      "path": "assets/story/data/11/1018/storytimeline_111018001.json",
-      "hash": "6f4e2a1dfcf5485eca05bf162dc6005987f18fc2717c3c9d99d587b3e0b3765b",
-      "size": 254
-    },
-    {
-      "path": "assets/story/data/11/1018/storytimeline_111018002.json",
-      "hash": "ea770bc2ada484c2c9cd95bfe842c186fbb95777d44ea2000c1443cf8ad48ebb",
-      "size": 264
-    },
-    {
-      "path": "assets/story/data/11/1025/storytimeline_111025001.json",
-      "hash": "5e83b926c19a4dbc5241a73f43807adde56c855c67e98ed86090e9efcec4fda9",
-      "size": 301
-    },
-    {
-      "path": "assets/story/data/11/1026/storytimeline_111026001.json",
-      "hash": "2c8e9d5ca50d59c5fcf539961c37de3f204648933ed61f2116e603acf8f8d6b3",
-      "size": 233
-    },
-    {
-      "path": "assets/story/data/11/1026/storytimeline_111026002.json",
-      "hash": "cd46a49737f6a490a047c4102bad24eb61b9a87adaaccfafd73875f15ad78726",
-      "size": 301
-    },
-    {
-      "path": "assets/story/data/11/1032/storytimeline_111032001.json",
-      "hash": "7706085d99fef6cf1be512172c57278ef3309615b398c3dba3f61b905dbaf709",
-      "size": 261
-    },
-    {
-      "path": "assets/story/data/11/1034/storytimeline_111034001.json",
-      "hash": "0ddc9fe0d445270357a39a6186702b61195127c206e97ab63c2ae9a7722c73c7",
-      "size": 215
-    },
-    {
-      "path": "assets/story/data/11/1034/storytimeline_111034002.json",
-      "hash": "21e695d6909c522a937622aded522e7bba575dfde8753295ddab53391e15d2dd",
-      "size": 223
-    },
-    {
-      "path": "assets/story/data/11/1041/storytimeline_111041001.json",
-      "hash": "06f43aff0361c78ed1139a7272c9b1c2b44e3f2ff0f43aac646fc02ff4d273c2",
-      "size": 319
-    },
-    {
-      "path": "assets/story/data/11/1060/storytimeline_111060001.json",
-      "hash": "a6d425a09bbaff58f7115eb6fd18f3f99c8d9c2e06bd617f25e4529588f63d26",
-      "size": 281
-    },
-    {
-      "path": "assets/story/data/11/1060/storytimeline_111060002.json",
-      "hash": "92ded4f3a6fc97df336b17866017bb7af37ab9a6499c85e0b5f590ab4189db01",
-      "size": 263
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251001.json",
-      "hash": "fb5562aa3d99f618cee75d768062ab8ed431be8d8eac5d15b6c8f8c4403ffe50",
-      "size": 397
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251002.json",
-      "hash": "d7c0756809a3aa74f7a9a649b10985a63226a65f78a64b53f6baa7667e829480",
-      "size": 756
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251003.json",
-      "hash": "ea2814fd47adfd15833f95c4eb802dab37dafe3265feb8671ec91de266161091",
-      "size": 647
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251004.json",
-      "hash": "7683bf86650b6418a81c08e71d3e91e1ef46265f3ce6e2853b9f9bf8a5cf3fcb",
-      "size": 580
-    },
-    {
-      "path": "assets/story/data/13/0001/storytimeline_130001001.json",
-      "hash": "da7875805c3dd2793888e901c51a7b717bfd92b13f884afb3937bee8155aeba9",
-      "size": 4035
-    },
-    {
-      "path": "assets/story/data/13/0001/storytimeline_130001002.json",
-      "hash": "a91ed18ddcfcac4808b1054aa2720889c525b37bb1496ab06c212cfc74b45b57",
-      "size": 3125
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000001.json",
-      "hash": "20ea1e4999ee57e20a7ccfdae6d33b5dbd5564bc3f07064697a808d2e6953184",
-      "size": 2572
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000005.json",
-      "hash": "56b8a1b6dbb5a550613f8cd7ad52b7adf440ed3b1b40e18f3fcbbff5d45a0565",
-      "size": 476
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000008.json",
-      "hash": "3cf313c1503d61cee5cbe668e743748c1555d60a685a52122b0b137f2cf2da0e",
-      "size": 383
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000009.json",
-      "hash": "ee7eb24bb855760deccac9c564ea21f30eedc568aea3a2bc895755cc8a47da54",
-      "size": 428
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000010.json",
-      "hash": "8dfbe16ba1a7aa300d109684133a07d66846a3513cf410ac170e410d7d22266b",
-      "size": 431
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000011.json",
-      "hash": "316052ae9fbaa9278b4442ad98c9dcf61ec39c38d725b18ca222feea99e7d5da",
-      "size": 458
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000012.json",
-      "hash": "362071e735b4e6214a41976bbb481383def5a938b477d94225353b227c44be1f",
-      "size": 448
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000031.json",
-      "hash": "7c2c2f047bb41b2bb510cac73329d5c3c997e799a99c46e5c1f821ae2ab0c573",
-      "size": 604
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000032.json",
-      "hash": "00b0a2a83ad477100a09050d2e9a3e1eca11272b452e0e773323c22876b62fe9",
-      "size": 510
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000033.json",
-      "hash": "152d5bb4cefe7b98a8f835d292c8ed53daa45593cc2ad37f246d3f5c90f83f38",
-      "size": 586
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000034.json",
-      "hash": "48446023665e2c54e851b25c963f9b343762b44058c7c6bbf39624e09da6a81e",
-      "size": 928
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000035.json",
-      "hash": "97a592c6f77027ae6d9c668dee90c1683de7e12ac7d9970067648bc2f541a20d",
-      "size": 649
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000036.json",
-      "hash": "d74ac28228c5917128e009a1b6b97cb209529647eb637dc291a777450d82b897",
-      "size": 3671
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000037.json",
-      "hash": "497c9fc751160a2a7999e283ebad63eacc1c757efe564512cf7cab6c317b3fd9",
-      "size": 257
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000038.json",
-      "hash": "c1ca24e4375878e7718b91d56b46f81faea003f994b7ef76c6651fc0dc868cba",
-      "size": 232
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000039.json",
-      "hash": "d903f4524fb8935ab675debd398280b11d775e851b3f5b93b63e25ffc8402234",
-      "size": 280
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000040.json",
-      "hash": "e297af8e0fb8c8934ff6f1ca82988a8f2a4e4985ca9f2c409c290925ba9b406a",
-      "size": 254
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000041.json",
-      "hash": "3e71f10ff459b500ea50b9e1d47f7ad0ac1e1bb2255062c8ca66457e9eadc2e6",
-      "size": 3221
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000042.json",
-      "hash": "9e9302e4a2610a3c7b4d03a1bda11164a349cbdd8067c3469dcc5b3efd5f9e5d",
-      "size": 336
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000043.json",
-      "hash": "a42223105f778d25c19f66d807f3dac1e88177df70856e4a4cf9c7720bb0c9fa",
-      "size": 960
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000044.json",
-      "hash": "b118f0776b37cd6d5b8b94be19ec2d8548eaabd1e37cbb616d262fc867f52b69",
-      "size": 922
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000045.json",
-      "hash": "f8603dbb9697394fc44ca02868f11dd3dcd0054619b9d98b2e84f96dc11d190f",
-      "size": 1112
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000090.json",
-      "hash": "a218a49810044d126b5ff7c98e77c36f09b6c8e1eda0cf4a23a346080ddf8f94",
-      "size": 336
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000091.json",
-      "hash": "a6572cb4307dc57fda61231fd0ed565cbecab0860713835343c84bdbee5a41e4",
-      "size": 8598
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000100.json",
-      "hash": "a412ecbe9e553613051d1becfb08407f06ef632cd3367838e4eddc3ef6b06e4a",
-      "size": 3200
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000101.json",
-      "hash": "fe33760b9c0f36291e3a778460c60c5ab180762f6eb70e5cc77016a9428185bb",
-      "size": 879
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000102.json",
-      "hash": "2742e8d3ceb2786515460fc881fdf7ee73084a5ec8a76cbb75768f9e87a841fa",
-      "size": 630
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000103.json",
-      "hash": "1369bf6748eaff338f021422893d463b6f2349f08f827196940688d1bf6ed056",
-      "size": 851
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000104.json",
-      "hash": "1349b206d806d68d4c60674efde3ad0af0ce67df0c5391e7c79ebb7c5240c699",
+      "hash": "01d64ae3a6bbfe8e196fea8bb9d277e20e69760c3fa8f98d7fbe364b799d9aa2",
       "size": 789
     },
     {
-      "path": "assets/story/data/40/0000/storytimeline_400000105.json",
-      "hash": "e414a24b7bdc10c4e84509c3c145aefb431dd55197477e7d1a6bf19453d13c04",
-      "size": 781
+      "path": "assets/story/data/01/0001/storytimeline_010001003.json",
+      "hash": "82c4090db2bcec87a4975c8e2448ab2932fefdfb2e2a8e4635edbd760b0818f6",
+      "size": 321
     },
     {
-      "path": "assets/story/data/40/0000/storytimeline_400000106.json",
-      "hash": "6faf5bfe5d579fb5ea8da92160e1e8527cac4d5677d4abe3c17b9d2d5abdc460",
-      "size": 806
+      "path": "assets/story/data/01/0001/storytimeline_010001004.json",
+      "hash": "7665792be647f0c5ef88d1bed7b46c9f49be9e958dfedbc2b82d7194eb501d53",
+      "size": 509
     },
     {
-      "path": "assets/story/data/40/0000/storytimeline_400000107.json",
-      "hash": "4eb6c36e6f4835d62742c53510348d72d30d6d3f3e9e49232f1c5688d189b0ea",
-      "size": 1055
+      "path": "assets/story/data/01/0002/storytimeline_010002001.json",
+      "hash": "2a1cfea04c09f29ece669ace742939724ec464a56f910acce02036b8c6aaa4cf",
+      "size": 194
     },
     {
-      "path": "assets/story/data/40/0000/storytimeline_400000108.json",
-      "hash": "ce73ebcbad8ce7607aaddf9b00a03d368dfdeb38c6a6686a42caed0c2b3c8ea1",
-      "size": 948
+      "path": "assets/story/data/01/0002/storytimeline_010002002.json",
+      "hash": "a2b8ae479e0a91babe2b0cc37ddfa10b51df7b30ed2de080fc588061fd56fe96",
+      "size": 1010
     },
     {
-      "path": "assets/story/data/40/0000/storytimeline_400000109.json",
-      "hash": "03224d81f325945609460817d4ed793c20dfd62297ceead6eec419ebe39a3d88",
-      "size": 844
+      "path": "assets/story/data/01/0002/storytimeline_010002003.json",
+      "hash": "263f1dc4205bbdcc67272ad55475a2afa62008463d96fa674c7f5b73b79101eb",
+      "size": 532
     },
     {
-      "path": "assets/story/data/40/0000/storytimeline_400000110.json",
-      "hash": "b63a175bc4295cb29ce466d6b7558e93099063991db12f95b3dcb4843281ce44",
-      "size": 1389
+      "path": "assets/story/data/01/0002/storytimeline_010002004.json",
+      "hash": "b29ca9999f00f33a9b54094fc1a6059ee139f3f146885afbb507ab39679b0d3f",
+      "size": 340
     },
     {
-      "path": "assets/story/data/40/0000/storytimeline_400000400.json",
-      "hash": "8b6a27765694c2290d33ee068d8b24251fb7ebc8aaf562371e13313312bb0968",
-      "size": 670
+      "path": "assets/story/data/01/0002/storytimeline_010002005.json",
+      "hash": "adf3ad2dc3902ec5677f6e3c6da437f94e5d5ed3cf16ac5afaaa9e950992a457",
+      "size": 285
     },
     {
-      "path": "assets/story/data/40/0001/storytimeline_400001002.json",
-      "hash": "4a9082289cc4633b92747238adeeee72cb31c1167f7730ae990877f95b790d6a",
-      "size": 10582
+      "path": "assets/story/data/01/0002/storytimeline_010002006.json",
+      "hash": "af54d401e3e0a7676af04df4a4d3b6cca20a7e46f1c7e7fb9e4c574c1969e3c4",
+      "size": 342
     },
     {
-      "path": "assets/story/data/40/0004/storytimeline_400004249.json",
-      "hash": "6a7e0bea1a80eed6649f53241f5d31b7e8bff54d0db04af080d1b4e2c5e26d86",
-      "size": 2648
+      "path": "assets/story/data/01/0002/storytimeline_010002007.json",
+      "hash": "bdc09f10f083f6c64fa5d393a2472afcc0a33717759da90234620e9a2715fef3",
+      "size": 398
     },
     {
-      "path": "assets/story/data/50/1007/storytimeline_501007100.json",
-      "hash": "99c3b22995a1a946727a3e8db73b8f5999371c0548e7c3f6bc72074b462b7b0f",
-      "size": 4923
+      "path": "assets/story/data/01/0002/storytimeline_010002008.json",
+      "hash": "8ea16bf4e7010b3662d290508b359dfe2661eaeadfdceea9825ac073acbd7445",
+      "size": 1356
     },
     {
-      "path": "assets/story/data/50/1007/storytimeline_501007101.json",
-      "hash": "0788b54b71c8de135ebcf460c8eeb77601867357a196cd0455ce2f5d9dcda5cd",
-      "size": 4218
+      "path": "assets/story/data/01/0002/storytimeline_010002009.json",
+      "hash": "68c1f3a7cbb7336b2fac72d4a8e64fc7469142a6ac21ffde84d42c8afde75cce",
+      "size": 1232
     },
     {
-      "path": "assets/story/data/50/1007/storytimeline_501007102.json",
-      "hash": "77be51d6d38af0a9262204a80a85eb5c9e88010bb035d7fdb765264329b014de",
-      "size": 4637
+      "path": "assets/story/data/01/0002/storytimeline_010002010.json",
+      "hash": "6a5d96cdb79c129388d57f7aa59ec9e29a1e3f92b06f2f808d24609bbe89ef79",
+      "size": 411
     },
     {
-      "path": "assets/story/data/50/1007/storytimeline_501007200.json",
-      "hash": "39e5a7e8b90e215f2383acbcf501e9e4538bde90f44a5e35fbd2c292de4d9e5d",
-      "size": 1970
+      "path": "assets/story/data/01/0002/storytimeline_010002011.json",
+      "hash": "d4d477bf33eecd698d4bcb2beb6e914f25ade8b00ade9c961a0a8b48fdaeb43d",
+      "size": 804
     },
     {
-      "path": "assets/story/data/50/1007/storytimeline_501007201.json",
-      "hash": "fb1366b1262de50cf14bddbe83ecefaba25ce3b60271dc7b0257231e5861552c",
-      "size": 927
+      "path": "assets/story/data/01/0002/storytimeline_010002012.json",
+      "hash": "cacdf02edc748602477f5090dd77c94d4c9e784a03e4ab74bc2308b2e1e5931e",
+      "size": 692
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041100.json",
-      "hash": "38aaf63376af6676e109b361b2ae086f8f9242f2258b829278dc85226fac5343",
-      "size": 11204
+      "path": "assets/story/data/01/0002/storytimeline_010002013.json",
+      "hash": "eb9bf407f86b7e152a988f7e7bb7f277b39a9a1fc3c2a3d51fb4de24e0350eda",
+      "size": 593
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041101.json",
-      "hash": "6d7a45e8c8841831f814da46fce636e0e5672af5ce2b372b3ffc5685bdd077d6",
-      "size": 7510
+      "path": "assets/story/data/01/0002/storytimeline_010002014.json",
+      "hash": "cdd6383b54c30592785edfe17be0aca0348e80105b0781c2cc96fc519d0322e9",
+      "size": 724
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041102.json",
-      "hash": "5fef6276dfc42dfa15048e03b33e85a9557b1af72f965dc46631d4db16220218",
-      "size": 6117
+      "path": "assets/story/data/01/0002/storytimeline_010002015.json",
+      "hash": "9103571e4d20b6bce3cb08bfdf1e7e1fa2f39ce3830e8b17dc792e674bca8306",
+      "size": 718
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041103.json",
-      "hash": "8afec29c2aaf9a8fe99e202c5cbb2cf39e4fe6d9ea2cceaaff9672be08da68a5",
-      "size": 3240
+      "path": "assets/story/data/01/0002/storytimeline_010002016.json",
+      "hash": "d96899a69fb8a86189d4afaf5fb8a8616c42bd1e5d73e9423a34fac8351be779",
+      "size": 701
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041104.json",
-      "hash": "0af2fbbd0350395cc5b5f2c402881edc3b5e9fe5a58c4302ab76e34b331da389",
-      "size": 8321
+      "path": "assets/story/data/01/0002/storytimeline_010002017.json",
+      "hash": "14394d38595791e1ec78c1839d3b4471802ef03c557d9b762e5fc90add04ca08",
+      "size": 979
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041105.json",
-      "hash": "437be2c9a1edfb42ea46cc74f2120da3c190e6e81f19c332a15d6552b7f137d3",
-      "size": 1041
+      "path": "assets/story/data/01/0002/storytimeline_010002018.json",
+      "hash": "e175116096224b338604a303f3b7fde3e87773e421d46457498be2424dddb6df",
+      "size": 355
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041107.json",
-      "hash": "302ab35c7ac37b0b8adc5d354b98efe5e4fcaa5fe43da86285f30518eaab3d5d",
-      "size": 7882
+      "path": "assets/story/data/01/0002/storytimeline_010002019.json",
+      "hash": "28a162b7c10f0a179bd7359fce36065cc31f90bd32be38cb6814d8e30b7d3010",
+      "size": 961
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041108.json",
-      "hash": "01ea312423dfd934ed3e9c8f2efa1be78975c6142df23a73adedcafbf3e84836",
-      "size": 8735
+      "path": "assets/story/data/01/0002/storytimeline_010002020.json",
+      "hash": "9fb7dac7e89e08802ead2885fdee94afb59a301f7ecb63a6b28147c5f0618751",
+      "size": 680
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041109.json",
-      "hash": "ee10ed807c97fde0ab6e65929dd3b925136aa75d0d91430f7a2a6a75b255eeb6",
-      "size": 11484
+      "path": "assets/story/data/01/0002/storytimeline_010002021.json",
+      "hash": "45aa7b8a65d9eaa486234bd0152bf59c63a07a9d10ec32edc6feabb8e743fccd",
+      "size": 646
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041110.json",
-      "hash": "31eac39de39cabd8f67c3f7571f12fcf2310dcbfc94dbf1c0413dbc4f8fcc2fd",
-      "size": 3038
+      "path": "assets/story/data/01/0002/storytimeline_010002022.json",
+      "hash": "392c756c1cdf606622814d86148d4f2f52b4318bcc4872e887ff84ce277ef11c",
+      "size": 460
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041111.json",
-      "hash": "a164b94e0cfe268a5ed92f0e74e03258d3d2ac1ab40462896929d7d1571e2017",
-      "size": 6399
+      "path": "assets/story/data/02/0001/storytimeline_020001011.json",
+      "hash": "e1591dc7e79a97126cbe6c6ad84bd3f5ba89d5bfd0599809e6c330dad6f075e3",
+      "size": 7136
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041112.json",
-      "hash": "e0276516a284c157822cea93d3fcbc6dec90e65fd14692185d9f269001421944",
-      "size": 7503
+      "path": "assets/story/data/02/0001/storytimeline_020001021.json",
+      "hash": "028e599f17f3de67f7a09fa72ad0913aaf7cd0ec9277d42a5b6a5ffb2af5924f",
+      "size": 8690
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041113.json",
-      "hash": "66a2251c8142066ec0fb243f4ff852e8749af874f5b57b58a74d3377a6dc72cb",
-      "size": 8899
+      "path": "assets/story/data/02/0001/storytimeline_020001031.json",
+      "hash": "dbe1cfb3da2045c964442e7f241fbe3c3db6ebe2364239efa8308b0d7a5937ee",
+      "size": 8548
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041114.json",
-      "hash": "a7416c4e1b71b2374cba23ce063c2a1284b3be3caacd6f04679313ddf44e1183",
-      "size": 6512
+      "path": "assets/story/data/02/0001/storytimeline_020001041.json",
+      "hash": "3311486515fbcf708f80e234cf2662c16b1401bb1817057e1502ffdd17e383cf",
+      "size": 6955
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041115.json",
-      "hash": "cbd7c96d48ecf9170bac4b7de0afe4f49a28d354421ba5871fa6e670e11f0ab2",
-      "size": 8896
+      "path": "assets/story/data/02/0001/storytimeline_020001051.json",
+      "hash": "1f9d4886b0802fdef45d61c240ea3d122d2c2d4f0e0341ac8ec5c6d74ed9c130",
+      "size": 5109
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041116.json",
-      "hash": "a8c41e5b12e370d50bf079be3d4b056e08950deba07da9da3629d73046c57cfb",
-      "size": 4132
+      "path": "assets/story/data/02/0001/storytimeline_020001053.json",
+      "hash": "48cdb3dc23c9dd37674552139c25d898dc43ef78bb851ca2fcae68d3a5bc08ea",
+      "size": 2141
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041117.json",
-      "hash": "c3caa3a3a2d84dfc12687557e06c08f096d20f36ac16208131c86ef37a80fdad",
-      "size": 8229
+      "path": "assets/story/data/02/0001/storytimeline_020001061.json",
+      "hash": "3914263e7602f941bdeaed7e89d112e02efbd3a4663df391f6156e1c68f9a972",
+      "size": 8451
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041200.json",
-      "hash": "61775c78e5d713d17c55d719ff49fb9260279c491a1385b026c614c8716cbf13",
-      "size": 1425
+      "path": "assets/story/data/02/0001/storytimeline_020001071.json",
+      "hash": "b3cea60914521ca4a5de52e0aea3e8476a6e04bc5a344e0e25b641340d681b43",
+      "size": 8370
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041201.json",
-      "hash": "ec1ecdfa73ee74a4912d4c3e7dff63d670f401fd5f37f9ef53823d594995285e",
-      "size": 1698
+      "path": "assets/story/data/02/0001/storytimeline_020001081.json",
+      "hash": "ec087ffa9c216c15003752b4e8b6271379c8d3373c90f83821da15cae6cb63db",
+      "size": 7702
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041202.json",
-      "hash": "b5c891bf68e6ad0cbb3ce95d4c4b6d2ebf1936196db30f336c02810a5c31ee90",
-      "size": 1794
+      "path": "assets/story/data/02/0001/storytimeline_020001091.json",
+      "hash": "d16bfdc8747afd50736cdf04d9adc023248e6b9c87a4cfa0f54c1fd2c9951533",
+      "size": 8945
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041203.json",
-      "hash": "c64234cc53e68c4fdb2224277cf6dcefbcf2bf637f0059e6e9f7380b59401fba",
-      "size": 892
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041204.json",
-      "hash": "02237e2cfbd0d82065e2674eb0f8d95caddc026ac50466f441845ab9789f3649",
-      "size": 4340
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041205.json",
-      "hash": "056749537c030f02c34dd14268a59d152101573e5a74ac19434bc7e38a214a9f",
-      "size": 2672
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041206.json",
-      "hash": "c4236a0a8325ea3ad572814098868d5e932600e2ae80c4e3e8200873e9256190",
-      "size": 1041
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041207.json",
-      "hash": "85ec6d21d92b2c79f09de37ad665f25324325fecc1f8cb0c2d125568d8cf8eb7",
-      "size": 1228
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041208.json",
-      "hash": "3dafb1a826c4d66a9f0c38143c93372638ab49a8a01dbd67e6074e2b4047f629",
-      "size": 1417
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041209.json",
-      "hash": "4cf407a8ad07629809197b113a8ac1c10f801f2db961e395df9c06e5f6d91e7e",
-      "size": 3351
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041210.json",
-      "hash": "ca57cacdb54537ad875d6b454626e2a20031d425c976004d5af060e9b47b5680",
-      "size": 2206
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041300.json",
-      "hash": "3aa57f36c14db936284c82b4dda5538362a32deb40dae7d2fc4668a9a30273f6",
-      "size": 1735
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041301.json",
-      "hash": "4b5c59ba0bb57c99af8fe379bb7ac6f05e7f300361d3fdcf15c4ea696fd2894c",
-      "size": 2724
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041302.json",
-      "hash": "ff9a557d68e648d6ecbfd7379bf2c47f8a8580bb86cd958cf7f9472177007855",
-      "size": 14487
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041303.json",
-      "hash": "062250c8a46d5f656bd66bad2f9f874a72ddf1e7d0549e890220c9e0fa6461cf",
-      "size": 4027
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041304.json",
-      "hash": "c676fd23a1ebead047ec8d6094837cec71f88d52ce3d1e107433994b9f1ab165",
-      "size": 2455
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041305.json",
-      "hash": "9ec098e210793de6bf2597580a207b34e84d0181ed71802405e4e3e38c9015a2",
-      "size": 4025
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041306.json",
-      "hash": "73fcf304e60f4584eb06ac71f7c23a83159dc842a085f799a7adc81eb6363360",
-      "size": 5685
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041513.json",
-      "hash": "4ae6f01499d3a2624735beec6b9ae7e8708d994d796b42690eb850e90c724f80",
-      "size": 8901
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041514.json",
-      "hash": "e09d37b11eaa8eaede09c7b2a7c492c8650feca59b5be6ffdf0edd1d59f754be",
-      "size": 9654
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041515.json",
-      "hash": "3e402ef3dfd1a06085f320ce6d58b8df1d2572046940ef44da214eb1eae930d9",
+      "path": "assets/story/data/02/0001/storytimeline_020001101.json",
+      "hash": "d6f7496f72fc1d571ee8f31ad18ab29825a11a32e4e033a9e80578c4fdda66f0",
       "size": 9607
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041516.json",
-      "hash": "3bb9905c3ca0181507a1572622516b5367d4bca5546021be6eb4c3943bdb3dd8",
-      "size": 4514
+      "path": "assets/story/data/02/0001/storytimeline_020001111.json",
+      "hash": "21c5bc33abdded44e4e6dd266693a86d96f8261aa736e8e91a5c60ee9d49a2e0",
+      "size": 9044
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041517.json",
-      "hash": "e554261fa28867c2cae46c4daa7b2deacaacbface48034bf8801a7d432c39f27",
-      "size": 1446
+      "path": "assets/story/data/02/0001/storytimeline_020001121.json",
+      "hash": "cdbc405d14dbaeb1d711a7df53993d035b46f2beefd1a6fbe80d551d74c9990e",
+      "size": 9524
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041518.json",
-      "hash": "3cc81d86e05f130d8fcce91d32b392aeb21586fd9ea457cfd19a963327f671e9",
-      "size": 1296
+      "path": "assets/story/data/02/0001/storytimeline_020001131.json",
+      "hash": "70b01d3a9f95a008ea78c013fb08ae7dfcde13aba7d70c7078553f279a72261b",
+      "size": 7889
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041520.json",
-      "hash": "4a675ffae2c357753bd80b332e5264daedb2d25e876c7f7c558d5c3a4b588067",
-      "size": 10948
+      "path": "assets/story/data/02/0002/storytimeline_020002011.json",
+      "hash": "4b010cff57635060485b9201850d462ce4107bd028093fa3bb170e6e3b3207a3",
+      "size": 7903
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041521.json",
-      "hash": "46d7e9915fb18eca96f52b88436115bd9582876bc0837a6e1b50415d597b4ade",
-      "size": 1037
+      "path": "assets/story/data/02/0002/storytimeline_020002021.json",
+      "hash": "4d7717fef520752736de777fb52307dd1bb079cbeb72e98a85b8f651c53c69b9",
+      "size": 8312
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041522.json",
-      "hash": "083fac40b88dd0afb1eca24d47ffff2d9f274f6e948e5affd2627a7b560422c3",
-      "size": 1450
+      "path": "assets/story/data/02/0002/storytimeline_020002031.json",
+      "hash": "56d8ddf4fe347969f456bd17ed13e7d22583cc8f0115b65eed8979c6cf2ce8ea",
+      "size": 8728
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041523.json",
-      "hash": "060c3d1207a87d99ed1a4cb9ef0cb7a6119d426feec8e2898192b80a52be9da6",
-      "size": 3815
+      "path": "assets/story/data/02/0002/storytimeline_020002041.json",
+      "hash": "73c8128bd48d53ac6742db562c674a07308c699ccca3d372e5ec4daeb26eca83",
+      "size": 6638
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041524.json",
-      "hash": "10de0e9e27ebfc0ac02154df68309f85faa5b8f4b53997cf98418fd7d7ecd166",
-      "size": 5960
+      "path": "assets/story/data/02/0002/storytimeline_020002051.json",
+      "hash": "b76390974529afce43e6878b96a80bf584625400a20433c229e27abb2df3ccb2",
+      "size": 7189
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041525.json",
-      "hash": "a19301e87efa9a6bed66ea4d5aedab1d830d174c2625a82d842e310db60e4906",
-      "size": 7694
+      "path": "assets/story/data/02/0002/storytimeline_020002061.json",
+      "hash": "379f3c70912a2e6871e4228c6857b47bc1b7653be0a7fd79cda038385c813f5e",
+      "size": 2696
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041600.json",
-      "hash": "4f3e40c54b32aa34fc9ff2a3988498013274519dfc2bbbfb3edb90c0c3ea7f4c",
-      "size": 997
+      "path": "assets/story/data/02/0002/storytimeline_020002063.json",
+      "hash": "225823a73e29c7f6296b8555e0d2d8c10da1493996010c20fcd65c228a0b3e83",
+      "size": 3209
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041601.json",
-      "hash": "19be25aa6b2bd3b690759a3d6944a3b67ab0fdbf2c9807dcdb53e5861bb63525",
-      "size": 866
+      "path": "assets/story/data/02/0002/storytimeline_020002071.json",
+      "hash": "0a04df849268c481925256dd10c2d3df23364114c04d4ab27fafffacc2c1bf1f",
+      "size": 8492
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041700.json",
-      "hash": "5d21bacc367cf7c2741fd0b267a7b40c9688d491e50fdcbfa48ed375144e51dd",
-      "size": 1291
+      "path": "assets/story/data/02/0002/storytimeline_020002081.json",
+      "hash": "618aa301c02471e7873a069ea9236fb3d998ed67bdc6c53c6959bdd0164e7e2a",
+      "size": 8396
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041701.json",
-      "hash": "665464ca03673b43143327d5a5ba6e1cfd784c4caa75c9a7eb17026547785a39",
-      "size": 991
+      "path": "assets/story/data/02/0002/storytimeline_020002091.json",
+      "hash": "b2df42a0d93cc3bf71d8ade10ff6935e630acc09c93a4bd2cedb8c794dc68e00",
+      "size": 9367
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041702.json",
-      "hash": "115d6b97f1ffa7d12147408a6280e7dee9ed0f417a47eaafdbe8c754eb882d72",
-      "size": 8527
+      "path": "assets/story/data/02/0002/storytimeline_020002101.json",
+      "hash": "711d48709c05f464f35f870a97a9373c207c2d6bb087adef4756a5ef33f664ba",
+      "size": 7933
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041703.json",
-      "hash": "8b2c4fbf61be474e8a8a5d390664de79a1d6c445c519884f9c3cc3921afe862d",
-      "size": 8670
+      "path": "assets/story/data/02/0002/storytimeline_020002111.json",
+      "hash": "85d32d8e4a678910a6b754c62104813ec423e3da5fa91ca5cf21f7f321e92182",
+      "size": 8031
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041704.json",
-      "hash": "20ab045c4db61a39318ca08057672f2dbfb8a59bc7ac84e5e60faa9db6f23b87",
-      "size": 14695
+      "path": "assets/story/data/02/0002/storytimeline_020002121.json",
+      "hash": "76680bd0489cc6dc49a5c30fad65ce1c64a5bc37b80efabdeadc81db5a2b2d4b",
+      "size": 6441
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041705.json",
-      "hash": "43d8f1a40d650538b621c6dc2eab7c327884369b6517284dee7a9d69ef4d24b6",
-      "size": 8285
+      "path": "assets/story/data/02/0002/storytimeline_020002131.json",
+      "hash": "1c23ecdd27edb504484381caa1b89dd83f014d2cef609430922a8f7d7aa30cbb",
+      "size": 8183
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041706.json",
-      "hash": "91b34ba645738508a4c604224ffcd8e65d806d07375d111a78be35e4b3087960",
-      "size": 7412
+      "path": "assets/story/data/02/0002/storytimeline_020002133.json",
+      "hash": "49898bd004dce0e777868d4e82315c87975cc4b3eef6c8e095b103c550e64746",
+      "size": 1891
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041707.json",
-      "hash": "62e2e7db40f450247d1cc57f50b9e61fb79a65bab5f0706d508f221646b6c554",
-      "size": 4685
+      "path": "assets/story/data/02/0003/storytimeline_020003011.json",
+      "hash": "f42205acae5c3c34c8182ed7a2d9136517116c2a87ca3886c23995ca7e6431cf",
+      "size": 12082
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041708.json",
-      "hash": "a04b5b0f564b4a15548182d3bc98e2325571f3d236c6530069a7a4b4465c1213",
-      "size": 2232
+      "path": "assets/story/data/02/0003/storytimeline_020003021.json",
+      "hash": "df720ea6052ed1ba6b56970cd478930f195b87aae3e78c99c4b8286dc4c6efc9",
+      "size": 13140
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041709.json",
-      "hash": "5fe069a15af02c34cb6f4110b8af84f24d21ed6fa4b4ace4b7b684d9360b0475",
-      "size": 2318
+      "path": "assets/story/data/02/0003/storytimeline_020003031.json",
+      "hash": "3317836dfbc38e7545bc0e3977c5da15ed1021f82224e14478ceb8938ff07fae",
+      "size": 9071
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041710.json",
-      "hash": "0f77ac40e5d029445c72b5625bc1e1b4b0a44fa552a006d572f18e34213916d9",
-      "size": 2393
+      "path": "assets/story/data/02/0003/storytimeline_020003041.json",
+      "hash": "c61081c0e8e77510e61c906bf3b4c4009f09d3ab21c444619429a6b60a5876b9",
+      "size": 9537
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041711.json",
-      "hash": "574d5c6d4f018bf0a6ac19e0ab5c685ca188ab32d478d43bf8259c272057372b",
-      "size": 3091
+      "path": "assets/story/data/02/0003/storytimeline_020003051.json",
+      "hash": "fc618b7691ac6566baaa125ea25be8c6f91c12fa18d3e47326c7ac7c62b9900a",
+      "size": 9463
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041712.json",
-      "hash": "6edcf7c36794c26a02f6fac04b5e5e3d185139c4f63a76cce8a8bbdb3cc76d25",
-      "size": 1854
+      "path": "assets/story/data/02/0003/storytimeline_020003061.json",
+      "hash": "e15ba92e8e7326e4c3d0789ec5bfc9c676dc2da0f3b045ea1bd74675fd7f2d04",
+      "size": 6871
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041713.json",
-      "hash": "923df845537be621d68f3644befb63ce3884575db4c7950e09e3b26bbe3e80fc",
-      "size": 3485
+      "path": "assets/story/data/02/0003/storytimeline_020003063.json",
+      "hash": "f815a7bb1c17498552895a2e69484175436ab70a4fc48814ad940773145105be",
+      "size": 2045
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041714.json",
-      "hash": "8c7527842dd04ca859ad962fa8327be83e0de92dde7a13ce44bba05ac16df0e0",
-      "size": 5413
+      "path": "assets/story/data/02/0003/storytimeline_020003071.json",
+      "hash": "2bcda672a3c2dfdf7f43b2873377e01db62fb1ed6f69549ad129c8a655bf1888",
+      "size": 7798
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041715.json",
-      "hash": "6908675c5420f09a3bb791eb2a8ea4bb08da8506a1c786ec35db12f01efede0d",
-      "size": 2299
+      "path": "assets/story/data/02/0003/storytimeline_020003081.json",
+      "hash": "8672bc6441513efc877d252649c4b465e4f6969585f90dc954d8aecc403b6ddd",
+      "size": 10029
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041716.json",
-      "hash": "4c61f58568d6049c14db4ecc0fa90bcf80b46fc693499f57133d4aafab70e8f2",
-      "size": 2579
+      "path": "assets/story/data/02/0003/storytimeline_020003091.json",
+      "hash": "d377f305cc0106f64637b0a136e52ca729816dda22c74603b4642079415ce6e6",
+      "size": 11374
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041717.json",
-      "hash": "2fe2a2ca00486dbf2f54c656360d2ef8680bf7c44aa6a5ecf04106ca3b779796",
-      "size": 3673
+      "path": "assets/story/data/02/0003/storytimeline_020003101.json",
+      "hash": "a980de5c7a7b6513f61b9a7f14b4c40ccd90dab6a1eea191711cf518fabb5e14",
+      "size": 6085
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041718.json",
-      "hash": "af39175ea496c53fbea5e05ddc8f81779ba3a350557bb3ddd637d679f2823832",
-      "size": 812
+      "path": "assets/story/data/02/0003/storytimeline_020003111.json",
+      "hash": "e6b1d333ff9a3463cfc005f46ec2044af2372b7eefa0bd6485a328a2ceede483",
+      "size": 8725
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041719.json",
-      "hash": "aa7fe6dd9232f902637f1394ade3a2e06cae9f0df310790ca5c23190800481f2",
-      "size": 1192
+      "path": "assets/story/data/02/0003/storytimeline_020003121.json",
+      "hash": "288a0f785d7316d9c89c487656d54c48ec5845ddcd4cdce0e927d4064e321d78",
+      "size": 12247
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041720.json",
-      "hash": "e1a70a5bee51b8fa583568db1ece3628004ad84e907630c554dbaf34c1654cf8",
-      "size": 18789
+      "path": "assets/story/data/02/0003/storytimeline_020003131.json",
+      "hash": "05ab4a984a6894906722b3c8957a2b377ad3cebd35d41506a92135206226265a",
+      "size": 3058
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041722.json",
-      "hash": "0eaca813037509f787cf1b3e8aeebc332a25c140d612cedfa50f15cd1607b208",
-      "size": 1617
+      "path": "assets/story/data/02/0003/storytimeline_020003133.json",
+      "hash": "7891de8c8286f27deedc82901a600c8f5a1877794f93b7adb7f46bb6b02638c8",
+      "size": 5108
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041726.json",
-      "hash": "a6f8313cbe191bdecd4e4ffe766010f440a1713f03ad4b79c4a34060aa7b4d90",
-      "size": 1878
+      "path": "assets/story/data/02/0003/storytimeline_020003134.json",
+      "hash": "d1b6dced30fb69b57bd71f7b87f45db6c7a4c38f36faa19ec1ac13ee2a87eb85",
+      "size": 704
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041727.json",
-      "hash": "ad756921ea21e2ae7022184b38ca75b50e43d51f0ddca16367c6c1974190c4d8",
-      "size": 921
+      "path": "assets/story/data/02/0004/storytimeline_020004012.json",
+      "hash": "239cfc783d555f7b723282069c8f193ee53a5c4f9f42f96b0ca71ffb212cb7b8",
+      "size": 7699
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041728.json",
-      "hash": "b39ebea6d32129f8f0f078a7e37ea50b927b47e69e1cda63fed5e363e4d63c0d",
-      "size": 674
+      "path": "assets/story/data/02/0004/storytimeline_020004021.json",
+      "hash": "37e636b4f5427e0d11a96480d73dcf4182a29ac0a98e672e4b3809612271124f",
+      "size": 11524
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041729.json",
-      "hash": "cae3123bca3054122ef12ab1e344e9017f4373197f8b90f9048bfd404f0ddcd6",
-      "size": 842
+      "path": "assets/story/data/02/0004/storytimeline_020004031.json",
+      "hash": "fb2f2cdaa1c02d2140444f6a94b984a290ffc8d8e13117062faeaa618b778cde",
+      "size": 9698
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041730.json",
-      "hash": "ad756921ea21e2ae7022184b38ca75b50e43d51f0ddca16367c6c1974190c4d8",
-      "size": 921
+      "path": "assets/story/data/02/0004/storytimeline_020004041.json",
+      "hash": "4f2409ad297e3fdda58b7c462651c1dc08be40b7f81d09d3a30cc7e8e585fa3e",
+      "size": 8594
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041731.json",
-      "hash": "b39ebea6d32129f8f0f078a7e37ea50b927b47e69e1cda63fed5e363e4d63c0d",
-      "size": 674
+      "path": "assets/story/data/02/0004/storytimeline_020004051.json",
+      "hash": "03ecc1ae0949e87eab7706b9cf94756fca7dd74c46bd5e94f97a7739ed99d513",
+      "size": 8692
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041732.json",
-      "hash": "0ac70c7c941e421152da5ba33f2a094c60ad1deaba9e1377520f81a364342a6b",
-      "size": 590
+      "path": "assets/story/data/02/0004/storytimeline_020004061.json",
+      "hash": "f9ab121bdcc89d0a674f7fe131aa7f4dfbdaa303578bc495328a24c26052bcdc",
+      "size": 7374
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041733.json",
-      "hash": "75cfde9ed155e1b4e696f6c2be46dc77434098259fcda4b03ae2d20630141238",
-      "size": 443
+      "path": "assets/story/data/02/0004/storytimeline_020004071.json",
+      "hash": "8b11f1557b6c55aca6f275fea9d13083daa51463ed3e7daeb9756302987e07d2",
+      "size": 3018
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041900.json",
-      "hash": "a7ed18f64bda3d03365324e67a81a0a4b4a0e95927e0d168da7ce96afe217a7f",
-      "size": 1122
+      "path": "assets/story/data/02/0004/storytimeline_020004073.json",
+      "hash": "299d6bf1702b03970b06bcd2994a937e7a2019f2bc80a33722c7ea0ac7f49a4c",
+      "size": 2475
     },
     {
-      "path": "assets/story/data/50/1052/storytimeline_501052100.json",
-      "hash": "00094dc16a7304135ecb690f512e6c235e3f744091676d02e3fb231e532bfbbf",
-      "size": 5974
+      "path": "assets/story/data/02/0004/storytimeline_020004081.json",
+      "hash": "d1a896fe47feb224f6d78a6e4cf99b5b9425aef22ffd19f0a9437768c13daaad",
+      "size": 7895
     },
     {
-      "path": "assets/story/data/50/1052/storytimeline_501052103.json",
-      "hash": "c4c97759cf624c47c2522514c79301c29f9c06f62b265ff952b0909a424a99cb",
-      "size": 779
+      "path": "assets/story/data/02/0004/storytimeline_020004091.json",
+      "hash": "2375f41796f81e90d3add71cc234b4c20c6fa876a9c0f7a13c165a7713d3b644",
+      "size": 8591
     },
     {
-      "path": "assets/story/data/50/1052/storytimeline_501052200.json",
-      "hash": "43fb0447b34ae89a5c51d6f63e5d59a9e0dbfdf3119e6f2b29787d31e30ae6d6",
-      "size": 1677
+      "path": "assets/story/data/02/0004/storytimeline_020004101.json",
+      "hash": "0406594fcf86b2d89d54ff5032b113f7b362172bfd764c5a2c3618e1938a066a",
+      "size": 6907
     },
     {
-      "path": "assets/story/data/80/1008/storytimeline_801008001.json",
-      "hash": "d19abda154e56347b898ce3f4bb461e0bbaf0723986ef9d0767891874c3599d4",
-      "size": 2886
+      "path": "assets/story/data/02/0004/storytimeline_020004111.json",
+      "hash": "fca21cd60ec4f5b67472b28e2e528d966eb68d4d328510eaf8f8bcde90496e3f",
+      "size": 12599
     },
     {
-      "path": "assets/story/data/80/1008/storytimeline_801008002.json",
-      "hash": "68b4a254c851b9cc2854268cebf44e80698d2baaae2ec02f24c60598fa7b3a36",
-      "size": 2044
+      "path": "assets/story/data/02/0004/storytimeline_020004121.json",
+      "hash": "a1c504a1bd80ced2841a0a1fbf6060fd54c8e0a925d269c2e78d292f467f08ef",
+      "size": 12241
     },
     {
-      "path": "assets/story/data/80/1008/storytimeline_801008003.json",
-      "hash": "5965eb2d27dc2fe4d381a2c5e4aabde1e3c9115739e8199922fde11d4d22a42d",
-      "size": 146
+      "path": "assets/story/data/02/0004/storytimeline_020004131.json",
+      "hash": "cdfb8b212754b684e47d99899b3326e704216786ea34482cb7aa1b413bb10cfe",
+      "size": 5634
     },
     {
-      "path": "assets/story/data/82/0039/storytimeline_820039001.json",
-      "hash": "50b72e0388a41ac3b937e0a9b14dce25f638366240e0e704229230d90a753993",
-      "size": 7458
+      "path": "assets/story/data/02/0004/storytimeline_020004133.json",
+      "hash": "8ad615f4f67af7b3059b2b820eb24c57cc350386d33dde69c266b8b001450bd0",
+      "size": 1549
     },
     {
-      "path": "assets/story/data/82/0039/storytimeline_820039002.json",
-      "hash": "ccec5d724eddc826dc996a83801b808018182d162d8414fc4f3ea9b9d8f06c9c",
-      "size": 3708
+      "path": "assets/story/data/02/0004/storytimeline_020004134.json",
+      "hash": "805ea39c59fdde301381bfbb2a570974b90bc2fcc947877f5c11f3ad5f04c4d1",
+      "size": 1649
     },
     {
-      "path": "assets/story/data/83/0005/storytimeline_830005001.json",
-      "hash": "b0492960a0fd65764289010b8c6ec9212bc66f6835ddd9f9a80b1f6f61ede7c8",
-      "size": 2938
+      "path": "assets/story/data/02/0005/storytimeline_020005012.json",
+      "hash": "4582ebb9e6b8449e9b41aca8af9e77d4655b7cf96537bf3561a13b3afdf90969",
+      "size": 8838
     },
     {
-      "path": "assets/story/data/83/0005/storytimeline_830005002.json",
-      "hash": "487c38f9d79324f432da03671268354c129454176e5db8c4c8fa94e76333b9f6",
-      "size": 3427
+      "path": "assets/story/data/02/0005/storytimeline_020005021.json",
+      "hash": "d1dbc58c41a667427ef69ad421ad706181987aaace6e7c6419f983e31b05f700",
+      "size": 6914
     },
     {
-      "path": "assets/story/data/83/0005/storytimeline_830005003.json",
-      "hash": "b4fb0741feabc4daf82997dabcb16f9e42418a85649b23d6f2d97862259390b6",
-      "size": 4142
+      "path": "assets/story/data/02/0005/storytimeline_020005031.json",
+      "hash": "05b94ae789f4242cb054706c76d754139b092a3ccd168c4411c410d94e61e410",
+      "size": 8926
     },
     {
-      "path": "assets/textures/chara/_chr/petit/petit_chr_0070.diff.png",
-      "hash": "8ceea30c07c495e4064ac06689472df14d3b47772dd76773f1807e40ed522487",
-      "size": 16858
+      "path": "assets/story/data/02/0005/storytimeline_020005041.json",
+      "hash": "70d7f2b1f945a8784e324658385ab4a451bb4d144f8771f696e0ed6834c2adef",
+      "size": 6841
     },
     {
-      "path": "assets/textures/chara/_chr/petit/petit_chr_0071.diff.png",
-      "hash": "305fc0f664f66808c06ec4c656fcd6c4934f2dd5a6ffadb7dd83ef131983371a",
-      "size": 17739
+      "path": "assets/story/data/02/0005/storytimeline_020005051.json",
+      "hash": "f1c3991b1ead2092b72088270b321bea39155df5fd6892e72813b09ee97fa291",
+      "size": 10406
     },
     {
-      "path": "assets/textures/chara/chr1009/petit/petit_chr_1009_000101_0070.diff.png",
-      "hash": "cb7336cc85dedb47738cd0b1598d33c73f244f3a0e4513c2b5686ac7527174ae",
-      "size": 15841
+      "path": "assets/story/data/02/0005/storytimeline_020005061.json",
+      "hash": "e19c196f37e8ca559a9c03dab1aeb2f7809aba70432c0d1f0bd2d80329f21821",
+      "size": 8678
     },
     {
-      "path": "assets/textures/chara/chr1009/petit/petit_chr_1009_100901_0070.diff.png",
-      "hash": "8ab24190c52452007c9172b2aa7d0e57ea5e18d8c043fcbddc8ce88f7f7163db",
-      "size": 15835
+      "path": "assets/story/data/02/0005/storytimeline_020005071.json",
+      "hash": "bc38c28c99c66c879cb61002270b17db1ffe3d906a7152f48eef0f0ca2638d7c",
+      "size": 8438
     },
     {
-      "path": "assets/textures/chara/chr1012/petit/petit_chr_1012_101201_0071.diff.png",
-      "hash": "842072117ec64dd4296a186a0c6f96618738af155d2fd1712b1e03dcdf641da4",
-      "size": 15445
+      "path": "assets/story/data/02/0005/storytimeline_020005073.json",
+      "hash": "1b41d95f0b14b097487d3258f45a3fa7c02fbfc3b00fd83bdac56644cfe17fa6",
+      "size": 3383
     },
     {
-      "path": "assets/textures/chara/chr1023/petit/petit_chr_1023_102301_0071.diff.png",
-      "hash": "8be7604c3524412baa472057262d2399671e94e700cab830e97865956998c527",
-      "size": 15281
+      "path": "assets/story/data/02/0005/storytimeline_020005081.json",
+      "hash": "d89fe46468d564e3071f53dec63a6a140e8a50c502ff8bb4cb00643adca9100a",
+      "size": 8660
     },
     {
-      "path": "assets/textures/chara/chr1023/petit/petit_chr_1023_102346_0071.diff.png",
-      "hash": "d4c61eb65da6d63c34829a1d770192d6276330948c57bb0edf2b67ff10795cd1",
-      "size": 15324
+      "path": "assets/story/data/02/0005/storytimeline_020005091.json",
+      "hash": "87faf91b899cd04b2a92c3c89501ea5d361982cbed41d5999236e1590dddab85",
+      "size": 8913
     },
     {
-      "path": "assets/textures/chara/chr1044/petit/petit_chr_1044_104401_0071.diff.png",
-      "hash": "d7858a346d27cf3caf81771a38d8edf3fa0d2e738d441f8ff826fe97d2fd28a9",
-      "size": 15451
+      "path": "assets/story/data/02/0005/storytimeline_020005093.json",
+      "hash": "e5efd73b106c2e47a82ae0c5f68dbb83773b739ca5a941e6f90a3f970333afe6",
+      "size": 2258
     },
     {
-      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_000101_0070.diff.png",
-      "hash": "46a978dec2e08b6f8cf68c0e89765298b62c4d587eed1394081c794b1e8283ef",
-      "size": 15858
+      "path": "assets/story/data/02/0005/storytimeline_020005101.json",
+      "hash": "b891b5ab9285fa5449d62307a1e4ced562701a9be208a277e76e60412b8c825e",
+      "size": 11378
     },
     {
-      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_000101_0071.diff.png",
-      "hash": "f7f8decdd6c0e4e0508d5def74624d99a7f9c90868608fc37fcffc58cec994ed",
-      "size": 15320
+      "path": "assets/story/data/02/0005/storytimeline_020005112.json",
+      "hash": "473b955d3ec379a622fafdb31750ee0a9ba45c96ae646a2e3b6f25f94d87aee6",
+      "size": 10037
     },
     {
-      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_106601_0070.diff.png",
-      "hash": "295a5acbc3516b63b9af9e06eaf4ac0c13ffb81537a687cc1b95f5222c760423",
-      "size": 15854
+      "path": "assets/story/data/02/0005/storytimeline_020005121.json",
+      "hash": "952c4e7efae0f970199b6d584a9ced05ea9199c6adebaac3477a9685cc610b33",
+      "size": 14543
     },
     {
-      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_106601_0071.diff.png",
-      "hash": "6ed8efa43178e19aed10fce3f82a557a3f20c251b533e82d003f162b0fb2c06f",
-      "size": 15341
+      "path": "assets/story/data/02/0005/storytimeline_020005131.json",
+      "hash": "32e26b763c238c119cb8d5bfba40b14d63c37aa30693afddf8d8c6f01c10c3c3",
+      "size": 3692
     },
     {
-      "path": "assets/textures/chara/chr1091/petit/petit_chr_1091_109101_0070.diff.png",
-      "hash": "03366514c3237df7638a54bdd2eb814f81851b777f809875a421e2e317833578",
-      "size": 16910
+      "path": "assets/story/data/02/0005/storytimeline_020005133.json",
+      "hash": "c09a594fd7b5d13954fb1792b5dae60b79c591bf63f16f3e57f0dc5c7db1352b",
+      "size": 4965
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1001_01.png",
-      "hash": "fb7785191f4a00201bcdd3746be9083386440c15c8eb6b89c37f42a487beb504",
-      "size": 250439
+      "path": "assets/story/data/02/0005/storytimeline_020005134.json",
+      "hash": "75e1618a4f1802def75285d2bead8908da1a3d70622f02f6b44b80dc78006d4a",
+      "size": 1236
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1002_01.png",
-      "hash": "f24df3cf15d1e158c43c0e08588b0cf5330e43240bf4f35187a8e7318f39bcef",
-      "size": 230088
+      "path": "assets/story/data/02/0006/storytimeline_020006011.json",
+      "hash": "a32a3daa1f89f5698f17740eea15fd201e57ccdf1059f9e5c3d2f92e1650d671",
+      "size": 13126
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1003_01.png",
-      "hash": "b2a1b57d9ccca21f2f25784bb0c3eff2ae8ddf10f9ef8698b341b5658afe0ec9",
-      "size": 178401
+      "path": "assets/story/data/02/0006/storytimeline_020006021.json",
+      "hash": "1f5ed712f3c97a18a4ff89386f914158debbd9bce6e9d5ac4fdb7a2d23e72f8d",
+      "size": 10387
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1004_01.png",
-      "hash": "5e931edcae295b31ed0ced299082becbe8ff913b3ff51d52d5fe3e235d71f7b1",
-      "size": 214358
+      "path": "assets/story/data/02/0006/storytimeline_020006031.json",
+      "hash": "47521ee7f01be2ef5da5aee7eb477122648607cfa05c34539d36360823d5527d",
+      "size": 8462
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1005_01.png",
-      "hash": "b42b97fd93233bbfdd660a36113f4e53ab637fe27d26c60a8d5cec8200970a16",
-      "size": 210185
+      "path": "assets/story/data/02/0006/storytimeline_020006041.json",
+      "hash": "e999c724d821d7484329ec4f736ca9d221c3356e2875a2635fb1656229b53999",
+      "size": 12314
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1006_01.png",
-      "hash": "c78b0df62f9c8cb0469418ff64f5f4c60b7e9f0bdcc48ee2998b53dd4d820186",
-      "size": 209188
+      "path": "assets/story/data/02/0006/storytimeline_020006051.json",
+      "hash": "2bc945addc508477c8f72fed3ca45146629cd17fc3bff1b69d7c4b8bc4d70688",
+      "size": 9239
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1007_01.png",
-      "hash": "259e585d46d48999aecf0221bacc8ed1a99450eb78a6a656bd5376bfe0cdea5f",
-      "size": 210579
+      "path": "assets/story/data/02/0006/storytimeline_020006061.json",
+      "hash": "27f8de2b8a30d60a60d3e64b774b1139395e1dedda9c9a24858d92e059e19666",
+      "size": 11274
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1008_01.png",
-      "hash": "f6750c1f950b666bc7dd7a6922c274f996649a4789639eacf187b07ff61a1911",
-      "size": 140619
+      "path": "assets/story/data/02/0006/storytimeline_020006063.json",
+      "hash": "767f2d7049b90f11bb6476313a0adc04619d73bbb19f4cce60a61494e725cb87",
+      "size": 6008
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1009_01.png",
-      "hash": "856cfd6cd82f0dd4dce0cdf8b2d396712393f1f6ed9778c30ab9c2303fc58913",
-      "size": 246510
+      "path": "assets/story/data/02/0006/storytimeline_020006071.json",
+      "hash": "f4d363bcf28ac4f2fdefd61f15832954bbb78695c8439405a7c23c4f9e289800",
+      "size": 13736
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1010_01.png",
-      "hash": "f8cfec84252945e84208756d926e8ee02e352310fe73b2738414319d3aefd4bb",
-      "size": 235057
+      "path": "assets/story/data/02/0006/storytimeline_020006081.json",
+      "hash": "02dc91ce372a8f66e0ecd5e6606082a1601849b07f3ec63b1b4fcb1e4cb1461b",
+      "size": 8266
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1011_01.png",
-      "hash": "c575e8bf0539d06b925ff7c2cfcb82940eec3f8f585525c11f1e95414197bea9",
-      "size": 247475
+      "path": "assets/story/data/02/0006/storytimeline_020006091.json",
+      "hash": "90c60ba78e7f46b6ea5d9ee7836387989b801b58bb2a1fa4e67ef7b86478ed86",
+      "size": 6878
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1012_01.png",
-      "hash": "3fac73fd1bb48de92af14a2e7719ea78eadb5d379e72a2e3f7065717b87b5126",
-      "size": 233917
+      "path": "assets/story/data/02/0006/storytimeline_020006101.json",
+      "hash": "43f482ae7f81d0f3a306b9832562ac648fdeb6b683c47fd70171c158ffee52a7",
+      "size": 13985
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1013_01.png",
-      "hash": "65fa445b50b7d3ae6e170c071c4fbb8b73c406174a190621b9748c0ab6fd7481",
-      "size": 245809
+      "path": "assets/story/data/02/0006/storytimeline_020006111.json",
+      "hash": "fbc3c129fc7e64e56e83055d1d6571dd9db68cca17fdc3c36dfaede30b25d1d9",
+      "size": 7864
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1014_01.png",
-      "hash": "f540f2a5901c8f5317d67df958e0f46f72c4d0776174b73f2de6ef2e00d83f7f",
-      "size": 251602
+      "path": "assets/story/data/02/0006/storytimeline_020006121.json",
+      "hash": "f9d84d8c590e1218f4d80d40ca2645d9ed2ef8e08cb4c499f400a6bcfe883d2e",
+      "size": 12492
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1015_01.png",
-      "hash": "ac6c32b89f45a32e5b8892618bb49ff4400a81ce8ec44f57f86f9c7417c16b2b",
-      "size": 242190
+      "path": "assets/story/data/02/0006/storytimeline_020006131.json",
+      "hash": "52b8345209b8795f1e68fd265d2662e66bc10deee3cd0a4555ad82b71d9867e9",
+      "size": 6404
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1016_01.png",
-      "hash": "262e5c5b1ff5e7e2246c8e3effd097036cd2e0e7445d69b0b17041ecb949ac1e",
-      "size": 182019
+      "path": "assets/story/data/02/0006/storytimeline_020006133.json",
+      "hash": "e19fe620518f64f1617bcf7e371cd0325fa891328c4ed4252283fd4545e663e6",
+      "size": 5399
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1017_01.png",
-      "hash": "5b5200a95fd01308b76bb33f6ba0bfafbed70b329f2050cf90452d6e9c8afe78",
-      "size": 268124
+      "path": "assets/story/data/02/0006/storytimeline_020006134.json",
+      "hash": "5441d6bf0cb7e638d369665f5ccf91eb8f6a5ca88c103a47a378b4b3b56c0c5d",
+      "size": 702
     },
     {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1018_01.png",
-      "hash": "5818db7c3d5ea800e2e92d325ec0b629781827134f9c4a221b5dc39931cfb000",
-      "size": 205286
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1019_01.png",
-      "hash": "e4ed3140eb330b64574a67607c31030735453143fd476eb53f4a3c2a0c2cdc6a",
-      "size": 254396
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1020_01.png",
-      "hash": "78447697f25ee3c08a70640b092f32177bf73724bcde661ac646c0d09e56ba7f",
-      "size": 191505
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1021_01.png",
-      "hash": "7a6aa44383bd3fafb88981ce3b337537dc9cada027c83fcf92014e2568056296",
-      "size": 215916
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1022_01.png",
-      "hash": "487a4774bdebde2bdc15578df3c019c8a9fd0eca25aa0f5c41731e756f76ba08",
-      "size": 200733
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1023_01.png",
-      "hash": "def76d2b8be1735988f355e3578d3c01485c3cea6e1d7fd5ccb850f4a31eb542",
-      "size": 249439
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1024_01.png",
-      "hash": "7ebc44ccd6405ae44d1fb70c64d689a9be150f6db46638c7e35d1e996a15676b",
-      "size": 254725
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1025_01.png",
-      "hash": "6a49610ec8c680d93a708d0a164d67006cd13f0a3d14ec980a08459008da4d63",
-      "size": 231569
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1026_01.png",
-      "hash": "97cf1fc35d5ce1dd73c8ebf8f8d6a95366dd57db4c4b5595e95f9468e86e50f4",
-      "size": 203056
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1027_01.png",
-      "hash": "6332ad231a287648a18746daffc27e0d81af6e38b7f533675d5353e3224786bc",
-      "size": 226464
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1028_01.png",
-      "hash": "0687783b36bc5c8d58867d03e7e0c660ab4625b32cb7066332bb9acd51c2950d",
-      "size": 253928
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1029_01.png",
-      "hash": "487bbd1d8b4c9a52a3f52f26dbb39d10552eb71df14f437f1724c5763b735940",
-      "size": 212270
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1030_01.png",
-      "hash": "f8867da0d92025688884f2ce2caba171245d8fce0433843b26726f5126cc97e2",
-      "size": 228234
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1031_01.png",
-      "hash": "156e27047eff5f3e01b5e3999fbf533be12cabc10485b3cbeb68a06807cd66bf",
-      "size": 188245
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1032_01.png",
-      "hash": "645cead3f58b83edc16625000fe28fa7bf3c5e8d50e0764f3e74c226ac70375b",
-      "size": 271508
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1033_01.png",
-      "hash": "adc8db9d76822087c56041ee9736032a525af30a09661e2c501997cdadc72a6f",
-      "size": 239514
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1034_01.png",
-      "hash": "33a4ee14f0590e045690bffbf9c8fc3a0e837b825ea56f8f4b26296f40a6ef4f",
-      "size": 177877
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1035_01.png",
-      "hash": "40f24f9ca33eb54a87b95879758d92b2841d07845b89e0d5383f53bfc7873f5c",
-      "size": 242820
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1036_01.png",
-      "hash": "6f68dfa42b161409aaa91656b40615a3d7569defb91242f5941eed146212db0c",
-      "size": 197386
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1037_01.png",
-      "hash": "9724800d8cf03c00a746f349afd08d64323889950fd0021a7ed78ca732b2f078",
-      "size": 179650
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1038_01.png",
-      "hash": "13f6fd787419453d23cdd421e1db22e42f92a10c0e16d4fe6033fc290661338f",
-      "size": 181195
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1039_01.png",
-      "hash": "b68729a12bb1c267c7ea137e992415afd4093ea18e03d2f59e600c63be50d02b",
-      "size": 226029
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1040_01.png",
-      "hash": "394e0b43bba17cc4b781ed92ba5b84d210a54fd57fbbded23865859de843dd28",
-      "size": 207525
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1041_01.png",
-      "hash": "77a754d5c01fe98d6f7a17d96be8b44e976c944c797996d3c9d03647ce414f8c",
-      "size": 218829
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1042_01.png",
-      "hash": "0e5f984d675f52f8232aeeb7e4a521d8d70bdd1f33ace76bc0ebffa6f9e3619d",
-      "size": 265826
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1043_01.png",
-      "hash": "a2fbc878f4561b09df21f4b631ac2b503efda3d91b66d02aa5adf2251ef6334d",
-      "size": 240390
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1044_01.png",
-      "hash": "5553559a1960ad4586db0158dab1fae6dbc91c6603e17aff459a61711d0b7ed0",
-      "size": 245518
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1045_01.png",
-      "hash": "c69cbf659cbec45d6b3a802073a7d3413f28aaac22681b30e2561deba582dba3",
-      "size": 230623
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1046_01.png",
-      "hash": "d971b77a6e644697ef3fa45893b41fad04edc15c02512a98745c40125bf18124",
-      "size": 234343
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1047_01.png",
-      "hash": "992cfb6afc613e6cfe8bda78520e8686f83c8269446ab5ad4f597eb0354e9a23",
-      "size": 226442
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1048_01.png",
-      "hash": "d041183d2b281bf8b63401f3afe1af728f90af1286dfcbb4c1b2214b77f6a552",
-      "size": 219581
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1049_01.png",
-      "hash": "148bdab6b277376344494dbbbc7f32eca516229601a4d234ef645977bf77816c",
-      "size": 234651
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1050_01.png",
-      "hash": "7856cd3b289979e187fa7affe31678f5e8a4127552b2062a1a4f5521a3d02835",
-      "size": 225439
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1051_01.png",
-      "hash": "998dedd3b727b94059efc2307ed049783fceb6b25cb6af9ae8f229fa842821f8",
-      "size": 240609
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1052_01.png",
-      "hash": "cf859f1044e3550b5ff2f6c95435e7bad2c218671eda86039e01a8fbb16af549",
-      "size": 163016
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1053_01.png",
-      "hash": "ad41234b4b92c3abaf6241eed6610cbbeb5bd04a0993054575e05a8dd6772782",
-      "size": 232143
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1054_01.png",
-      "hash": "1385d02994c06a11b200cfe6d2a76c581effc89bfef67aa5d2eacdd586fa0cbf",
-      "size": 240189
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1055_01.png",
-      "hash": "df4249ecda6c78f886714ea4b1361dfc431dec62a53e570a8fefeb8ef5c2425c",
-      "size": 251207
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1056_01.png",
-      "hash": "f0b417230ef236975f3a1cb6a4362a30b0375bab56756b069bb7779cb9547149",
-      "size": 205377
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1057_01.png",
-      "hash": "893d7940d83806af54a7ba2728e0a3271123bc1942f8da96f8a651b8f2d9c30a",
-      "size": 167133
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1058_01.png",
-      "hash": "215c14feff4960d7777440aeb892005393e8181a52eadb8b4745f79099547b69",
-      "size": 217361
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1059_01.png",
-      "hash": "5fc32886a27f482269af8ffe6e778ad7e21243152ce86fa1718f560662a2e6c7",
-      "size": 232878
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1060_01.png",
-      "hash": "b20308d61c27b3d0516e35c4ce688014767fe44798eb616fefa58a8ed20116c4",
-      "size": 189207
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1061_01.png",
-      "hash": "27ad230a348e59069bc47671681b03680c8af7a5a7f3b407ee0e18afeb7562d0",
-      "size": 194903
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1062_01.png",
-      "hash": "3253ca3903d510ee79f1b44f952b14f759d5d861f632596a6326a3d9afb90302",
-      "size": 194080
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1063_01.png",
-      "hash": "3cc324c6b31ddb32dc1a28ac21db9873ae4ef838c983c47921d96925120472df",
-      "size": 217899
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1064_01.png",
-      "hash": "a55d5939f24e5083bd548e5247097b8a72e3a6165c8b9459036dde49439c8a85",
-      "size": 242227
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1065_01.png",
-      "hash": "89ef932aa6e8844d60b09d48e04063c8d4772c8ed7b544260efc9f12ffa84175",
-      "size": 244634
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1066_01.png",
-      "hash": "117f43715705b21a3c177553250324f7aebeaa9de1cb39c71374f29aa925ee78",
-      "size": 188619
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1067_01.png",
-      "hash": "0f86f1a7606bfeca5d13b55729e22bc357e9d1808046121b451de17ba07a581d",
-      "size": 231003
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1068_01.png",
-      "hash": "19e7e9611da5332cf5658cabeeb12672066310340125f1ea4ff32f3795cea609",
-      "size": 227495
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1069_01.png",
-      "hash": "d75e7d2ede6fc523e24b3960a379cac263192eca53ebb8461e412c06b8661cb6",
-      "size": 255063
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1070_01.png",
-      "hash": "da4ccf580e191bc9cc0b97e848db997bb657466ebf9a1e81ca0b1e64f8cd60b7",
-      "size": 247590
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1071_01.png",
-      "hash": "60263cd223228d2f41b73bff21c67bba0c275a88be7cc563813d53c0a65f214d",
-      "size": 243487
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1072_01.png",
-      "hash": "77c12701ecc09e7a72b20956a7f7db7ed862f58f119cf6d5c390a8691651b666",
-      "size": 249726
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1073_01.png",
-      "hash": "c92cf5918f354b030b1c5948f04a70717eceb9f9148d5983e0f6154005a07705",
-      "size": 187178
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1074_01.png",
-      "hash": "f88aa8c28a2685588ca694c38207caebb9c73bc21fe1bcf4f663f5c19a80cf18",
-      "size": 251295
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1075_01.png",
-      "hash": "67122a3edc586ba51981226910db4d28c5bad9659793f67873aea880dc5f1b15",
-      "size": 220218
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1076_01.png",
-      "hash": "d6a15ea66c221e0a6704382ea22b9a54f7481b8a6e1f0088f97b5604109e2179",
-      "size": 225527
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1077_01.png",
-      "hash": "28cab496164424f267bd56f8f6768b0682e634ade237f9518907cf86d71b8c61",
-      "size": 258676
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1078_01.png",
-      "hash": "384fb85b56d3c5ab4e07d4a8a29c80a98ae32eb7b44ccf15bbeb01e85fe7a323",
-      "size": 239901
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1080_01.png",
-      "hash": "1a4c0e9ce66a4b875b89db3535d97e96b9cbbd95f0e9724d527f05f0e182fd07",
-      "size": 181464
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1081_01.png",
-      "hash": "6fa11c0350790e29607715623b3df3988d3b544f2107eada6db4da5eba1182df",
-      "size": 228763
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1082_01.png",
-      "hash": "e5ec58edaccd127dcdb560254d3ca4ab7c1fea640a9d131b9105d7cc9b70801f",
-      "size": 227754
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1083_01.png",
-      "hash": "71535bb6a850e843ec046b9bdc6f289d68c09bab7a591df6cd2fcebc4db4b237",
-      "size": 264108
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1084_01.png",
-      "hash": "1b51e5cbc7dfbeee63d032482b9fbaae0db68f85076fdb180d25b7fb8856ce2f",
-      "size": 234741
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1085_01.png",
-      "hash": "12a6e2c5b70275f5590d2c54d290658ee44a4d2fa340275de17459d803fd3244",
-      "size": 230074
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1086_01.png",
-      "hash": "406acea8c2b52a16c3bfd720a762b3814b263fe4a9391c92f8be7e102cf6772e",
-      "size": 250515
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1087_01.png",
-      "hash": "fb94f68b23cec4b82367c03fedfc8f9d2565678849e9428d66e6158ebba53497",
-      "size": 234924
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1089_01.png",
-      "hash": "577218322cd86a10c5adf94a66d50c2d9fcb1adfeddefbf500661b100eb9e725",
-      "size": 236799
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1090_01.png",
-      "hash": "54719d53a220e7b672bf64caa4ba6b358d4d407b090242fa8ae35f575cd83bb0",
-      "size": 151608
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1091_01.png",
-      "hash": "47a2aeea50b7d38322972900b7ba48deaf9457a0852bc3527efab5c5a0a45baf",
-      "size": 137904
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1092_01.png",
-      "hash": "442448ea9cd6f04a82d0ac1db7a419d43888d15233b8858f4c4c94bb110ae145",
-      "size": 219244
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1093_01.png",
-      "hash": "906220a372b025435349aa51f10493e02a87cfda4c7941ba6b6d15b81fa77a71",
-      "size": 231860
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1094_01.png",
-      "hash": "359a46becae30c66dd91fc77552642d165360dfdb3137d396600cb2fc6578e2b",
-      "size": 265162
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1096_01.png",
-      "hash": "82096fb87121feb3742a8a185446f07d34490d3cb5b633c678a56ce41b78ee76",
-      "size": 192260
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1097_01.png",
-      "hash": "17ab13e1f95f5613efcca2c4b836a19714c30344c1a92fac13a1f2bb3766275e",
-      "size": 224304
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1098_01.png",
-      "hash": "772beba0b0543fb0ab7dcea9bd80664d550f0d38cc4acbfb6b9e77bcdc0c1e18",
-      "size": 275188
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1099_01.png",
-      "hash": "f0665df0959d045f4429dcc47503e3c75a988eb1acd695039fa18b5db1dc5aa1",
-      "size": 234766
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1100_01.png",
-      "hash": "6577a34c8f2759e5a9ff38053191aedea1aa4ef287ab29f818cc4cb490c88e26",
-      "size": 250427
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1102_01.png",
-      "hash": "adbc94484ebea67b68c23e72c1cf71b68ae11bd6ed02b7879be146b82d3d54f4",
-      "size": 258169
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1103_01.png",
-      "hash": "f2d6a05b8cb1cc684197bf858c2fe16113d4a97d48d926f249e7f2dc840e3d21",
-      "size": 199765
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1104_01.png",
-      "hash": "df64d0da8f59185b003d888602e9e9ea76df328361c2a3d287eaebd5dd429835",
-      "size": 264875
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1105_01.png",
-      "hash": "812ade20746bb860ad17fad6ab52dde0726bdbcd89ff9aa98faa725c9d65af60",
-      "size": 229452
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1106_01.png",
-      "hash": "362be75546f3371092638935b67603d783af0b7716b354d8040d9f82a3a42b48",
-      "size": 227233
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1107_01.png",
-      "hash": "f8ce29ead72034aa818561ff72ac0354191d83cbd37c17f5da67dbdc2b67c138",
-      "size": 278917
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1108_01.png",
-      "hash": "0f3a9d3402ab571bdb6bf9f464f3c87066c631b50ab2d86955d6df68272a1aae",
-      "size": 182783
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1109_01.png",
-      "hash": "a53746b33f35cb718903f15e10c6445b074d0c054b7be29fb2954c8dd411c701",
-      "size": 208704
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1110_01.png",
-      "hash": "f46df6de858ca0be300bd1a9214d4aebce327df1ba0f763bf617c6141a2c565f",
-      "size": 160526
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1111_01.png",
-      "hash": "3f2ad58c55c2873f5056d191a19dbc7f8d9e6a1d4e687cbba29dec133c253480",
-      "size": 216282
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1112_01.png",
-      "hash": "b12d48ca30a7132b5a38bc00ee1972e03e97815e5e7b819786a861bedf71e620",
-      "size": 228552
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1113_01.png",
-      "hash": "d3205ca1ec746fd798858f04e3ec5a0b09dc909842fcd8c862ad77a600c8d2e5",
-      "size": 237071
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1114_01.png",
-      "hash": "309ee665d3c18636a5806490d3c3fd92429b9071bc958de6cccf1a9bea721973",
-      "size": 210151
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1115_01.png",
-      "hash": "82ee7f566034e8babc750a6219668ab360e6a2b0d394532f8270ca0f8db7203a",
-      "size": 149662
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1116_01.png",
-      "hash": "5bab5699c7eeaff47b1eb32b14d8174ddf26d1e420b9142606c84673b354ad76",
-      "size": 199258
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1117_01.png",
-      "hash": "72966ce806a2e07c0bd3ee2ddc798793f4764cdab6d686f80d0777db1f266e92",
-      "size": 211644
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1118_01.png",
-      "hash": "298eae309aa046aa9acde0e0e80c6ce36c1512348523435ed73ea7bf0de2c01e",
-      "size": 238752
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1119_01.png",
-      "hash": "1c2471898b41f98cc4f5195891dbf40503d5675c3335e70dcbb30187fbb22233",
-      "size": 250591
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1120_01.png",
-      "hash": "da618c97f20ad927437fc6c4d48b8da8a5981f923b3213ecdcf95b6b1818c990",
-      "size": 282855
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1121_01.png",
-      "hash": "bfe6c27c6fa0a81f16cbea648b0bff36b5fd44242e9f8acbfba3f5d287eff7f4",
-      "size": 169269
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1124_01.png",
-      "hash": "5e21847942b58528a5be11638cade4264f39a5214961f4b2955c69ab26ecaf57",
-      "size": 229984
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1128_01.png",
-      "hash": "fb487c9237c2b0f757728322ce21f7749e52b8f35be3113732e73928bba781f0",
-      "size": 269853
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1129_01.png",
-      "hash": "4bb881617ba444a8bf474054e31c129ef7230c51e448be26faa265f6f5b812bd",
-      "size": 226255
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1130_01.png",
-      "hash": "6c44bc7659411d3f3844659a078e70954166944997ee18ce105802667db871fa",
-      "size": 208390
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1131_01.png",
-      "hash": "d01088b2f5d8f1da0aa58e1b3d250435c454d7e8aa704143965a13e5c78952c3",
-      "size": 229927
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1133_01.png",
-      "hash": "c05a6657a6dd6e6e7187d28c1f01352f5a91c3a3490e4dc86972264d79844902",
-      "size": 230733
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1134_01.png",
-      "hash": "d5653856219c0ff4b7a2582fff01a0abe91cd5d96852db5fc031cef1529906f9",
-      "size": 225012
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1135_01.png",
-      "hash": "0e5628adf354879893ec810dfade1ab68ffb9e4a5e2302abebfa7d9eb5d16d4d",
-      "size": 220584
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9001_01.png",
-      "hash": "676a2ea96f0652fa06ab74080f8708bff40fc8079885f8a6dca4648cd714d693",
-      "size": 211151
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9002_01.png",
-      "hash": "0d7a4a0c90d30808e01965ddb569e57cc5cfb61f5b4ba256bb47c01efcb2ee6d",
-      "size": 247891
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9004_01.png",
-      "hash": "07b92ff555ce5c8c2f36aba59333eb94a22b591314c3ff82e1e2c7a0f3a91834",
-      "size": 210642
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9005_01.png",
-      "hash": "47a24ac6e5ceba2b580b0c03cf14df1ba40068f0e05dc62171c77238cda4d02f",
-      "size": 208850
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9006_01.png",
-      "hash": "6a97335fb500c74864f62e3a2dc66ca0ad01c7de7c6d444f0ac97687ecbc98f0",
-      "size": 240831
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9008_01.png",
-      "hash": "9e225b82c18f006e846c6c693d0244462517deec6e2205afe4834f906fee1d38",
-      "size": 220155
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9043_01.png",
-      "hash": "7b4f5788ad4f6fc555ea373fc0a122646c9cc3cc2d43d0c009e3f7af318ec858",
-      "size": 213183
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9044_01.png",
-      "hash": "0af844a7025cc341996e85e14970f5b2e2fa04268b04866771731184a80f0e1f",
-      "size": 261846
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9049_01.png",
-      "hash": "998cedf25a8ec77f3adc525a407433d040ea8eee3a7462f259c6167e85cad9b0",
-      "size": 254070
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1001_02.png",
-      "hash": "43227d353f6444523176f80bc1066278765f1202d607b53c95880735c01e053f",
-      "size": 245339
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1002_02.png",
-      "hash": "b98e3f249ef09ce63d70aa27a74baec3b47ae57ed5218527d7680a529601a32f",
-      "size": 226568
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1003_02.png",
-      "hash": "7ac9e09bf95abc7ad26aad76f50e73197c5b76b900068b8a11e2da9b7b3a1ffa",
-      "size": 174399
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1004_02.png",
-      "hash": "a3320e43a6509a210c64d75d748dbd900157d961188bcbf3cc0e65ce00c44ba5",
-      "size": 213050
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1005_02.png",
-      "hash": "d39ac769834217383e08cfa69718fba13b9552ed1903b0154121e9d211dce22f",
-      "size": 203009
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1006_02.png",
-      "hash": "cb9463315bab777bf582344f4d21f839c39f869bc7b9b7e5525a28fa9fcd6a23",
-      "size": 204996
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1007_02.png",
-      "hash": "893c83c39e4ebe7c09a09ecf84b7c6fda951a028e8dda7bce882b52f9dc6c152",
-      "size": 207982
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1008_02.png",
-      "hash": "7914102abe080dd71c13dd740121f7e8701e4c4439b72448176f3d96873394fa",
-      "size": 138444
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1009_02.png",
-      "hash": "027956ba6fbc73763c72abf86d50f10310f85c5ce5e0a689d4ea7520174460ce",
-      "size": 239714
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1010_02.png",
-      "hash": "d7b329bedead79f403213d45cea349ca3bd02219c0bda9c093a3fed0675d1ca6",
-      "size": 227875
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1011_02.png",
-      "hash": "92eb36c195a2ca25ae917ec9a91ecd5c675b28abdbc28de091c6dfeb55d9c8fe",
-      "size": 242017
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1012_02.png",
-      "hash": "7bc41bb59b86fe645d8f095b6ec6bd11554bdb297780e360e87602dd84fddab8",
-      "size": 226860
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1013_02.png",
-      "hash": "b153131be27d90425a6d90238b60a28cf271066b59dd71c84d827bd1ec28ffb7",
-      "size": 238680
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1014_02.png",
-      "hash": "bdd0080436cecccbfc99e5b5c9860939ca461cee508ecb88383bf890e54b64b0",
-      "size": 245056
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1015_02.png",
-      "hash": "853eec3fdf62363d6f1e29e9faceed705d3feae82b49cdfb5818cd5333564b1a",
-      "size": 234255
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1017_02.png",
-      "hash": "f624d486c0fe59926d546fdbf560e9f88ee21a327e13474c3c1c0f3e9aa5644b",
-      "size": 262586
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1018_02.png",
-      "hash": "aeee5cac2828b7bb00a90212881b7590dd6a4fae7615125f69b0c1864759f4fa",
-      "size": 198903
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1019_02.png",
-      "hash": "b8dbfcf142ddd734f70ed98c92a3535b5b9e8e424ca8d0245b0516efcd2286d4",
-      "size": 249562
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1020_02.png",
-      "hash": "2c973dffe04b230d7a4288b62e8a0971ff1f39bad363755cdfdfeead499df302",
-      "size": 186703
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1021_02.png",
-      "hash": "d2e5f3b8e1f39b7302d9429efeaedf2e1c46c33fd4b64783a7d4586829dfa456",
-      "size": 211103
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1022_02.png",
-      "hash": "03fd2841fb1273183df2f6da202b7dabe932326b9794bd25f00b3d45d2529a5e",
-      "size": 192530
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1023_02.png",
-      "hash": "dacd193f8f835809513922ef35fda1e43e2ccdaac6058a63a150e01b8c46059b",
-      "size": 243012
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1024_02.png",
-      "hash": "d69b9b952414c897d167c9af9b4ec0aed4c451da4a44d626e3fd2dcd8be87351",
-      "size": 247926
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1025_02.png",
-      "hash": "bea539bf259bc74b628863724d3d0825f926a19070ccdb1736a5ff9d502e1abf",
-      "size": 227388
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1026_02.png",
-      "hash": "6cea9dbb0a2015ca88f8c8ec5fe42bcd27d9378a165057ecedf1973f95c25ea9",
-      "size": 195777
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1027_02.png",
-      "hash": "bc13ec29fc52a5e24e9e79eda29c36cad990732d64b11420f2df81848f0e94d6",
-      "size": 222652
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1028_02.png",
-      "hash": "8fe5754fd4ed37ff9912cda4609256e586fd4459ede17298ea2e1fb35accff77",
-      "size": 244661
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1029_02.png",
-      "hash": "666af3df1978db2bd81950c9100bc35af7ef00568c25507208308c8c91869583",
-      "size": 207144
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1030_02.png",
-      "hash": "56b1e194ff28bfe019c8bfb90dc6658a9536bc59ffddba75d8961304913a8d34",
-      "size": 222963
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1031_02.png",
-      "hash": "a125104c7af9c28d692f9191e066ec34a6a1c2becb69418e140ef0d5c295ad4a",
-      "size": 184098
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1032_02.png",
-      "hash": "f53db7b6886b426047681f2d66f62b22904f7d9d7af0a6db0bd83c7391f90493",
-      "size": 265470
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1033_02.png",
-      "hash": "c9df7639d1bd682fd34917c18c5c0d80c321d3d6786792a5c5bd97845d82a5ce",
-      "size": 234799
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1034_02.png",
-      "hash": "86094a35a95467ba4ad0e76af352a4ccc72307aac195f76536c92b3764e2ddd6",
-      "size": 173557
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1036_02.png",
-      "hash": "7493494c3f11d8c2570b80875a5bb4ff089cc4cfcbf88369a9bebbd18a02fa15",
-      "size": 192535
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1037_02.png",
-      "hash": "842a118d6e531cf4c1efbf0ef5df6676755404905f5b10aaffb6d47d1b6ea84a",
-      "size": 174572
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1038_02.png",
-      "hash": "e728a6f112e81315da360fb1d5e00562789828650a2f77cee8798b94f60c513d",
-      "size": 175650
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1039_02.png",
-      "hash": "8832c41051e057f27e925956722234dcae5dc27025aa21cc25c0269a78c8d2f7",
-      "size": 223680
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1040_02.png",
-      "hash": "ecaf1ff237de0ad52ca7b9d39924e31e64e32f8d0c9035d46244277d1d3426f0",
-      "size": 202498
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1041_02.png",
-      "hash": "6f4284eace396a43fe2ee14169d5fc044845974cacadbc5f0eb78e431343aa70",
-      "size": 216325
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1042_02.png",
-      "hash": "4c9325b5ada67180d4b9c052239de49198877cc37005e18ba79ae581ec8a74d6",
-      "size": 260633
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1043_02.png",
-      "hash": "583c3c5452a26724b05e164224bf1721d92d1532c9e3c5a290ea4ee123cd7846",
-      "size": 235406
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1044_02.png",
-      "hash": "20d61bf3af5720117a49f1749d4b08eccb7dad8b1d1a4c476e42ff6efb515b13",
-      "size": 239671
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1045_02.png",
-      "hash": "d3b027f2bd0f181c72e5120591b043ab8b7a1a47a2ce9fa2b2031c386dbe6011",
-      "size": 224863
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1046_02.png",
-      "hash": "e096a48b1a1be6296e4923f655264364216b9876444985ca412c87308fb9657e",
-      "size": 228611
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1047_02.png",
-      "hash": "858643f0893fc230542a2522e0032a0f0a95d7a21ff693e12a69999d265de175",
-      "size": 221703
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1048_02.png",
-      "hash": "f6083eb317db8b4105e61628191d689bd06525156d542c7b37108fa2164763dd",
-      "size": 214960
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1050_02.png",
-      "hash": "139c876de2c77ea8ec2c3be7c3658c850591d2ddfe11f5be5b268fb05f29ce03",
-      "size": 219413
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1051_02.png",
-      "hash": "9665b10e24419fec14b7c54b7c8491f29fa973000674efbf401859ddaa5985a2",
-      "size": 233464
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1054_02.png",
-      "hash": "40747f7c37b8f33754a44a12bbe4cae4bfc5798bd4708b159bb4e1fef358ba3e",
-      "size": 234362
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1055_02.png",
-      "hash": "123991723bf03fc9dcc94546127c5d9787f000759c91ec346659eafffb80aa0f",
-      "size": 247040
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1056_02.png",
-      "hash": "8a874ff2795f44de984481e2636fc404b09bec4e72446cf7294e2e50dc879d28",
-      "size": 197925
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1058_02.png",
-      "hash": "a93207d23f3db619f7d948488fc16a664933682ac454a077183f27304c347288",
-      "size": 212719
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1059_02.png",
-      "hash": "778a583ee743261e0fd0447874a9f94a6b5347a635879bf082fe6de5d9d6ea1d",
-      "size": 227537
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1060_02.png",
-      "hash": "c595966cf469bc7ba8ba54d597093ccfd131e84670d21901acb09e89cea144dc",
-      "size": 185225
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1061_02.png",
-      "hash": "ebaaba5c06d529e985bb327f68b18b16675a9c1db8cd09c629e8a176d7fe37da",
-      "size": 188437
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1062_02.png",
-      "hash": "e8466ffdbc5c92f6f6528e104aa8a0fbcf87219f973ee16f407e13b61ee2cbb7",
-      "size": 190546
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1063_02.png",
-      "hash": "5385e4c3ecac64b71af76bbadcdd5d7ee12c89ebf0ceb6b9f8810dd4457f75c5",
-      "size": 213018
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1064_02.png",
-      "hash": "3504318aedf44e0579c27fbe1732c96086f31721b9736f8f855d96786fe22d78",
-      "size": 236200
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1065_02.png",
-      "hash": "7bbfb7f85c7a83ddf6af4fe139d40ed98e70358bc26e5a737db5d78afce500a2",
-      "size": 236976
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1068_02.png",
-      "hash": "365bbdc89245f5f23a68044282b791fc108e560bd6ce6c38825333b29d2b4ef9",
-      "size": 223979
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1070_02.png",
-      "hash": "d04fc234bce0ce9e5eff21687f694a34f3f628fb4af4e90145565ce2cd6c3257",
-      "size": 240872
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1071_02.png",
-      "hash": "1b500e721031971e16c3abfded2db86c5928b9a6e988ad4ff694f4d990186182",
-      "size": 238011
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1072_02.png",
-      "hash": "7831a7b9a0e6265e63dc6865e01e3b83141452f6ace71cdef1616d2a4b879fbe",
-      "size": 242683
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1073_02.png",
-      "hash": "4284fd0eb364fbabdde8449cc7eda4526a5d649bef2d9ce0d1e8a8cff3d9fc78",
-      "size": 183169
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1076_02.png",
-      "hash": "e7bdf3328785f0abf5558bf390f4366a92cbe829bb853c15a7307b58937e12b7",
-      "size": 219340
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1077_02.png",
-      "hash": "a54415de87a8598eb3adb1abd0c65f322e94f2206ac212b22e256ffa2b30e18a",
-      "size": 251837
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1082_02.png",
-      "hash": "daffcc15546181fc32a2840bfecb11396d6455bb83ae114ae1f4fe47465d7fc6",
-      "size": 221067
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1084_02.png",
-      "hash": "6da0b9659bdd74a94c1ae97f9793540af4015fb4552735fbca5c79c477465fb2",
-      "size": 228310
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1086_02.png",
-      "hash": "1b94289b13caaed97b76633c7c30f5af85753cd0d9536210fb102ddd5a7fb482",
-      "size": 244323
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1087_02.png",
-      "hash": "9ab65355bcd4258742ae7b6accfdbe81c47165430f4bd5b8f7451e714a1c1df2",
-      "size": 229117
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1090_02.png",
-      "hash": "c04fa9208ce236c0a4b77de3ed8cede72281fe8d67605aea989e12d5d251ae14",
-      "size": 147777
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1092_02.png",
-      "hash": "fd4ecedf8e0aca388041f17284ac3fd723584976b56c3c1e524077db7f0f2dd5",
-      "size": 215487
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1093_02.png",
-      "hash": "86c7d4faf4501385caecd9fd37e914158dd0453f395671e6e0485a98fd2d293e",
-      "size": 226027
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1094_02.png",
-      "hash": "bc4e3870fa242421a8f18d6bbdb9f5531456e5302edc4f20dde34e8a5c134af5",
-      "size": 260601
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1098_02.png",
-      "hash": "351f4e0d96787673d86dced08d7a5c30eab651170273a33f2479b5fd41296977",
-      "size": 270472
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1103_02.png",
-      "hash": "134a2534cfdb5bcc7cce72cd8d60e798995302500e8845d9e52e21cdf6797d4d",
-      "size": 193696
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1107_02.png",
-      "hash": "9cc35e937b6707fa6fdbd81bce5a6c78614ac06aa982a2bd666d602181e6bd98",
-      "size": 272267
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1112_02.png",
-      "hash": "29859a5910b65ccd7717b6e57617db2224c582ed117f3872c7ed32ff4360a47b",
-      "size": 222592
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1124_02.png",
-      "hash": "c9169698994ce33b6f6852c7d4660b9e51770912e5ac97b2c77af2f1dddfc5e6",
-      "size": 225688
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1130_02.png",
-      "hash": "6185d6484d7cb384ac7a15c7c09ad24208a24e1216907530304d47843d6ed101",
-      "size": 201475
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1134_02.png",
-      "hash": "81a574c35635d117b22c919f0245be534c4814d844c753f10e927b546e908f0d",
-      "size": 221722
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_9004_02.png",
-      "hash": "5d856f70577c785661bff575364d0e6779402717689b743d88f050834134fb6c",
-      "size": 205719
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1001_03.png",
-      "hash": "d29893441473eb83ea81b8f4e5fc7044a66ba810ef8a75160fbca27537768e68",
-      "size": 322457
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1002_03.png",
-      "hash": "bc911f9f4b87f4513877ff42685e9188851d6da82f2ce17d6648a564cf9d7340",
-      "size": 323302
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1003_03.png",
-      "hash": "b41c2431bd231868234b5fce5179a17a984a03ff657ad36d5a5de6dd9673d4ce",
-      "size": 251958
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1004_03.png",
-      "hash": "8a5136cd4fc3ea143658106772728a7b8916e15cc29ca83d612079a43d3811ef",
-      "size": 262165
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1005_03.png",
-      "hash": "47cb281ca432696becd197c543d8a7aad39c7e22d6e816705be9bfa7b422549d",
-      "size": 270097
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1006_03.png",
-      "hash": "6e02fc2ec21884ff675de617df3caf582b6a421ba3180172d879bf5cea246150",
-      "size": 254253
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1007_03.png",
-      "hash": "19e62f46779e905a138058988a91ce4202d64bddf11e1e86f1c41220060edf7c",
-      "size": 259333
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1008_03.png",
-      "hash": "48be979f8a7ebdcf006ab7c5b80c67a8b415fe92e3243db287484d353c1186b9",
-      "size": 166623
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1009_03.png",
-      "hash": "4bab045e7a44900390f9c47e177416b950bd0e48691c6645bc0ff2b95a0d18ef",
-      "size": 315069
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1010_03.png",
-      "hash": "2b4617f79fe3afbd136d5803d7c5a9c1cb9f82ebce572c14965e21b3ea18b86a",
-      "size": 291070
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1011_03.png",
-      "hash": "72a9a9f84beb2f56718bade33271655e4a78bc636fd09b2147d79cd30246b30a",
-      "size": 312110
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1012_03.png",
-      "hash": "68c96ee87384ab27c8447dabc4850edcef275d214162c9fb39647c6ad66cff3b",
-      "size": 293498
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1013_03.png",
-      "hash": "4ccd793f2f306eda17d5c5d3698efb2a4eb86f5eb762a93476b92fcff6df1877",
-      "size": 340048
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1014_03.png",
-      "hash": "4af012d0d2d5300daa122a3d4b5efddf26aaf163ba00425921f744d6a3b99cb7",
-      "size": 337360
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1015_03.png",
-      "hash": "282991f0234d0467005e9ef28092c23e832c1813b2525260322ef78546092acc",
-      "size": 309970
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1016_03.png",
-      "hash": "c0761913d9628eb9691d0a5157ce179c09ce69654252358a38cb8356b2cda981",
-      "size": 273630
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1017_03.png",
-      "hash": "c65e826c37ba7278950ded73b3c2aa40be3b9a5bf4e529ce07228a2822f33be4",
-      "size": 349797
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1018_03.png",
-      "hash": "195027dede35074d0ebd4be123cef632f42d39c35fdad1f108cdcf7cc7ead332",
-      "size": 255811
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1019_03.png",
-      "hash": "5996fa3edff592e649e5d07749370173233b1c69752736d8ac7ee4d6bd3cf5f2",
-      "size": 326962
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1020_03.png",
-      "hash": "d0f53bae26627d14093b459777d5c40c5c197d92015efa6d07f8d812341c9244",
-      "size": 255916
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1021_03.png",
-      "hash": "894dd5e722f18ae5954fd3fa168c0e203592b26d5a25354fba89d30a5d7432e0",
-      "size": 310553
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1022_03.png",
-      "hash": "8fc6464cdba0da38ef40891e4609c09be93d345b51fc3a6cc98d3e812ee3734b",
-      "size": 273378
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1023_03.png",
-      "hash": "1b1fd304bc0d0217ceb5ba6c8569d59dbf99094c422ffc4fb3ba5567eeb6cc93",
-      "size": 329807
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1024_03.png",
-      "hash": "cd2e316cd08affae457a4e3cacc569536e7821d08dfbb84a4cfda30f14f541f5",
-      "size": 329432
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1025_03.png",
-      "hash": "06e9200d9c42e228a200e23c9a8e0771d0591858bce3af8039321cca8cf5a369",
-      "size": 327337
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1026_03.png",
-      "hash": "24ae60e447f684dc0854722b24d0831b96afdd7b7288fc3dadb90f5a77ba6088",
-      "size": 310509
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1027_03.png",
-      "hash": "7dd18a5981e91e3a47c7ad6ed1fcdebcac6f45a81139de50c8a604ba27da4ac0",
-      "size": 285810
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1028_03.png",
-      "hash": "e77a66db974e6ec337fa40566d6f0ade5cb8f59f81361be89834c0c1315f28b5",
-      "size": 328802
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1029_03.png",
-      "hash": "43bd159f3c9072a99975be73ccb002d2154656b3056f918ad8d565006c0676aa",
-      "size": 281977
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1030_03.png",
-      "hash": "f6baa1a5612a0e62c525f93a320a993c57abd52d2c78d1fe38b56444d1a56de7",
-      "size": 281804
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1031_03.png",
-      "hash": "8233e93dc60580df7fe6dd899ad227b108dd5d33bad641d59f80c3062fb3fed1",
-      "size": 244269
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1032_03.png",
-      "hash": "f56d483656372ef38b37668d336ebdd96beddd9e9c6ebd4a92de9a5d9b394e75",
-      "size": 343543
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1033_03.png",
-      "hash": "58a57882d59dbd85abf4d4e01eb1fdac1a0b51e26281b5ce5dfc4baeba76a095",
-      "size": 302575
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1034_03.png",
-      "hash": "b1ed2c9d4173bb8694349ffa7b0f2611138bf4dcf749757b5b3d0f6c1f601f40",
-      "size": 226265
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1035_03.png",
-      "hash": "b330035def2e665a292600ead3c652e8c94d56da0f5ebe140f07ad7a44ce61c5",
-      "size": 326547
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1036_03.png",
-      "hash": "42fd8ff64da6f7e088ab8c7bb63689d7dfadda6ad6cbdd51377e1f1fd1c802ac",
-      "size": 251355
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1037_03.png",
-      "hash": "6f680fd91ed2dbafbba39009739c8db8a4a16da0ff4b64e1e07dc71f77525c54",
-      "size": 276727
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1038_03.png",
-      "hash": "6a05394a59d0fdd20cd192535ccf88f14753f4350bfcd75d2d31927cd51f72f1",
-      "size": 277330
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1039_03.png",
-      "hash": "7e5293e6985e2b7bbd8e924a5774ed5285a3a34abb0842748d38aff9aca34777",
-      "size": 303378
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1040_03.png",
-      "hash": "155348fa56c82921921d77d58de9d6fccbd88f117c7d475928141fc1eb54a572",
-      "size": 248075
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1041_03.png",
-      "hash": "fa6ddc7327dcfa0537d9495e212c087a3d88cc758a7c5913475b3a8fd5fc8d48",
-      "size": 315466
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1042_03.png",
-      "hash": "698aa1c0a10d1d50c08e0816e83bf4b67d2c503d84825af92fde91114ad45d21",
-      "size": 345591
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1043_03.png",
-      "hash": "d901702458ab2dfc54a082853a067b166ced7b08fa20059e83e1f793f4136096",
-      "size": 315511
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1044_03.png",
-      "hash": "c7d18b3628a0d1e03b29385efc796459e9775d9e2d1cefbf6129747787612274",
-      "size": 308376
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1045_03.png",
-      "hash": "1f1e50c879e255f1e5045033e00f68577384d610c1dcf89735b9c207e12f7b2b",
-      "size": 299859
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1046_03.png",
-      "hash": "5a8eddd80e3cb95f9c23021fbd33ca3cb76c503081f03272c3cc84e376778909",
-      "size": 295735
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1047_03.png",
-      "hash": "1b949e39c60d827e16b50d3db06481fd13f2e3d6c5a235753dc32f24d1994889",
-      "size": 338774
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1048_03.png",
-      "hash": "256b2f943fae0e9c38240de889e80371d676df556e6d12bbf5dc45e59df88b46",
-      "size": 298315
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1049_03.png",
-      "hash": "1ad40ab35fe8b71313006d7277c9c94c1f6b8eb88789a500d28cbb4e36fbea77",
-      "size": 325463
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1050_03.png",
-      "hash": "092c847dd1139f6abb642b7d9c47f72b6f0f492414b45af527d08192ac84ed80",
-      "size": 314502
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1051_03.png",
-      "hash": "e2b5e976e42785d2ea240d813dcefe8587b1faca38b5e1c322d6e35004f75813",
-      "size": 321905
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1052_03.png",
-      "hash": "cdeb53b3439ba6965df7e6c517cec2785eb45430dbf9ce1d8e6ddadf870be687",
-      "size": 245332
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1053_03.png",
-      "hash": "90d1ac7e9fdc0ddcf8b37ba8a489028b6e55150180379c4f5eae3333ed7c2f8f",
-      "size": 316855
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1054_03.png",
-      "hash": "7384114628c383d4a3c7b04ed5697d4bba25fca3be41307d30183753ca82ed92",
-      "size": 303048
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1055_03.png",
-      "hash": "2b912c201c9445c41b13131e5944dc0fed3f2af68fdf13c4cf883e12b2f760b8",
-      "size": 316825
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1056_03.png",
-      "hash": "2571a415f4ddf7f158b71f461ab6585d956a0916b7939a868daaccc7f6d6f1aa",
-      "size": 302407
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1057_03.png",
-      "hash": "df7be894b140eaefbe052ca80133fb0f13a9c8b998c543a638636535b03c79a3",
-      "size": 203624
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1058_03.png",
-      "hash": "04866e4a8c2e13f32f79e9c6b77c4dfa37f5d6bd33a1b8aeab3d2f839eaf3e7b",
-      "size": 301051
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1059_03.png",
-      "hash": "11a73f1053fb14f28e31ed9a5d1435c86fea0395c7f842800a2a1b8ad8ea8b33",
-      "size": 308490
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1060_03.png",
-      "hash": "13f569f06b848dedb04cbec9f3a1b0d843cfe5a6d41731c36858f163c93a3e1f",
-      "size": 270596
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1061_03.png",
-      "hash": "1656717e120ca0a9cbaffc2b75707c5b23da244ef536b81b3231b21b6c54bb10",
-      "size": 238482
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1062_03.png",
-      "hash": "2f2e432974fe6984c2c064685f752a92fffc6e79b512f03e4f416fbcc1caff7f",
-      "size": 282697
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1063_03.png",
-      "hash": "5121309fd001cf188e589e759caf56ace1595182ab75cb61f45d2c8310423d25",
-      "size": 280402
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1064_03.png",
-      "hash": "b822fdba3db347a00f0b85730f9a955ed44e7241ce1e1d2263fc1cf3ed3adf7b",
-      "size": 315333
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1065_03.png",
-      "hash": "5868869b9dadc59c57a7f5ac092a68c94d8409a4cc5848cce34f3afdf9a786a3",
-      "size": 321584
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1066_03.png",
-      "hash": "5f0e9d12845df482a6a7b33fdc550d9f386d037d06e921d5c94bca495e53643c",
-      "size": 254158
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1067_03.png",
-      "hash": "dcf8cd0f401dc3a5aac3ed801f76cef6f4120b921598e0d366548a1d5251a69d",
-      "size": 320690
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1068_03.png",
-      "hash": "24d337c19a8ecba7f712a03992045f6c3651c026eff78859cd50190807b1775c",
-      "size": 302620
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1069_03.png",
-      "hash": "a7684a2b35616b3cfcead31f15c9b96d6e85b9f6467e3de539ed42472cfcc9ef",
-      "size": 329748
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1070_03.png",
-      "hash": "0759acb2f7508f67fc564da363410de11615a328975e2e042480cf22de9597d9",
-      "size": 338260
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1071_03.png",
-      "hash": "0bdb2a4be241bae371534656c2308c7441637563dc75a9ff23c55ac6375a99f3",
-      "size": 302823
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1072_03.png",
-      "hash": "44ef6d00526bdc9e95b9d1fa63c89eac717bd4e31e177eaac07c9542a68ff59e",
-      "size": 313212
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1073_03.png",
-      "hash": "30b3953191268d3912aa9c32359799f1cc6bf1b482e9fe0731af3d6d94c441a4",
-      "size": 293524
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1074_03.png",
-      "hash": "0b3ed51df7e8fc6b7b4c3cc3ac0500733a31cd35905b1ea42d0b61d1faf0511e",
-      "size": 323799
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1075_03.png",
-      "hash": "50312b1030bfd6126fdbecd288177cfdc49c4baab57fd5b9be7adb65e64b7c43",
-      "size": 278041
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1076_03.png",
-      "hash": "8d10531276c841ebf7de2e41ef0449496ab8e9efd157fe87a2fced746d028907",
-      "size": 305065
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1077_03.png",
-      "hash": "25f4674c950c25853cc555297d082f210f3c8bc514950be32f4ef92654361f7b",
-      "size": 343763
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1078_03.png",
-      "hash": "95fa0e82dc16022b19d4e0b0b937c6f80f1837a788d55b20cbbcc2e43e321185",
-      "size": 323671
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1079_03.png",
-      "hash": "ec5eb6146617a2099748a204c43e34057fa4355ab4024e3da5a36de0d9898c72",
-      "size": 191414
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1080_03.png",
-      "hash": "cb6537b8774964610a136b0c0d17c4c2b496aaf102499383cc83d0e774035927",
-      "size": 238317
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1081_03.png",
-      "hash": "171afc4b8dbf1978c44dd62518f9059f40bc34fe06597336ff7ed3e39175a6f0",
-      "size": 273490
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1082_03.png",
-      "hash": "595bb14d3516775dc1c07b3490c725796e5ea23c3b460db433e8fbb28499be0c",
-      "size": 295101
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1083_03.png",
-      "hash": "e4c0282f51e1a690c81da193bf3ae6d0ef0a49bc17a63f254a0de4bba1c2c49e",
-      "size": 347033
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1084_03.png",
-      "hash": "7b77b1d3bdcc8381bfbeb11c88234126e443caee4ea13e9160a28412a6d78044",
-      "size": 307374
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1085_03.png",
-      "hash": "9020dcc46b7f0c74ca7f5f484b9ba2bb762c5f2445bd2ecd68c9684c0b7286d6",
-      "size": 297930
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1086_03.png",
-      "hash": "95adf176ea4cbfafec1f52e04eb616c2c86857efe7bd2673678a36b0b00ff8a8",
-      "size": 322439
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1087_03.png",
-      "hash": "170cd7aba2007f0960801fea8b72c31506119a02e768671750a6bbcb2b59b23d",
-      "size": 313907
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1088_03.png",
-      "hash": "f97222da4c58eff142d533808e107db677ef3a18634da0d52da695183f000806",
-      "size": 310259
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1089_03.png",
-      "hash": "08fd4c1da0292dde7e8d41f351a4b72f910f3b700b1fb73298c37a3ecc76200a",
-      "size": 308284
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1090_03.png",
-      "hash": "53befdf19d710b0e6be177e47e52d0904474ced3ebc35e453ba8da351efd1aea",
-      "size": 185693
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1091_03.png",
-      "hash": "29630cbfa3739bedad2fca5c6594e888bacdc8cba386dfcfedec85cfd271fa15",
-      "size": 168854
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1092_03.png",
-      "hash": "cfea740c74642bb6d715da49ba629c950f0b50ce4c8d2894e333c9d8de9e3091",
-      "size": 291600
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1093_03.png",
-      "hash": "863006d527d92d959db22807999fc96c616269ae98aba4fe0edc97f32abc878e",
-      "size": 287146
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1094_03.png",
-      "hash": "4f5c88a2d78f64787c3350058815bd1ef3e89c9b72d89ced6310ef7b20f46929",
-      "size": 330502
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1095_03.png",
-      "hash": "8d22cefdb9e0699f543b0641d1cdc55992bfc15ccd5237f1a08a8c6e6d63b2a6",
-      "size": 186788
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1096_03.png",
-      "hash": "92571e0cee500ecb16ef7eb615f303b25ec30a6601220324e9c8576afc9f1584",
-      "size": 248617
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1097_03.png",
-      "hash": "1e46cdbf3d0317154b89433db728ef9b01adfdc900f8680a088ce31b3e5b648f",
-      "size": 280433
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1098_03.png",
-      "hash": "3fc2f761a46e9f29bfb36394381d2c656f49dfe13487e279c398059d1a47fed6",
-      "size": 337486
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1099_03.png",
-      "hash": "6be4f49d613a01ad4ef0e546ee441d6e527816de468a94f7f1bfe4b1e533b520",
-      "size": 317814
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1100_03.png",
-      "hash": "8a951981a3296a4c5ed976adf322e03a1439929d8ad235eb559859f0628ed036",
-      "size": 312089
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1102_03.png",
-      "hash": "faafe495b14fb2371eb2ebebcce906443b82780b242d57a4ac46e3d43afcce74",
-      "size": 329448
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1104_03.png",
-      "hash": "c5ecdf2a9dff7664a53ed7520b1979f48057da5e01fa8ec3fa39c462e5b6d6b7",
-      "size": 322738
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1105_03.png",
-      "hash": "98741e76d7558d2ff3bbb3bce908bd055f33c557412fb9d63ca9eb824c23af68",
-      "size": 303599
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1106_03.png",
-      "hash": "71b77fe6aeab90151614c5b6eadf3f8aac269c14eb476224a9168356bd35ba92",
-      "size": 297283
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1107_03.png",
-      "hash": "97362d1cb438519a9e4c65fa61acaa513f799f867a0e72e0461005fd0a4c58ac",
-      "size": 345920
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1108_03.png",
-      "hash": "8ee3b31be48461b2098ac405ad6b4a5a624c875762340c6ffb30b53a4564ba1b",
-      "size": 237699
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1109_03.png",
-      "hash": "00ee41fcba5e99eb272ad32072487ec974044410ccd3d544f8936fea5946df4b",
-      "size": 270323
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1110_03.png",
-      "hash": "bba20eab4b7141c449acbaf72d4196828c27464fb153efeabbee7c1030471095",
-      "size": 194792
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1111_03.png",
-      "hash": "214b3adc7e812dc0ee5862d28cadc51a45a5057e5e662b95b98f0d1cbe7afbae",
-      "size": 280064
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1112_03.png",
-      "hash": "8c3d537f1ab25329c6c7ef2f73a5a7ea29bad762fdd0e0692d256bc0f4dd79b7",
-      "size": 299886
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1113_03.png",
-      "hash": "b789182745ebe6a3115a3f142cbe87736246620a244944cc91a165475a963876",
-      "size": 320831
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1114_03.png",
-      "hash": "0caf22a7d2ddbca3e32bd4b5474bfadb10837adeebb187a5fe3ec4ac969e2347",
-      "size": 273635
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1115_03.png",
-      "hash": "19585a471f5bd8ab10866b1a8abd89f5e8c6fc3517d2ea59d931508218265ff9",
-      "size": 192444
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1116_03.png",
-      "hash": "9d4a5609e1984d38f1709e4783a6735e3233117757e97fc1177fa80a025abc18",
-      "size": 265986
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1117_03.png",
-      "hash": "6cfef9d17b5135508d3778282fd9165e6f962b6580bcce8b5cab19c61b936035",
-      "size": 296950
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1118_03.png",
-      "hash": "9472297796cdec9dbad5f397648085fe0775a7ed1b4944bb924169b24ae60a1c",
-      "size": 331654
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1119_03.png",
-      "hash": "815f5fbeb17cbf2fbe33dd187a25d6de3433adbe512b5dc4d68bb3bf9ea0c1e1",
-      "size": 317794
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1120_03.png",
-      "hash": "1f7f3c04e26ee5a6649842fdbc93bf0c91baedc5312f109dbc46ea9e1e4e2df1",
-      "size": 353144
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1121_03.png",
-      "hash": "3a2586e0846d6516140de114487e6d06ed7c0df755ee0945e27ee9dca0fbba49",
-      "size": 215355
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1124_03.png",
-      "hash": "ac0987243b81d8aa1c20d402b196985b69d583196fd3bdd95be03864d1d345b4",
-      "size": 318256
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1127_03.png",
-      "hash": "63828fad92d4adccf27f1a86f6f09aa4606e884c614841a84912e0ff17c4fbf9",
-      "size": 229153
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1128_03.png",
-      "hash": "31e19affe68ae469f0a68b9a1fb120857760e088253b6813fa8a9663d4db2b79",
-      "size": 342359
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1129_03.png",
-      "hash": "a15c75ff446cbe1efbde58b7371a7af5d3b0b92b53fdfd79eda16202eaa25e59",
-      "size": 276698
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1131_03.png",
-      "hash": "412298076c93ce57c0cbd401e53fc4a3398e1fc122f2501f30797a309880873f",
-      "size": 290519
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1132_03.png",
-      "hash": "f3360d733b562d7940c337770ac3f2b3548f1fe6bc26a2d28a645e435897b524",
-      "size": 351606
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1133_03.png",
-      "hash": "fcfd270696670952c6cd662542ee4cb8b7f2cbe32b44329600cc891e70a865da",
-      "size": 330723
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1135_03.png",
-      "hash": "3b7a505ce6cee9e67d4ca67e91b93853a30776cb3c73930d747c70ee6dec549b",
-      "size": 260764
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9001_03.png",
-      "hash": "0c70c33b50c51108c6a912240f34d2f5ee8bcabb31f537f8288c274f5abe8838",
-      "size": 294045
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9002_03.png",
-      "hash": "8fcf92207d352c582d26d109a62343f47c1d1a47cb5b11dc30a8e93f03b9fec6",
-      "size": 317631
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9005_03.png",
-      "hash": "a189a74ebb3830c4e69a7f26b0777f2bb72a6dc3853f3719cd0a56a0bd4e6ac5",
-      "size": 288080
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9006_03.png",
-      "hash": "462b6fc1c40155ad42b8974dd55b6a17afa12e660d62d0865ab308636871966e",
-      "size": 325431
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9008_03.png",
-      "hash": "e253d60c43cd62fad67abd5ec46dba94757c21348309e1b92b528beebe3c3f3c",
-      "size": 274279
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9043_03.png",
-      "hash": "d0adc1847777962ffbe2880dcfc92c6901830907cf32835d9fab903a42500793",
-      "size": 270603
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9044_03.png",
-      "hash": "3c5dff45f9e56b4df29931e066ae2a5d58c1de5c8ef9539e89d6e28a3c635e11",
-      "size": 328066
-    },
-    {
-      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9049_03.png",
-      "hash": "725962300aaa93f32a70ad2f678385291eccef4f9f30dced7c77421f5cba2b16",
-      "size": 315801
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100101.png",
-      "hash": "8cdd69d3c937d23a3fca7b026f5bd37f76737672152455dc511bd46589c2e42a",
-      "size": 467906
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100102.png",
-      "hash": "5a76923cd38cde82720a08f9a035273ae1ba86dbaf6893dbbefcc1987dc44bdf",
-      "size": 505368
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100103.png",
-      "hash": "9b52db46766b85d60e8aa6a6d68e2480500c292d010984e7d34d2e52686a1cff",
-      "size": 506812
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100201.png",
-      "hash": "6ab8306b2939b8eef48c3d69b73eee3d5b8cffe8c6d4580861e91eeb1c2175e6",
-      "size": 520421
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100202.png",
-      "hash": "9ba74c293b28f657de9d80236b8ec857a5a3d698ecd350980052238a6987a5ac",
-      "size": 500558
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100301.png",
-      "hash": "f6ee5375f6ea0c42ebd58f4034832f9b1137544b6af756df6cc239a360bd2dab",
-      "size": 472468
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100302.png",
-      "hash": "b28c3f914fa59e93ff8b98be617fea739586896bb107a90026abc20bd6dc07cf",
-      "size": 528955
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100401.png",
-      "hash": "99d51452b023a05a023764eef58ac663d6241b4c059b8704028551daec1dc6a5",
-      "size": 508147
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100403.png",
-      "hash": "75390f75c5528ce91d6e5761c2122450e550f9ad37cd499a4d90b7ffc3484c53",
-      "size": 477101
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100602.png",
-      "hash": "4ee1fa96894c59a7191d09ba42bc71bc859b4275ef89d708cda9159ab21beda9",
-      "size": 491209
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100702.png",
-      "hash": "99187899ceaa2ec630c5d113a18ef915458a5f07daa9c67b4d140cd137b92318",
-      "size": 549206
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100802.png",
-      "hash": "768bc4270e653bc1f7b447a41bacb3baddca329768e37a1fe02bf63e3223ed66",
-      "size": 529212
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_100902.png",
-      "hash": "0c6e460115a91dcf446665b9031e590175899e2754a73139bbb8b255b3119be0",
-      "size": 538053
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_101001.png",
-      "hash": "7bb9dfe5f5108af7e672fef531f1febde22f5a22780ef23453b05f493e455ce8",
-      "size": 435724
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_101002.png",
-      "hash": "41fc81d697dafbc25eaa2c4765a8451673d5ef99613caee7af6aa7d3e83d6855",
-      "size": 481824
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_101103.png",
-      "hash": "b1d787862721475bd2caa112f90e76fbeed170617bf6ae0891df6e231034790f",
-      "size": 522364
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_101201.png",
-      "hash": "34d0b7d3fd39b164059686f3c4fa914036873c177d321dad53fb798a88bc9ca5",
-      "size": 557398
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_101901.png",
-      "hash": "a713026f0fe1bde55bcfc0cab97d6c0647c20dd2fba966395fd137dadcbca8aa",
-      "size": 437184
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_102303.png",
-      "hash": "97cd64dcb1942f284f0601ab94797bf82f35f905d6ec17bcb59c67b94e192feb",
-      "size": 509004
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_102403.png",
-      "hash": "a8f0655c708fcf0f3a815c64b9c41f12dab17607f24cf9d6cbe82ed1572fa655",
-      "size": 524569
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_102601.png",
-      "hash": "f608ac6457a62d597faa76c51f11f97570eeb32c727a8756651047eb2a07f006",
-      "size": 569666
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_102801.png",
-      "hash": "34bd7ae1936c852747a1f6adaff5753eb74fcdf09d8e8970bfeccfcbf5cad99a",
-      "size": 505340
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_103001.png",
-      "hash": "84e9a2c4daf33076964867d84185e42f1b3550a5284911d188787bf721d0ae0f",
-      "size": 545513
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_103302.png",
-      "hash": "30711f7ae9757e53ee1ab47bbaaeda5a14086554f9ceeb92b10701a3ed05cc9d",
-      "size": 490949
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_103701.png",
-      "hash": "caf428f9168d56626a15e7c1392997f54a5dddaa07bdd1510fba1ae53857fcb2",
-      "size": 473157
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_103703.png",
-      "hash": "b3edea03bd8757c697fd3d119f85e6b41769d03f67bec031143f77618301d3ca",
-      "size": 513473
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_103801.png",
-      "hash": "cd03a867fb70a5d54bac713addc88a48d9fa71579ea96c0d3b7a9d8cad50346e",
-      "size": 482498
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_103802.png",
-      "hash": "8146323550db600750161d9f2f37d47ab3ee957481502b7f36555b06f28d0122",
-      "size": 507119
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_104202.png",
-      "hash": "1a4a7a63268762130ff080a0a57039dca34387d63d2864b10f7550c7930e4780",
-      "size": 419715
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_104401.png",
-      "hash": "a0c71175da2c0f9e2d75432ceaf62538c0ca92a63cfb7f5bbb0f7b19a29d9abd",
-      "size": 608499
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_104402.png",
-      "hash": "0d005a218a899a472b5974c49c45f4cd61cbed8d20f371e5ba8d03a13af50628",
-      "size": 553023
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_104502.png",
-      "hash": "031a459ea8e2a083d52c8e79e11f2b825d59776e8de379fa5dc7a1573bfbf370",
-      "size": 491051
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_104503.png",
-      "hash": "ff5087e2d579ec05b641aa422fafbfaa2de5e224fb99f991d0d8111d96480153",
-      "size": 385673
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_105003.png",
-      "hash": "eee665d32226f6cef7382a4d7a3127b4b33800effdd152dc11e14a4969f73d66",
-      "size": 497960
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_105501.png",
-      "hash": "99f6aaae0b78ba39f1d9c112040bfe3a54ab9eeb4324f4e1b4f2aa5eb47b2a76",
-      "size": 516175
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_105702.png",
-      "hash": "493034c564b160e9b06da5c41a995680441d2ec4199596b8c2340abe81047ccc",
-      "size": 532331
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_105801.png",
-      "hash": "cd4cecc532d472588888fa58e3326ec81b93aa55b07e93dfb0105fca62b01cc3",
-      "size": 548733
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_106002.png",
-      "hash": "8212b76f243beb3001d39a5850a39af0b5da52fd225a3a4136cfb8d99567ba0e",
-      "size": 522695
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_106401.png",
-      "hash": "7c113cbf7bc99e3d9d7beac467cbd8a6ce04e029d887d56fc023ce255df9fb4a",
-      "size": 557390
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_107702.png",
-      "hash": "ca52e077a282102559fb966f14c333460907fc78d9b0090c5d8e9ecdc0726de5",
-      "size": 483698
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_107802.png",
-      "hash": "4fa4ee11ab99087a8bca3fcef76b440c7da3857990be8d321a25d533abecd7fd",
-      "size": 514808
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_107901.png",
-      "hash": "c1591ca00e04098862f2e4295eff88f40479a4c6904d3f3d71ac1315d4f87f0d",
-      "size": 514998
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_108001.png",
-      "hash": "1754031ac49c8cb1e81952b84f774a4942efdc18e5a44b867dd92a8a4eade186",
-      "size": 489884
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_108301.png",
-      "hash": "06a2f0f464b8091854ff2587f87a2ef53261d8395f8291d7dcd859bd06c742c7",
-      "size": 452721
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_108701.png",
-      "hash": "a63e27eee6b99195aaf5dca3c9dda806b30d4c689a15151521cf53796a4f2d51",
-      "size": 491819
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_108702.png",
-      "hash": "da4a121334eea989be81763f50adf033f6f9df8517ba28123e8c603e589d2651",
-      "size": 516954
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_110402.png",
-      "hash": "fb1887f7bc322f04e69a1ceb801194335cddb0a13da48a332ba5b4e20e685af5",
-      "size": 512495
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_110501.png",
-      "hash": "17aee0b0af0ad22f32ac554eb68004215e03889183c61efce470f54a84584d96",
-      "size": 406830
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_110601.png",
-      "hash": "2f593db9e22a45af650ef7c60bc8f383b86b7dd4664ded68b586aa2c3a9ee468",
-      "size": 579184
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_111001.png",
-      "hash": "20bba1465cd9e34a9442470ee65d2526576db592a5226df44f4a65f29fbf301e",
-      "size": 546861
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_111101.png",
-      "hash": "238775039156255a1c8b2a5759678521f8ac83d63fdbf239e48cb1ede29df52d",
-      "size": 507309
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_111501.png",
-      "hash": "f882f507c6860b6b3b5346a20ed976cfc9537153f49ca3bd49366e9137848ba0",
-      "size": 473649
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_111601.png",
-      "hash": "cd8ff29c04cbf116b5a7b2534bfc349b7b72557d54fc2ec484e092d769aeb9b6",
-      "size": 539012
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_111701.png",
-      "hash": "ea1c6a3bed42fe3d8b63d575cfd931bc242c39074838bb00bb4fb2c1f87ab128",
-      "size": 529234
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_112001.png",
-      "hash": "93ba0b71906e61bcf6657d2a78b030c1db98c6a81106e383717da0250976a97a",
-      "size": 517085
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_112101.png",
-      "hash": "192a87657f7b0c1cdfb62f5befba3e51fa63c9be733179d3243a0113d036a585",
-      "size": 495511
-    },
-    {
-      "path": "assets/textures/gacha/comment/gacha_comment_112401.png",
-      "hash": "451daa5f6b161f0a2ce2dfb13b7635c6dfe5c1694ab6be719e4fb2e8d1a4ddd9",
-      "size": 535771
-    },
-    {
-      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30067_03.png",
-      "hash": "57d3419ae5750042fd174ef9fa672f04bac8df4e2765de1c9693c6ec3020b884",
-      "size": 284258
-    },
-    {
-      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30081_03.png",
-      "hash": "56043cd6a01f0138cfd8e53b79a4413ee17bd1061cab98e40c6af828853fe50b",
-      "size": 269278
-    },
-    {
-      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30137_03.png",
-      "hash": "74a972a9de8a9002523fe817495cef51ac4a6347a5bbee2321963428309df083",
-      "size": 323877
-    },
-    {
-      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30180_03.png",
-      "hash": "5c8bf0c742d0c2237a5d3e6639dcd0ba0e783eff0ec4bc136c9f194a47835f6f",
-      "size": 321224
-    },
-    {
-      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30241_03.png",
-      "hash": "5184ed44217ae98dbd1dd1704484d59e14e94e7328118791db6f238b71724ab5",
-      "size": 287426
-    },
-    {
-      "path": "assets/textures/heroes/utx_txt_hero_skill_name_00.png",
-      "hash": "2982d4d6b382caed1078a7e1078fd35c67bca5e20f26b50363e04ca7c2785dbe",
-      "size": 206318
-    },
-    {
-      "path": "assets/textures/heroes/utx_txt_hero_skill_name_01.png",
-      "hash": "35ad207d41251bfa8047fc78c81c2587c5ee641ff6b460280e698f86f9d0f8b3",
-      "size": 202783
-    },
-    {
-      "path": "assets/textures/heroes/utx_txt_hero_skill_name_02.png",
-      "hash": "0b79cff589a7f42193feb874fbd13f364f22ada173ba87ef8c99eb016af43fec",
-      "size": 189795
-    },
-    {
-      "path": "assets/textures/heroes/utx_txt_hero_skill_name_03.png",
-      "hash": "0027bd3cd65d1021162b6e86a4f2c943c449528cb2e35db5e3c7f303d68e8905",
-      "size": 181419
-    },
-    {
-      "path": "assets/textures/heroes/utx_txt_hero_skill_name_04.png",
-      "hash": "8f9ce5cd2b607ef6f7c1cca8fe7f95b8f148bbb9ecbba5d1f555c69df89a601f",
-      "size": 219896
-    },
-    {
-      "path": "assets/textures/heroes/utx_txt_hero_skill_name_05.png",
-      "hash": "1163494438bbcc76dbb72e3f31bbb1bfb04a7627a0a874700a8d2f769d39f982",
-      "size": 201279
-    },
-    {
-      "path": "assets/textures/heroes/utx_txt_hero_skill_name_06.png",
-      "hash": "f42ce6ba3ef520ae791a62f994b7fc7d83fba8d64b32983ce8a480d9d61ee23b",
-      "size": 196541
-    },
-    {
-      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_00.png",
-      "hash": "f353516ed575d64758826fcd0427f3f08346316503672bec5cd74c16c6a19e6b",
-      "size": 48423
-    },
-    {
-      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_01.png",
-      "hash": "b75ddc8e7ae46b89a0072e3bbbd99dc39b7950071bea21feb64e8740f8910719",
-      "size": 48798
-    },
-    {
-      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_02.png",
-      "hash": "55a63c23d4d8f84999bae178239a42f6e077707e976472c9deab5722c0aad338",
-      "size": 60762
-    },
-    {
-      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_03.png",
-      "hash": "6a29cfcfe11f1c18c733ee0a2e1499713b248140010937dc974760f0edd6b4e8",
-      "size": 63108
-    },
-    {
-      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_04.png",
-      "hash": "1354b0c9ef4fc9545f59456f1973291896fa114cc25d9f3e241c8d99464a02c9",
-      "size": 53251
-    },
-    {
-      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_05.png",
-      "hash": "e12a0d854b60dae8dc51470261552ae8dd7763ff43be084ddd735e4bf646b017",
-      "size": 61359
-    },
-    {
-      "path": "assets/textures/home/ui/texture/utx_btn_home_race_aggregate_01.png",
-      "hash": "693adee11ef35a818f13486f19a2588f8822e315b73173da8a5999d8adaf5492",
-      "size": 255219
-    },
-    {
-      "path": "assets/textures/home/ui/texture/utx_btn_home_race_down_01.png",
-      "hash": "3a5c3c28abba3810bcd92a87d2f706bbf8b949860fbdf8f5a757a672effc1028",
-      "size": 161291
-    },
-    {
-      "path": "assets/textures/home/ui/texture/utx_btn_home_race_keep_01.png",
-      "hash": "ccee2aa23bdd7fb029db9ff4343288b4717dba552273e727f5e75019997d2180",
-      "size": 154881
-    },
-    {
-      "path": "assets/textures/home/ui/texture/utx_btn_home_race_up_01.png",
-      "hash": "1edaf15fda1c8122e7e68c72f2dab17fc1dd322e5b1f33ac03d8c93edfb2bc11",
-      "size": 163663
-    },
-    {
-      "path": "assets/textures/item/item_icon_00234.png",
-      "hash": "18a8d54370bde96aee45f4678098ea50cc705b7ab466f6fb0687fc2cb0441616",
-      "size": 60223
-    },
-    {
-      "path": "assets/textures/item/item_icon_00235.png",
-      "hash": "38b1a8b6cfbfcb54235fec22a03109b102a17a0f45ceb8135ef23a142ef6ac5a",
-      "size": 58698
-    },
-    {
-      "path": "assets/textures/jobs/utx_txt_job_limited_00.diff.png",
-      "hash": "44a13c8293c5506130ea06b9207f083bc96d4fa7023f25fe80b80a788d5c6b51",
-      "size": 7195
-    },
-    {
-      "path": "assets/textures/outgame/campaign/campaign_icon_l_0007.png",
-      "hash": "0c9198497d93b5be7cc66aa83c3ef7a8c27bd7e8429f0dc56c062e04fcef33f3",
-      "size": 26193
-    },
-    {
-      "path": "assets/textures/outgame/campaign/campaign_icon_l_0014.png",
-      "hash": "6767d50137c6694dd4226323fe1cf0b65174d3bd07bd9a51fcea057d4d596090",
-      "size": 45420
-    },
-    {
-      "path": "assets/textures/outgame/campaign/campaign_icon_s_0007.png",
-      "hash": "0f06e28aeaff5a895f894ff8492fbeda13468827927ab9dab6093706a1d9f673",
-      "size": 14680
-    },
-    {
-      "path": "assets/textures/outgame/campaign/campaign_icon_s_0014.png",
-      "hash": "63eb96dedf9be0682b111cc8fa8f6cbf44b9ac8738ce4b4760da08c7e2dbc9f0",
-      "size": 18858
-    },
-    {
-      "path": "assets/textures/outgame/campaign/tex_txt_campaign_allget_00.png",
-      "hash": "ea6efa868982d37716502e6f223d412f526f68ab6469023fa54e8e07c544a5cc",
-      "size": 135542
-    },
-    {
-      "path": "assets/textures/outgame/campaign/walking/utx_txt_campaign_stroll_03.png",
-      "hash": "bd258681658b3c2917fa7f3eafb7b45018fc14b832a49c3d6d8d5e3468cfb6aa",
-      "size": 15844
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1001_01.diff.png",
-      "hash": "a3a54234867e93d7ebe904cd7b7730c9f6e0f1887d1e696172f409b695ff7116",
-      "size": 1053524
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1001_02.diff.png",
-      "hash": "e4fa030b9e7fff1a54cd12ff15e98b437525e5bb4c1b7bb7f61fe6558838e831",
-      "size": 924932
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1002_01.diff.png",
-      "hash": "9942eb02167dd93c6c750ede20d4ad73b64288036bf25c69016558453d5df727",
-      "size": 992012
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1002_02.diff.png",
-      "hash": "631e5f2a8b7cd6a4a8c533d2cd00a8b956104af086cad53c28d805b3f8d7326c",
-      "size": 1188440
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1003_01.diff.png",
-      "hash": "1765f293ea4219713ec58a98dbfa3bd4b94266bac024810e6174e4fa78166165",
-      "size": 1166429
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1003_02.diff.png",
-      "hash": "7f269df077eaeb84f1c696980349b7c3d29f067bada5b048b1d9e59d4fe84c4f",
-      "size": 1290182
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1004_01.diff.png",
-      "hash": "2b57f561f6c6deeee9e73d99f32e89b4a363193120db24b9c7d63d9d8209badc",
-      "size": 1119230
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1005_01.diff.png",
-      "hash": "7b77b75e398794b5b71aa2e8946672fa9b5adf1c96811c801495ffbc8943744d",
-      "size": 1381343
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1006_01.diff.png",
-      "hash": "85b0e01653621ef788167ab0855d8a3a3a4f4e5f0188ad512d448ef86601c6fb",
-      "size": 1130294
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1007_01.diff.png",
-      "hash": "ce5d8350a482bd48a7e2c3aa2c91bf8d7bf6bf2ca80b57719e112cce8e9676af",
-      "size": 1240231
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1007_02.diff.png",
-      "hash": "37254d57b62ec9837381768c3863928681d2c6d43e7f4cf47c64e9fb8de3fd8e",
-      "size": 1009794
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1008_01.diff.png",
-      "hash": "8499e469409b6145cb101f2b553704b4210f3748bb94eba14fa2f74a3c277a47",
-      "size": 1110940
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1009_01.diff.png",
-      "hash": "fc378d5018a922423bcc6fa869e4b95702320f64c1e9e9b4d950e589e3710917",
-      "size": 1120889
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1010_01.diff.png",
-      "hash": "5317281c25db4df72dba08e1c2a30b0e58965d7ab11f90335fcd7927f1e097a5",
-      "size": 1058960
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1011_01.diff.png",
-      "hash": "dad370cec4eb0545aeff059b788751b6522857f5cbfdf5018556add1ea6c4a3b",
-      "size": 1320694
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1012_01.diff.png",
-      "hash": "b15496f7444e0ef60f11db6f6ee916253e6d149a500007f64fdf86200b200ed1",
-      "size": 1374435
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1013_01.diff.png",
-      "hash": "3f397d534e74c1df4b90027c7c93994dab03108f7e035155cf5931c9ba8dfa01",
-      "size": 981184
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1013_02.diff.png",
-      "hash": "6f9aaadfea34e3e55667bcf36b38c28320fab63f33b1b59e842657f3944a015d",
-      "size": 962308
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1014_01.diff.png",
-      "hash": "ca46f922045bae398af0616b93185995e887651fe6205cf44bccd434ecd6237c",
-      "size": 1366931
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1014_02.diff.png",
-      "hash": "83b1f17c7c182af2e67440acd7aeaf8d2993ea2f21c7f5e5df03d7f356958111",
-      "size": 1119337
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1015_01.diff.png",
-      "hash": "b496905632e5df83f775ba914956113df215040da72b7b4720a18ee7f024c761",
-      "size": 1072280
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1016_01.diff.png",
-      "hash": "70b553901d550ebb2581e0163b9dbfdad9d4f9b64d5166586d815d0214c627da",
-      "size": 1006985
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1017_01.diff.png",
-      "hash": "0f1a769cc8b7de9a2a524c2d949b0cd5c82f48ab25c23d363ba2294c578bd7c8",
-      "size": 1190385
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1018_01.diff.png",
-      "hash": "fde201eb249b29368349d1251a9c28fff7118f26daffffe1b0b6228d47a0eb24",
-      "size": 1257853
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1019_01.diff.png",
-      "hash": "a2f35ea1eed7ca1f1696e8953976da4f8eea6105d8219333d8a4926155ad720b",
-      "size": 1000628
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1020_01.diff.png",
-      "hash": "658ac190eef724d008eddf4d1ca317587b3a5d720b02dabc3931c4947e67f032",
-      "size": 1220677
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1021_01.diff.png",
-      "hash": "b7482824c0eb9b0ce80736578dcb9a4518df10ec04e817e95b33597dd80f757a",
-      "size": 1255976
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1022_01.diff.png",
-      "hash": "19f567b556eb5ac4405e6373ca0ee9fb7ef19ca2c57bfe906ba22d24e4ef3994",
-      "size": 983823
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1023_01.diff.png",
-      "hash": "2df46e3edba86af1b24607733c872481fa0a8c6fed166ad7d89e476f3683739b",
-      "size": 897280
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1024_01.diff.png",
-      "hash": "fbedf1895b05aa14c2258cabf81ba044e6f5e1c8736c676ffea4c517a6898f6f",
-      "size": 950831
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1025_01.diff.png",
-      "hash": "4d3a1791241f2f663b05632fccd4ad5251169cb9d5632557069dbb9768268414",
-      "size": 955651
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1026_01.diff.png",
-      "hash": "671221f65f0324520c01c54b7b8da3dbee931ed6fed32d663ae83ef557908cc4",
-      "size": 1249543
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1027_01.diff.png",
-      "hash": "70096c2a7a6ac16b7ac485af7ae879e8e45f09d07522db8eb8416fd4c556e9c2",
-      "size": 958328
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1028_01.diff.png",
-      "hash": "8c9a65aef546c2e179543783a0870ac96ad02d8a9857d31fe3db871da858d049",
-      "size": 1089172
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1029_01.diff.png",
-      "hash": "ceb312032f6cb3d66abf491d4219f32aea32c935c8b3ba0ae869edfb94093b83",
-      "size": 1073126
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1030_01.diff.png",
-      "hash": "6087fd4d5f3c4df7cc99ce16676bd54ba27392df2efbece0d539e6c120fadee6",
-      "size": 1222285
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1031_01.diff.png",
-      "hash": "d80ac706393a009aae49a2a5283817d2a6cf396937165de87ed2d1c477aadf0e",
-      "size": 996135
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1032_01.diff.png",
-      "hash": "cac34e196043b7337f579fbffe7f705ee8409e3ba88753a1f8e245232d8c4ecc",
-      "size": 1101049
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1033_01.diff.png",
-      "hash": "a917e3b66c53f4636b73927f42c20f564915f9c3b594f8094311b9fd93a50d2e",
-      "size": 1266740
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1034_01.diff.png",
-      "hash": "a208e43119022aa4ef59d56c1226c7574657323a27dd7a27b45a507706242f9f",
-      "size": 1204216
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1035_01.diff.png",
-      "hash": "0d8ae9fe8277610d548cf7242a01a3b69a431f1ce97d8429fdc41fb0ff260c1c",
-      "size": 1208314
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1036_01.diff.png",
-      "hash": "86df5bfd7d32a711f4d1cf0192d38bed617b6b99b71988335bfe7006ff5281cb",
-      "size": 1055307
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1037_01.diff.png",
-      "hash": "57c281f13da442ee21f758df137d42f14b79392a3d99ff5653628e38f4ffb27c",
-      "size": 961350
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1038_01.diff.png",
-      "hash": "ca6b19627a6631a9a1f4973b2eaad3eec5a7b0fa4c521ae165548b999f97008a",
-      "size": 983097
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1039_01.diff.png",
-      "hash": "7453c806eaf6a3e6f94510693a2f3f6314bfd1eccea698671ec11f444676467b",
-      "size": 1268495
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1040_01.diff.png",
-      "hash": "e124b93bb15e448f060156671c174c9fe60e471081237c5e1a93f29e304521f6",
-      "size": 1187818
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1041_01.diff.png",
-      "hash": "00f79df75be3b360cbac4bd382356b2d0bab4b0b6ec0372aed4400eb79c07d0b",
-      "size": 1091463
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1042_01.diff.png",
-      "hash": "d4b2b425ed04e21972aa06bf86e70c51328d50fb16c4ae174cabff8b4dbfcc00",
-      "size": 1162649
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1043_01.diff.png",
-      "hash": "7293ae32d688fce56e31e472bd397609eb469671a9cf77f9c9da053fae6baba6",
-      "size": 1169658
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1044_01.diff.png",
-      "hash": "85b139fbe2bbab9e3f8ebf241a640e74c94bd7bafafc928eb5fac906d332d163",
-      "size": 1122883
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1045_01.diff.png",
-      "hash": "b7353e31c4a764d34134b9b6fdcd1dd9df5ef1c739dee723e065dd7d5b298500",
-      "size": 956809
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1046_01.diff.png",
-      "hash": "cc15504ae5e36fb1871e7da7b9d9db0cd5870cead0d00029da4389de1dd6f206",
-      "size": 1127738
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1047_01.diff.png",
-      "hash": "27f9724c3d7d5f6f97de444e30e94e7f4f56efcfb5b5696af5ea8af782e8e552",
-      "size": 1270965
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1048_01.diff.png",
-      "hash": "96294556d666800e687d861eb4d343c5fcbb06b96b6ba5d506482c96687d042f",
-      "size": 1108434
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1049_01.diff.png",
-      "hash": "c8f52e8e55b64b16b2ec575fe48e291fdb3291a2b64044cece47b3829d856814",
-      "size": 1270035
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1050_01.diff.png",
-      "hash": "6034f95418e2b0813e6b037963dbf5b3f433ee8fd92d9b490ef289e471ffd59f",
-      "size": 996371
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1051_01.diff.png",
-      "hash": "760d543849e30934450fc8af6ec6dd2df2143b70f47750275eaf0ca84bcdc1f9",
-      "size": 913372
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1052_01.diff.png",
-      "hash": "dcd14e5a2ee3bb91bdcd327d32f90ab6adc56738eb1949a8114e09fa7c5adf1f",
-      "size": 925408
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1053_01.diff.png",
-      "hash": "d88a2e1fdc071ea200da5182124b5e812be993f1774165b229aaca335325b801",
-      "size": 1183203
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1054_01.diff.png",
-      "hash": "4ca5c37eab2d1465c6ca526c4f63cfc1343788c0498a32e53eee41ad06686574",
-      "size": 1059977
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1055_01.diff.png",
-      "hash": "14ef741d09b13821ecd3c85224b884fbb5713506eaa7d7ab3969010d44d66242",
-      "size": 1210192
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1056_01.diff.png",
-      "hash": "1e0fb55a767ab955f80dc14b99876d842c62b06788e9aed5e5fcee0ce8dec6ff",
-      "size": 1234999
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1057_01.diff.png",
-      "hash": "0f4e23b4ebc4d068e10d1d7737f0222b6665a447a4b0a62b38a4f70e42b061dc",
-      "size": 1163102
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1058_01.diff.png",
-      "hash": "463d6d00ee81eb06624349da1755c4afa9ae7ee176248df7c25c91ad35f92998",
-      "size": 1222660
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1059_01.diff.png",
-      "hash": "15ce12740da0c6d9728eb6a7416c99c71616dddaf5f709e3105c2ea49cf0ca2c",
-      "size": 1120339
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1060_01.diff.png",
-      "hash": "fc81504be1eb08ace8081acc1873b10f91c895736703edf1415cf86afedd803f",
-      "size": 1116357
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1061_01.diff.png",
-      "hash": "45e4f9222c36d1f206c4a261e92917ebc62d19e4f396f6aba265c7f3768b0589",
-      "size": 1120825
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1062_01.diff.png",
-      "hash": "3ba32053eda833898bc5523d425ce7e706e5d254b1a53e6585646c3719dc39af",
-      "size": 993163
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1063_01.diff.png",
-      "hash": "5e130603f095ac5a5a0a50f493873763463feb8c2273f618f9c7b31af9059d3a",
-      "size": 988935
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1064_01.diff.png",
-      "hash": "da9908fddb6f752db568540c0ff24c79a0edcc0b0fa62d080012e48e2d7aaf9a",
-      "size": 1092120
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1065_01.diff.png",
-      "hash": "b47a36a8779fbc9e56d8a0edf7d931dbbe169e2c20aabfc07d20dab0d3f34478",
-      "size": 1077816
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1066_01.diff.png",
-      "hash": "534eafee1e93eeae12f15faed42cf0c6d0ca6a5217d706997d9016bca0490dff",
-      "size": 1182413
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1067_01.diff.png",
-      "hash": "acd2058ca075857fbe794ba1f0a2bfe116878ca71b0123830620f048d86da7d5",
-      "size": 1141112
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1068_01.diff.png",
-      "hash": "b2bb6c10eebd35412910675438c579c601d3eb9be3779099e7b9c778ee037c7f",
-      "size": 1355347
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1069_01.diff.png",
-      "hash": "f653ebb885fee64074da385e57a605b27140ce7cc6deb6b36c38a2441368bc53",
-      "size": 948826
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1070_01.diff.png",
-      "hash": "44c3120427b82a640154b9b70474995dfc65320e798af2b5982c0b7d02955f6a",
-      "size": 1202212
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1071_01.diff.png",
-      "hash": "2fa7ce72c0d12d9cf24589ff69f23c27d27632ec29b7c2abd81ee3552c29bee8",
-      "size": 965657
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_1072_01.diff.png",
-      "hash": "ccc6bad73d2d7286be45077a3cb5c1a89ed0c2429440bd3c88c9684ea4cf8d4a",
-      "size": 990607
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1001_01.diff.png",
-      "hash": "63cdb75014882cf7baeebc22d46a86fadb12f2d45b0800c57d06b1bbadd1a404",
-      "size": 191514
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1001_02.diff.png",
-      "hash": "8c860b2660394438661ee0d7bb7427b89585c1ae10dc92c6b03dc955de918fc6",
-      "size": 177429
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1002_01.diff.png",
-      "hash": "81a1e03cb5fdfa6a9bbb6c4587fc348ebcbbae187cb104c278083daed82093dc",
-      "size": 187910
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1002_02.diff.png",
-      "hash": "7239454fc1595077cf69130cf4aa30392e1919b58a13150cb258a4d8f8d716c4",
-      "size": 225548
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1003_01.diff.png",
-      "hash": "3b6384e3ff1ba1ab818a9f0a08b1dd5af3eb9165adf7fddf37cafbb2fa30da68",
-      "size": 215951
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1003_02.diff.png",
-      "hash": "f239e5d7731ad62eb549ccca56f2e29e8a28d60c39e488949ed7510b855d1442",
-      "size": 230766
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1004_01.diff.png",
-      "hash": "471313cc61a02e998eaeeb18b38ae80e11e72c45a3134522c62957c508455ae7",
-      "size": 222649
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1005_01.diff.png",
-      "hash": "a6eb76e3487d7e7dfd23781748fe48cdd96c486e4ef4f674f4607272d66ad780",
-      "size": 237341
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1006_01.diff.png",
-      "hash": "f15502195e54b3d86720bc0532bb32ab1202e871b49680cdffaaea8469fa65b8",
-      "size": 207104
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1007_01.diff.png",
-      "hash": "680d1ea2753d1cfb73bc2a328e6f1b601ecddec8377a08fc6d838a35cc31e62d",
-      "size": 218185
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1007_02.diff.png",
-      "hash": "3dfe52a51c0e3a3ac2f8deee970dabab84128363b6de0fe606375b68e61b6648",
-      "size": 187746
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1008_01.diff.png",
-      "hash": "f9df8c5b2094fa51d3227634873038f4c6a8ba83d07711a98ea7a9b0226950b0",
-      "size": 199545
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1009_01.diff.png",
-      "hash": "1a36bfefa2855efbb84c157330965405688b19493ec56c06fbd57dd825d87ec9",
-      "size": 207316
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1010_01.diff.png",
-      "hash": "eafd9d92fd33fcdc18f4f3e9264f521819a22cdb3a4002f1fae76c291ffdc5b8",
-      "size": 200798
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1011_01.diff.png",
-      "hash": "017b43391ec344f7b787a0252122a9d79dd0fa05c9011b7e8a8ab590f1aa04b9",
-      "size": 231334
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1012_01.diff.png",
-      "hash": "f0a03f67441399346f8913e81c113cecd47a60f57763ced70435f52930b331cb",
-      "size": 232338
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1013_01.diff.png",
-      "hash": "9f78c70896ee751bcd6f6e942a4ab365c9f8ca7d1b2eee4e2e4b5d2f97961216",
-      "size": 188837
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1013_02.diff.png",
-      "hash": "0db511643168b026529c2548aa1751e149a397d8702ac76a92d4580db91968fa",
-      "size": 187032
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1014_01.diff.png",
-      "hash": "fa0656d02d8bfd05847d16c9ef9dd40b5cf3414d8297482786af706b81d39f0e",
-      "size": 236367
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1014_02.diff.png",
-      "hash": "dbb29b1c9feb3673222dda5224d051e717ac21e195bbb14390559890118354ab",
-      "size": 208577
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1015_01.diff.png",
-      "hash": "d453bc9453a4811307548a87657578681c5304180e90581fcf55ce908c1d9448",
-      "size": 210515
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1016_01.diff.png",
-      "hash": "262182773e97faaa09f00b2bf8689d3776d965bc4bd624bcc4437c9e6666da38",
-      "size": 189891
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1017_01.diff.png",
-      "hash": "13bef7e8b4461d87c933b2016bfef33f7f5bd8a525e6e094dd92adb7b0994aeb",
-      "size": 220791
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1018_01.diff.png",
-      "hash": "3a44e848461d72962248a4524f2dcb0bd4505035971e60af480a8438b8a3214f",
-      "size": 219033
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1019_01.diff.png",
-      "hash": "73ae89a6b837ceb574da503409438de7f7424d8b654cf3bf855be4e93fa812fd",
-      "size": 201199
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1020_01.diff.png",
-      "hash": "f9aaf17e1f37c233d1bf12d0207a844ff2cc7e993e67745f7af650556694352e",
-      "size": 228621
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1021_01.diff.png",
-      "hash": "c23ef1ae5029934c4b5b640a563569800a20792a5173855b98cf2b95197b7c1d",
-      "size": 231369
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1022_01.diff.png",
-      "hash": "74b991e58ccde4b91402650988c4e1fd71bfd4258ab277286995a7b8bee96ad7",
-      "size": 195968
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1023_01.diff.png",
-      "hash": "69d9437811a8ecab942fdce6b70cefe3223d15b7770c95f59b7c282f358870f6",
-      "size": 176462
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1024_01.diff.png",
-      "hash": "d245b90ad8fe09bf65f3d87115e3f6966f88e64898c05c5d85e1ae63b8776354",
-      "size": 180985
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1025_01.diff.png",
-      "hash": "ce66b3354646924fb80b2ef2dcdaf6e3291260e5f95a60bdc9a8aca47f06b66f",
-      "size": 187498
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1026_01.diff.png",
-      "hash": "3654021b89d7c388fcde48af9f86a606456b12b4fb8bc05db775b7e836df8092",
-      "size": 235452
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1027_01.diff.png",
-      "hash": "96b143a7abc4804277670293f67a8f198338718ce6607efd72b23f99a3c25c94",
-      "size": 186047
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1028_01.diff.png",
-      "hash": "d7f670c0842dee89a7fb4c60f57b7e721dbbcd23aa81fa7144733e36b062397a",
-      "size": 197023
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1029_01.diff.png",
-      "hash": "c37ae7ae3da6e790a1198e7aa8f66eca986ea507f3081b135939499c83b053aa",
-      "size": 210014
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1030_01.diff.png",
-      "hash": "9aa6db972c9431a18b86ed89b5b2f9f6b33fd86ec9dd1783f34159edac61dc08",
-      "size": 228340
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1031_01.diff.png",
-      "hash": "dcb362becb0dd2c7d6c775c001e4c30d53472ddb2db9baa66ab6492681f1ec09",
-      "size": 184222
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1032_01.diff.png",
-      "hash": "da32d3b64fe8b828280c080d6499f8eed84426a616e52ea34530b6191ca82fd9",
-      "size": 200058
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1033_01.diff.png",
-      "hash": "a0d0784c4407547d6df92a80c9041ff14a43747e5cab8575cea971da4d9655b5",
-      "size": 220211
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1034_01.diff.png",
-      "hash": "e0e1e36bd672ab27c6eea8767219472c88e11ce22f011bcf4ef2b03ccc5a3d76",
-      "size": 220863
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1035_01.diff.png",
-      "hash": "7659894f0ee15761b149dfc28a66607029853e029fb7048429b24a6d285041cf",
-      "size": 226292
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1036_01.diff.png",
-      "hash": "07be626864ababee736b221a4080c4992a4de1047289f7332c03ee08530ad88a",
-      "size": 200582
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1037_01.diff.png",
-      "hash": "bfca611127a4fbaeedcaff9da153f9b12a4b1ce7fababf64acca2f4e6fd5ce03",
-      "size": 183748
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1038_01.diff.png",
-      "hash": "c2ec3e4118a8566e0ad28e6f0f9fe8df2607a09582412279d4407747bc62f15f",
-      "size": 183079
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1039_01.diff.png",
-      "hash": "d932147214a09882544c98f3279d4a642042dc62ec4c37b29787eb31c73b0c83",
-      "size": 222228
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1040_01.diff.png",
-      "hash": "1bce559fbc5ad477f616bc9bd98ea7bfbc2ef2a20092bfd8d085ba5f832d3b60",
-      "size": 214854
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1041_01.diff.png",
-      "hash": "4d4f4645f77b3949ca4d0e24af48468a592298d0d2d12c8b708a080c2d949556",
-      "size": 203802
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1042_01.diff.png",
-      "hash": "f2d32987761fadfc54fb16dac3d728366ac4174bda98e1abd5b511729cb7f196",
-      "size": 208751
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1043_01.diff.png",
-      "hash": "829c032da9eaa4789269d6847377205ea2803a0209a164ef6a9d2d86ad83358a",
-      "size": 206490
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1044_01.diff.png",
-      "hash": "5175f777c775eb89b678a1e574a9b843dc55de00e4f9471c0a15c0e2b7cfa8f5",
-      "size": 203848
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1045_01.diff.png",
-      "hash": "f9f0dae9825cf382b0d9a56a9ab1661b388b2e3b17fec926ae8f6f8f2226a259",
-      "size": 185664
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1046_01.diff.png",
-      "hash": "8b3c72ec4a2d4388e559ec4cc20d7a61a5325ac6dee25e5159fa0094476132c7",
-      "size": 213949
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1047_01.diff.png",
-      "hash": "4a3f8f1a21f5fd9b3ab77dd4c247fe2a72c61b2e93638b2b52fedb56041ceeb7",
-      "size": 229804
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1048_01.diff.png",
-      "hash": "ca25e15e74132c893491363d4ccf53b8fcad8af6222465e827831cad7ab8fdc2",
-      "size": 206588
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1049_01.diff.png",
-      "hash": "1daaaef379bb8f2535da3026d7be4592f7ffca1db89c20e70756b3d6d7090af3",
-      "size": 226314
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1050_01.diff.png",
-      "hash": "00cb711a4a10faa554b8e29747d1598ae2b87993de690f6a3dc15eb953ed5fab",
-      "size": 189509
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1051_01.diff.png",
-      "hash": "6250c2bf8c94c289fe6362f43753e82d5c48b7c21c0007c74b363b42cfe1889e",
-      "size": 175200
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1052_01.diff.png",
-      "hash": "d88cf0f1cf910e381ae617480c792f9e48d6881a238dd8908cfb8d4f2afcbacb",
-      "size": 171838
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1053_01.diff.png",
-      "hash": "bf0378ff88df1ff35e2bcc44bcac0d3d7fbad4d7ca2a5266e300181bc5717a05",
-      "size": 216427
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1054_01.diff.png",
-      "hash": "2d0a547d99e0ff70233bb4140dadd6033b6ed6fd3328bb798c9c8d8dc814b10e",
-      "size": 197664
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1055_01.diff.png",
-      "hash": "2225e90c40c4c4562bd1cdf67951bf140f031a31ef576f00e30a797b96d0466f",
-      "size": 215856
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1056_01.diff.png",
-      "hash": "c2019463bba46f999d8f5a9fc672050a41295d128c508077fe9998043af6c7b2",
-      "size": 228296
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1057_01.diff.png",
-      "hash": "cb619307d89c26cc0f003e0e5b96a35aac97c01a77bf46c34b2e6e9dc7e378ab",
-      "size": 203629
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1058_01.diff.png",
-      "hash": "ec4dd4e5037e198896658461dcde845297f5db92b2b005dedde3bc96894b636e",
-      "size": 245120
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1059_01.diff.png",
-      "hash": "3c3b09b737a3a58686e6ca63409c48f8fa030c4b816392eaf5fa1dd42420d179",
-      "size": 217901
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1060_01.diff.png",
-      "hash": "8cde66bb68c01f540f4aed043637765894c4115ac7d1af1eb031f5001a98eb14",
-      "size": 209408
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1061_01.diff.png",
-      "hash": "1f09929679b32d0f64a8e7778c5524049845769da70ae63c85023ac0d55d8f68",
-      "size": 208278
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1062_01.diff.png",
-      "hash": "0a54efe491bfb62360fe24a14b42a761bd4413f12abfc5766df1330d8357028a",
-      "size": 186712
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1063_01.diff.png",
-      "hash": "13a1d319918f762d2d8f9f0775b8a76588308d3c02aec7ff86ffa055b34acb30",
-      "size": 191145
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1064_01.diff.png",
-      "hash": "309497ddfcee64c0d4a9ce3d4721953a238c1b0dc714c67344030fc63549e5ff",
-      "size": 200489
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1065_01.diff.png",
-      "hash": "87b93abe2f805b0237ba37b978dad45d2405ce746c60aa1e3921683bf2423368",
-      "size": 197085
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1066_01.diff.png",
-      "hash": "dbeb2b7e1bec52f61f4801555567d973c042219f587b39f81efe636cd9dbcba7",
-      "size": 211595
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1067_01.diff.png",
-      "hash": "37a627e5126f698270b0d712006eda261e055ee75a4c3b297a06fedb9a829af1",
-      "size": 205867
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1068_01.diff.png",
-      "hash": "b12eb07d2313e5e75d607f460ad183dd8643702430a8a5fc4b670b4f3708ffbb",
-      "size": 239936
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1069_01.diff.png",
-      "hash": "c83c2978464e795aff139301998e4fe57c292371f2499cd24b77de3b35ce52f4",
-      "size": 183016
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1070_01.diff.png",
-      "hash": "85b3ce16018e1a8bd9f6b627506540d14b3490cb9a72befa80389e7af216a2ae",
-      "size": 213658
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1071_01.diff.png",
-      "hash": "176caead0493826ae5907969e5b3a0ebb174b7ffb745b9030e405d9a05564eef",
-      "size": 184622
-    },
-    {
-      "path": "assets/textures/outgame/comic/tex_comic_thumb_1072_01.diff.png",
-      "hash": "dd027b79f9f84a8363ffc198e00182ae119749929c84e3cbcce69a0572efcb43",
-      "size": 186442
-    },
-    {
-      "path": "assets/textures/outgame/shop/jewel/img_shopitem_jewel_0092.png",
-      "hash": "f53ee904d2637067541f862039f83f2d813aadf5504325751e78c7c4d986a78c",
-      "size": 194537
-    },
-    {
-      "path": "assets/textures/outgame/shop/shopbanner/shop_banner_000001.png",
-      "hash": "94b81135f6ed8864dbfc1399cbefa37181013d332d33125a45e2d9ff993e7605",
-      "size": 437194
-    },
-    {
-      "path": "assets/textures/outgame/trainingchallenge/tex_trainingchallenge_logo_00000.png",
-      "hash": "21c33a12148ef22e8fbdd47b5e5cb0dc8c3bafaa941ea65076e99efa79cca59b",
-      "size": 166303
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_13.png",
-      "hash": "82ca6d29a3ca17a4f7aab6305255b70086fe2f4802f8042035de923b87abac09",
-      "size": 160284
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_14.png",
-      "hash": "4fc68fdad1eef9bd86a921e835f6b7133d6b93a144490976e7da4c0e98ee5561",
-      "size": 154946
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_15.png",
-      "hash": "2cae91d4279858d13faf7318e775d842f7b3395981c85b809009bdfd2bd91dbc",
-      "size": 162278
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_16.png",
-      "hash": "24151f4fdbb08c3bf21e772dcbaca0aef22622ed540148d7c237146b330a3a93",
-      "size": 158295
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_17.png",
-      "hash": "6c0f7a84c05ec9919382ab34e9a55a8fb8f1d6d1f332caf7ca3c307404020985",
-      "size": 155309
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_00.png",
-      "hash": "1310189b277b0efabae1de9d643e91a4b72c462f736dd00adc9ea4ae7c8413a4",
-      "size": 57926
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_01.png",
-      "hash": "6e573490ba17792bc2e9bd20f707f17ec4669bea7cf33832256da00b48c54427",
-      "size": 58488
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_02.png",
-      "hash": "a98306e48b91384b45147c220a344e70101edf3045b2ffc277ce1820bb4a61f3",
-      "size": 72612
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_03.png",
-      "hash": "697b0617a52baa3316c04b1db2ebb46127146358e222947ae6b6e925f5bcb254",
-      "size": 75091
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_04.png",
-      "hash": "e0e3c3a89093ba76490c3b2fd93093b0efbbcf4287d7bc9948dcb929d983cbc6",
-      "size": 68012
-    },
-    {
-      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_05.png",
-      "hash": "d76d5cf94b8c5d3c868348a5a115fac668abfea7763384c1c51bcf725ac1343b",
-      "size": 73173
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_13_01.png",
-      "hash": "918cf2262f8dee7c169eeea8bde4a40ea1f527ae13486bcc121e013d32651ed8",
-      "size": 568864
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_13_01_s.png",
-      "hash": "d047da0bcefc6908691b25b0eff821b67a5e8213bf2194798ee0dd3171a94666",
-      "size": 192423
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_14_01.png",
-      "hash": "305ccf22386d56322c5a7317b90591066366bc0ebc22152ced2488a54b32246f",
-      "size": 421632
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_14_01_s.png",
-      "hash": "027c12085e6ff7c0389b98325b2f52377d1533e009f4f9a5bbd9ef918f60d252",
-      "size": 142736
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_15_01.png",
-      "hash": "c054767643cb1d579f0b861500c43f59d14bb2a032b56633e34b04c0e40dfb7d",
-      "size": 570996
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_15_01_s.png",
-      "hash": "865a3ed38d68314fe315eb9b9c075f8bbe0159227ad81d1672e0730ac8c8a81f",
-      "size": 194026
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_16_01.png",
-      "hash": "e16c3445a477a4e8e0a8fa1089760333039ed22ab8093d954d6d0eacad51687c",
-      "size": 470095
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_16_01_s.png",
-      "hash": "b6d5c560f6731b2e957c6820a3f0767ffc972b2dc31551c99297bce781fa781d",
-      "size": 158930
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_17_01.png",
-      "hash": "ecdb7990fd393a5fd7f5149aa88f32284b79de41e25d6590027e5430bb13e8b6",
-      "size": 473396
-    },
-    {
-      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_17_01_s.png",
-      "hash": "e65c2fd124f10dfb0c2d8798b8e7ac99b3ab1acba3b9e2a8b7319ce91bf45736",
-      "size": 161660
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10001.png",
-      "hash": "21b3f2859025fd0b3f5f4385466b0987265fa97e85025bbfb6471e299bb1d94c",
-      "size": 11864
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10002.png",
-      "hash": "f15e4533771c5cd51aeba1b43d1a99267c018915611e6651818b5c63e96e3761",
-      "size": 12074
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10003.png",
-      "hash": "863b497bbc449093eddef67caccdc0929edb3fb92ce0f59786d65e9ea7323ace",
-      "size": 11196
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10004.png",
-      "hash": "1c46c243db65e76945782574db314cef8d2e1ecc91b46599ed89b17be7d222f6",
-      "size": 11690
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10005.png",
-      "hash": "5ccd7b789a1d01cd41a04affab2ace8daea961b085e55033d5fb7871b981964b",
-      "size": 12531
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10006.png",
-      "hash": "e31759ba52ef712ee0a347e07a9af89d0900964932f9a943ef47089529bdc67c",
-      "size": 11571
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10007.png",
-      "hash": "185926fead280ad212c4e56bcd1e78f00b63a7c716308f6756f75065e4879c3e",
-      "size": 11745
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10008.png",
-      "hash": "52593dd5e4cd9f81d73270effd69892651730902943be3e4c7e185187a24b92d",
-      "size": 12816
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10009.png",
-      "hash": "e1cc46677c00546c80e6b1cb1fe706be502c9c4438c4b192233fa6702d5b843a",
-      "size": 11639
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10010.png",
-      "hash": "9b1eb38385bbf50c45d9e5171e03ea985e0b5d6496a0ed21fe28b476591a804e",
-      "size": 12871
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10101.png",
-      "hash": "e8a12c5322a63e1bb5bbc4718e02fe5c0f73f0ee4cc44d5319dff753f40856c4",
-      "size": 11293
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10103.png",
-      "hash": "523472fe747338d7a973829ff4f5352693bee00cb491bb939bcbcfc965aba2f8",
-      "size": 12733
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10104.png",
-      "hash": "6d7839e3e268b69b91fa6b5b4d1eb0aefef9d71d294cf642242201fcb7a718f2",
-      "size": 11237
-    },
-    {
-      "path": "assets/textures/race/courseicon/course_result_icon_10105.png",
-      "hash": "0541b970cfd48fedbf58414d40bb1451d236ea5d8d65cae43a41fd7f1127ef38",
-      "size": 12431
-    },
-    {
-      "path": "assets/textures/race/daily/tex_race_daily_00.png",
-      "hash": "981e393c880f6991d75b1e66f59e05cf2b5bb58c3725ebe3cb4df554e7ca47a2",
-      "size": 329395
-    },
-    {
-      "path": "assets/textures/race/dailylegend/utx_txt_dailylegend_logo_00.png",
-      "hash": "82cfc360e7fed2003351dd6659aae331b2a5ebe59757b550aa4427e29e4dc426",
-      "size": 391037
-    },
-    {
-      "path": "assets/textures/race/practicerace/tex_race_practicerace_00.png",
-      "hash": "09e058cca45a95ae10128f3ee550ff3ea94dd4edf28af3da834dbe032d39cf1e",
-      "size": 429175
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_frm_raceinfo_logobase_01.png",
-      "hash": "a215e6ed6b0f36aa47970053e35bac53dbb4afeddb34043a69a786a4b48c7203",
-      "size": 184003
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_frm_raceinfo_logobase_15.png",
-      "hash": "90f5129d25bbb2c0c2d87034353281d61922fc88b9b716c71d721b096c3a0508",
-      "size": 186346
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_01.png",
-      "hash": "63870d5ca840558e2d35384a329e306941f18b4012b0181dd29f6dd609c7b408",
-      "size": 132875
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_02.png",
-      "hash": "afb38155d60a8e7c32874b1b462028adf6c3e2cfc8abb035717ab135897470de",
-      "size": 146235
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_03.png",
-      "hash": "cef014572309801cf2333bfe1f104e548789f8e6a97064d15a9284e55dc009b4",
-      "size": 149669
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_04.png",
-      "hash": "fd91bb4502531d03de8c20c27068a58c0752ef4ebe90f5e9d5858a65b6514b43",
-      "size": 139935
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_05.png",
-      "hash": "d94d6ef996c203e81ac65483dd424d9f7546b26d132558cb2f21e8dbe1c75a68",
-      "size": 146815
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_11001_00.png",
-      "hash": "6b71ee9866544a0873824b70161d3e0f9500af770601e59e1807878f9aa1cce1",
-      "size": 194243
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_11002_00.png",
-      "hash": "b249ab1d60dd315c8cb0c65808d91e724d190238d53267eea271c6c239ba591f",
-      "size": 228212
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_11003_00.png",
-      "hash": "68deebf6f6ff60f2c9b6d3b61d85c54aa0e575081f4937b3d03038c84cdd404e",
-      "size": 213080
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_12005_03.png",
-      "hash": "58808d6f8809ee18c977e303b312682aea9a2669ac0870ea85394923f7bd1cc1",
-      "size": 191696
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_12006_03.png",
-      "hash": "0adf3dadab518ae18bc802bf9a042f482505007a4cc5ec26438e5b847157562c",
-      "size": 258446
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_12008_03.png",
-      "hash": "fb1e09202e52b8888429810ff2374ce884f1dfcd7660a7d65331aedbda0a873c",
-      "size": 177646
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_12014_03.png",
-      "hash": "384beacc4b3d0e21c5e3bff63a8e6b53b1afe2a070fed560cddbdf29b99bfc91",
-      "size": 303524
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_12025_03.png",
-      "hash": "46fcf1e4de868edc95c5011f3e1d8f71436edca0fce42b9b3cbebb0a38f74de2",
-      "size": 284264
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_12027_03.png",
-      "hash": "b3e6096279b33ddf853e793fdc18ed7676738aee0b0da9c546d1a8214b7347f8",
-      "size": 214636
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_17001_00.png",
-      "hash": "b9d6e14089ec686e7064c47da4fd96b3401226a960c0e1ac3df9b715f2e51291",
-      "size": 362730
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18001_00.png",
-      "hash": "6af2c6e2b5fc7382aa5d26fc240948fe5ff56914f8fbf9bce2420c49982e23d4",
-      "size": 161770
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18002_00.png",
-      "hash": "3aab692f92dcf11a18f3b2dabac7e0e97af079230eea1fe956b599f13c7e91f3",
-      "size": 263737
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18003_00.png",
-      "hash": "d5884ebcd701f12fc79a53f187fcdf53540c9e9a200bd2b1017e29b30f7e91f7",
-      "size": 179779
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18004_00.png",
-      "hash": "307d7023bb8a82b2c618d7242d82d9fff5b067527d589025774c14f9b363257d",
-      "size": 265154
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18005_00.png",
-      "hash": "d25331a6a9999022da34219f90e9f330b2136cf2e9ac80258ef6a948ec3306ea",
-      "size": 150089
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18006_00.png",
-      "hash": "5810e640c35dd6e84953b5547f3c058ef0fef8585eb06dbc1fa580216f612ccf",
-      "size": 177774
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18007_00.png",
-      "hash": "381db8f21ade629853d9771a638a5e12fb7517243c72c52cc467f52d86d59eef",
-      "size": 178918
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18008_00.png",
-      "hash": "f68af582fdb4d0f0ed73d485cccee9f2a62acb8935e206ceac946158d2f2c75d",
-      "size": 288906
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18010_00.png",
-      "hash": "6895e9eed9a933fa19910b628bdf3b4f565466b08480bdfd835de1f1108e2021",
-      "size": 230912
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18011_00.png",
-      "hash": "2ab0ca1ab412e7115c693c27fff7ae1076d1dd40cc1f18768eac9bf777ecc59f",
-      "size": 144035
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18013_00.png",
-      "hash": "d5177f623b5b41b53b4d3b31b615e170cb467c19e69481118d8a0aebfd59b7c7",
-      "size": 224717
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18018_00.png",
-      "hash": "7fe1d934e5faacba62408397864cf2a91aa1f656495eb28003aed860c2a0ac70",
-      "size": 249445
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18019_00.png",
-      "hash": "970f0a4fdb4864dfe715f2e4b31d2db7592ce64662010cabb478148209cf81c7",
-      "size": 205823
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18021_00.png",
-      "hash": "dba356c922037a2cb0501d46105c562aeaee9878e8b6940b0ac45593343eae07",
-      "size": 146432
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18023_00.png",
-      "hash": "864f5d124044cd0e8884265491cd1af36b29b7de566598ef454fa5075049f114",
-      "size": 228324
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18027_00.png",
-      "hash": "1847ec86e78eafe3891eedf3f92d881d6b56fa26b8f6ae4911d529b30c43c0b3",
-      "size": 267424
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18028_00.png",
-      "hash": "7215ad0c8e8522fd60ab4c9c66277153ed6c10644f3f05bf331b409ca9113859",
-      "size": 161596
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18029_00.png",
-      "hash": "be40d254795f6a8fd083980d80eb6b05405163464da03f6346f64b7f7227be6f",
-      "size": 238715
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_18031_00.png",
-      "hash": "fe8ec3a23b595e99c36eb5109f87dac6fd3d0dd62124711f40fcb7d3fea01afa",
-      "size": 173391
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2001_00.png",
-      "hash": "7aca7e6720b6b7c51ccabf56c8d3ab14bfe7791831152403547904f72806c287",
-      "size": 222434
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2002_00.png",
-      "hash": "57a2503aab1a50f8e081429719b6b00330d5160a753d604835ebd89e8e190289",
-      "size": 164225
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2003_00.png",
-      "hash": "75240a2b5dc33dee719fba8c5061d19b76e6cf6afd87203822746cae26e1793e",
-      "size": 246273
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2004_00.png",
-      "hash": "c511bade05b35770e0554afb15e3d4765d7994379bfec7d26fee084dbae0e4dd",
-      "size": 145891
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2005_00.png",
-      "hash": "9f88b26ea701efaed96d336dfec896ab2ae9846efd8337f98b7e2789f942bab4",
-      "size": 305698
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2006_00.png",
-      "hash": "4771b07280ab908dc6d23544efb736dd08181896145979c4796530e6b8531e09",
-      "size": 142663
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2007_00.png",
-      "hash": "adc42f97138f8ef40607d78798497dd3e2989fb42cd66a1e2be21f28b397998d",
-      "size": 157768
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2008_00.png",
-      "hash": "41c8f6a263f0679d1f63031bb8abb6c6f9d5ae19c622fe2c238cba20f925382b",
-      "size": 162733
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2009_00.png",
-      "hash": "c385588026b2c7c6e6b5800e9781d7c691c8d967064d024967ef5a1c641d2bea",
-      "size": 250239
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2010_00.png",
-      "hash": "a6d1ee5be73ad1d6bf199ed7dbb1a505b2f4edd4e7f700956ea73d33d40ab979",
-      "size": 219788
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2011_00.png",
-      "hash": "1963f89a47bb09ef9b0a8f667af91c27d86850d7459d82fd6ccb565e08a631da",
-      "size": 154978
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2012_00.png",
-      "hash": "f89c4415337a044c3bd64b691acef6148d6de2cbb157ef12d98e1537bef151c7",
-      "size": 268450
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2013_00.png",
-      "hash": "6b92dff0d500c870701792b6236f2db68075518d1b5759626de6485801ac7378",
-      "size": 340152
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2014_00.png",
-      "hash": "28366be158a0591ec89d39cd70bf576257d53eabd4ba10ade64a07f764ff79b6",
-      "size": 282569
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2015_00.png",
-      "hash": "1727a121b1fc14545e9da8d55a6b878228a92847d67a227c9e29387ed6efea72",
-      "size": 201653
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2016_00.png",
-      "hash": "4da67c7a686343db8182612d532e7016c1915d6f68a55073e783adb0ab5dc19e",
-      "size": 154787
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2017_00.png",
-      "hash": "2b0486b7728c38bb0a40e828764c30c98ce743031831f36cb6fdd2d411a8b5e5",
-      "size": 258658
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2018_00.png",
-      "hash": "998e6bed68dbb654a6aeba0faf569f23101c4a3be08ca06e93ad14faeeefae2d",
-      "size": 272681
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2019_00.png",
-      "hash": "69269f7a218c0b5b43ef0b9c44ea49ac53f00af9fcebe87307a1442a5e71e715",
-      "size": 211155
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2020_00.png",
-      "hash": "5cba9d02770d6f61c85a3d9cb6768917d3d8cdbec6532b015b1dc34b520bc5e2",
-      "size": 185942
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2021_00.png",
-      "hash": "44037937ffe1e5c4f92cc275e28a2343a09867cccc61ad0152b360e8dd8dd480",
-      "size": 248316
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2022_00.png",
-      "hash": "e49a26db0f6479ba4d450d27ae4cdebde2bc566d11e5de807a43a3ac864b935c",
-      "size": 190851
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2023_00.png",
-      "hash": "af4d69eb13c2a1995050b6cf79225856c87ae558a7862989dad66af0b9a7761b",
-      "size": 163510
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2024_00.png",
-      "hash": "060085a2f75643918f633934d559f89109e1f00514fbd1cc2da3cd9ba964fa3f",
-      "size": 259426
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2025_00.png",
-      "hash": "79f6b2c76efa009619de9f1c6ded9cebe9357dd2c3d0b3b1dddeaa86a5c00216",
-      "size": 316288
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2026_00.png",
-      "hash": "e8add020481a2cd3bb0d52af9fe605440a92b7fd7cfa64adbcffe7d85e352692",
-      "size": 221945
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2027_00.png",
-      "hash": "2d77dd4d45fddf3fce2a634e522766b37fcd0a31f26c6e3543f112d571055b0f",
-      "size": 235280
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2028_00.png",
-      "hash": "4ed90be9fe5200ebe507baed4a2b19a5db69f36697aad6d18403543bed0f821e",
-      "size": 252459
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2029_00.png",
-      "hash": "c79db6e5bcc7bb2aceb18c48cf3f54e837b897da50fe533b4b9a4825110f3fa3",
-      "size": 171008
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2030_00.png",
-      "hash": "fedd1213d4a0af2df52635639e3ec67810998fabad14955f02f6c2da0fffa957",
-      "size": 392082
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2031_00.png",
-      "hash": "04099d23410f9361ffd38bc41e743dfa36ab7637d3d897e2140cb7751b9c0fe2",
-      "size": 314458
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2032_00.png",
-      "hash": "b949b4a319a21fc5893fe3beaf985d64aaa3c0dae0fcb3e9ea9a79826ab23c61",
-      "size": 373154
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2033_00.png",
-      "hash": "cecf176addcfd6dc1b5894fe2ffefc11c9ddf9ca92672e7eb2644bf9df498e52",
-      "size": 252013
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2034_00.png",
-      "hash": "789c01c5fb9f8e3e0ab8337cf747590883da232ccfa50e7ec081c19f28bf3aa5",
-      "size": 178135
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2035_00.png",
-      "hash": "7ae8d6481e8734e3eb3e4a884ce4c1768dc09ebb1bafa19cf124121b6cad4331",
-      "size": 219788
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2036_00.png",
-      "hash": "60c6ff637276849062c485b9add91a438b42b2be07a325f051959294aefaa3bd",
-      "size": 199217
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2037_00.png",
-      "hash": "ab5b2107c890632f61c897fe0dd058d52d10f0b2e681c3da7754b99bc7131dc9",
-      "size": 139217
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2038_00.png",
-      "hash": "fa5d7f988639b9c19993a5cd4fe8668330213d49b10fd92cbeddd9739b131b85",
-      "size": 173558
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2039_00.png",
-      "hash": "d7e4392b9a64892ac18feb2dc62d7b186f12d87b4d9f3648ebb0b7e498f78930",
-      "size": 195461
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2040_00.png",
-      "hash": "2ef35f77b7062b174b27d90bee5865f326dcb9b652141db9dbe2fd25537a384c",
-      "size": 159151
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_2041_00.png",
-      "hash": "5a6ada1c707d440bede635fd188f9a8f0630b4988b7fac20d049a1a83cc4df2e",
-      "size": 265729
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3001_00.png",
-      "hash": "582a7a39ccd9791d4a0374696d888ed47d3a536e167dd3fa8c5bc99119ad6e6b",
-      "size": 178868
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3002_00.png",
-      "hash": "84718f99fb02a020126e1b3ca02a4771307ef46a5c5f25d72161daba002f0b38",
-      "size": 220610
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3003_00.png",
-      "hash": "f2598cbbbce4b9483a29f2f9d81f7d5a7573fefaa55b51df39e77e07a5fa560c",
-      "size": 203172
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3004_00.png",
-      "hash": "3aa9c872612c6cae4eb02416179bd9c0f281f55e0a256b8da44eabf9588d7f80",
-      "size": 193220
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3005_00.png",
-      "hash": "fd7d89534aea51bf18803cfa50b59ef17c73ec5c3935c8d55a08b8b2d4e4b274",
-      "size": 130994
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3006_00.png",
-      "hash": "10d7ee550417e4adc1a814de92f6f07fcf310114d905e6ed663b85defcbdafa7",
-      "size": 132145
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3007_00.png",
-      "hash": "8d091395aa4eb8343dc1a72123264124335c7e2a07aba28963150ad697f925ab",
-      "size": 278203
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3008_00.png",
-      "hash": "594f86e1704809721fe821214616aae0a2fb5a5f67586a28f9b7b679d7da60cf",
-      "size": 235581
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3009_00.png",
-      "hash": "452cfdf04636867e6f340b15928d0f3a73f382a3466a615c150801ed468242bb",
-      "size": 212360
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3010_00.png",
-      "hash": "f5f18728f2123bbfff76e9771b271201b808f51e352079ec686359d0f9e2d962",
-      "size": 252280
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3011_00.png",
-      "hash": "ce24a0f97fa58f8fbdb7b3e8ea4b6bb0066a51a7f9ed4420817be1d5bbaef4e9",
-      "size": 344186
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3012_00.png",
-      "hash": "f441e48080fdd5d10125098b7a816ecd37a92dde9dac5ed21f3af07dc8cf068d",
-      "size": 241067
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3013_00.png",
-      "hash": "e00ca21ccf556e812d503d7097b8dd587180da97d8f5926dd00f63df86070ad0",
-      "size": 252355
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3014_00.png",
-      "hash": "6da53afb89de36c0f6a5cc49167f905b8c893b990e1bc2772ecb28869aff28e5",
-      "size": 263546
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3015_00.png",
-      "hash": "2e5e0fcbcbb952e1c229538c656d745c2a2cf8e5793d164f1de5d27b8c5dbc66",
-      "size": 287024
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3016_00.png",
-      "hash": "438b4428adc8a2e25e58d63f69dd5ba5448d83ce2216a61c8d613e29270726dc",
-      "size": 211064
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3017_00.png",
-      "hash": "1afe696968b729b86a21d7d4c26de413fbf9351af44c88c421c1bfe5d11ca2bc",
-      "size": 139726
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3018_00.png",
-      "hash": "960fef827a91fc620809c87a2ea3a4a568d7c3d08feece10f1f6220d709b7634",
-      "size": 145350
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3019_00.png",
-      "hash": "8bab03758eb66618635eaba7cd045b73fa4d253a456597994f79a511fd7363cb",
-      "size": 250444
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3020_00.png",
-      "hash": "c64a237dc21b0d02d808b815a0e82a4db35849086da1c8c6f85d69b336d1520a",
-      "size": 327115
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3021_00.png",
-      "hash": "8c6df85d6733ce54430162c88c89fe790c36060468ae49064a434598f698726d",
-      "size": 238003
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3022_00.png",
-      "hash": "da9a1c8ec8cba4aa1e8b6b8397cea8787553202b392a877211e0eb491cc5436b",
-      "size": 184801
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3023_00.png",
-      "hash": "9a150024b14332e01e908e4815b732e4e373515ce3777bf9bd06d50428473286",
-      "size": 166795
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3024_00.png",
-      "hash": "25aafbe20e4eb4eebc6be313994038abf66d0f9f1607485b52e235b1c00e62ee",
-      "size": 239084
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3025_00.png",
-      "hash": "9e3b099f147aa110d19a194ea39c8b5e8549581294c69c9b6d5497c4b24f33ef",
-      "size": 268055
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3026_00.png",
-      "hash": "4659f2c068c73cab838019321f441bf5cca287ebdff5074d64a2ae5710cd67ad",
-      "size": 250655
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3027_00.png",
-      "hash": "88486f921b644faebb25b5507bd5fad92ecef3820a2a5b27140d93e1c4273c9c",
-      "size": 320394
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3028_00.png",
-      "hash": "73fac33bff75ec8c6b13c31280872e2528e80651667cc07c4200fae941aedb38",
-      "size": 276417
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3029_00.png",
-      "hash": "0ac61a1276c02d3693df326c6b4591043de7c26c925bf6b2e0ad8aab63a601fa",
-      "size": 187512
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3030_00.png",
-      "hash": "e2038333b8c8731e866e58e850f2314fab6c5f36cd89623e4844b99360371ddf",
-      "size": 205084
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3031_00.png",
-      "hash": "07fa92005e25e904c58f44a04055e2a27906d03b952310fee6631d3e8d850fc5",
-      "size": 266709
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3032_00.png",
-      "hash": "39af7bece35a9a0631cfa36712bba24689de4a92c2f4b48b19dd8b6f7d0fa17a",
-      "size": 181134
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3033_00.png",
-      "hash": "d9619ff28d90c078b03f85a3aa0de3abad47e7c91bf2b5900b41d2d3e4b944cb",
-      "size": 239771
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3034_00.png",
-      "hash": "f451344ccbd4bed802a1160ca009d08ffd42a5ae68076ea6ac59bd8355657a21",
-      "size": 367344
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3035_00.png",
-      "hash": "b7b087a2b0068252df86c52af878725da79fa0aaf559d1925297c7c5c7367376",
-      "size": 155525
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3036_00.png",
-      "hash": "f34398e021d9c53f800f82677997deb53c547efebf04276052f52d2fc5093f75",
-      "size": 242115
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3037_00.png",
-      "hash": "8fab6a036410a365810d6f4996a630af08da12f7dc6bc1c83d5232c0a7baf7e5",
-      "size": 247682
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3038_00.png",
-      "hash": "0b9dfc50831a6b0fe804f824eade900316fac49d43c91fe2e0f494d7ceab5150",
-      "size": 169696
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3039_00.png",
-      "hash": "bd49272bdb65aa8a5d718e3a5bc56b2b13eb5b3fc4ccdc74633d252f74ccf222",
-      "size": 209540
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3040_00.png",
-      "hash": "12973b2889e35edd35a8e9e5af97abab2dad6c5611b1cd567cd8848474108dde",
-      "size": 203837
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3041_00.png",
-      "hash": "38e4efba3e3f2da9ce0a24f3258d3068e8c7a4a0396467f4af8cc4375d896098",
-      "size": 362699
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3042_00.png",
-      "hash": "209678abb9e188d9e1f8f296ca69ef5d8756bfb64e4f8302f8a8cae0eeb02cc5",
-      "size": 286036
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3043_00.png",
-      "hash": "24f7016701122f5f34c329eb8b2d9eeac3728f138027541b9c4c0d0f0ad87f5c",
-      "size": 199816
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3044_00.png",
-      "hash": "4e00e41d100efe8bd08761b266f4006248f1cb72bfdf19da6f80b13c9ed1f25d",
-      "size": 208556
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3045_00.png",
-      "hash": "3bde1a4c46eb379d7ad8fffdb5679607ae971bdb0e906f58fe26255ab7d982c2",
-      "size": 244716
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3046_00.png",
-      "hash": "a76e1ea450b0afeb57871fcea824d22e9ac93268ec216b426dff339798ed65d8",
-      "size": 188194
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3047_00.png",
-      "hash": "efa2593d8d91c70b7a75f75a8c04186572ef830dc9645c99d68ca5efc6fa7075",
-      "size": 193601
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3048_00.png",
-      "hash": "ff42c780c2a1fc52123eb3d9991c95ee7490ac29507592bf4ec904b81a0ad42c",
-      "size": 230267
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3049_00.png",
-      "hash": "794e0bf1a2a25ec680afc7d692fa09763f7732129dfc61dbcc50937df6ac96ca",
-      "size": 331843
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3050_00.png",
-      "hash": "937b529f0683ddf5583495eabf93a0ec7509dc3332a00a7294fd2689b865afd3",
-      "size": 190360
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3051_00.png",
-      "hash": "1c209efba5f5674eaa9a55d451bfb8e40c38f1ac42761444f6853f03af5d49b6",
-      "size": 417591
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3052_00.png",
-      "hash": "d6d9797ffbfa77f172fb13e3067e4cc7d95c3748d568c29f83c2412a3ff9801c",
-      "size": 352930
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3053_00.png",
-      "hash": "6302171d633909b8d87f735eab26189f4df5769ec7a8e35c5a699c603a96f6ca",
-      "size": 177876
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3054_00.png",
-      "hash": "973295a1dbd31bfeafa11acadb1fd17038b443477c73faa9f2ef7af2e3ef320a",
-      "size": 185661
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3055_00.png",
-      "hash": "9ec7ff9ce050912f1aa5e10430199019241741ecdb363209bb7f069ce2d84238",
-      "size": 266248
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3056_00.png",
-      "hash": "e6769bf3343b478e8085307b45e980b21f07c1786e2376f679b2dcb0e4b524ed",
-      "size": 184002
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3057_00.png",
-      "hash": "d87b1e35afcba43421ff845f414f215f3f1bfb3c907f1f9593bc5cc6bfca6007",
-      "size": 327017
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3058_00.png",
-      "hash": "5a519d8cea4841f99c67d8897af01a986be310fcb4f85e9c04ce61335d198e3a",
-      "size": 187122
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3059_00.png",
-      "hash": "9cd6941b30634b32bf4f3f8c74cdc9cf1e4be5dcc76027987b6ef198056b436b",
-      "size": 248975
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3060_00.png",
-      "hash": "96e025a9f45d6b972563c4b635ae944154bee72c1cb18aebac1cc68f7ca23639",
-      "size": 229634
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3061_00.png",
-      "hash": "a765a7a3b02079a8ee3491d181436a043d6da1189a816c0f072802efa619667c",
-      "size": 248786
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3062_00.png",
-      "hash": "dbfc335dc47ffb280e4d6a25d295a50582a741ad01ecccb327f9d675da8c866e",
-      "size": 284458
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3063_00.png",
-      "hash": "73efb7b088abae90cdf40cd613a9e49530b87f2af7d0babeebc51eb5c2c7c9f1",
-      "size": 218616
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3064_00.png",
-      "hash": "90ca50605d067fad5e48a2a3db4f0516a4b94aafe0ec24d62ddaf60b0ee5550b",
-      "size": 349741
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3065_00.png",
-      "hash": "351d97f022724c6f36967b0de089dcc78375aee96d627fefc3d63fd4e53be5a6",
-      "size": 330399
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3066_00.png",
-      "hash": "0a9481cb17a7520671dae00995b66adc5d8ce589996337b7639904d38ea6c89d",
-      "size": 141704
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3067_00.png",
-      "hash": "49777ef35387e54df01acd2f23f908c6e3efbebbc814cbb8196b59fbd9f53b6f",
-      "size": 211953
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3068_00.png",
-      "hash": "52a21414398a2dd409d7aba1301a16e46395aaed1b23bd90005ad485a0119096",
-      "size": 288058
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3069_00.png",
-      "hash": "7ff9d27c66e58ab6cd36752327cec1429396364a8d228d7f674254c6c99cb68e",
-      "size": 219881
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3070_00.png",
-      "hash": "2271f907c106a31ae96c34f1155f82a30127be7a74e872805c993a56cdd1c45c",
-      "size": 263055
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3071_00.png",
-      "hash": "7c89ec29e4a316d04289c3576e9e03d7f8187239aec5e0eec563566b9b9c3479",
-      "size": 323592
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3072_00.png",
-      "hash": "c6519fdfa1e4307df4d82de2c60527be376109939ad74b8cb0c182c0f0d2f4a8",
-      "size": 236305
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3073_00.png",
-      "hash": "403fc2a16d9782be7722a3aada8cd5202aa7b72f8363f9465ec4413d31d51e30",
-      "size": 282453
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3074_00.png",
-      "hash": "d241ad7f4fc6579211dfeb055333b0bfddfc5e3e2875870805946e45efb60ce8",
-      "size": 201886
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3075_00.png",
-      "hash": "f12bd7c4fe0c3e58bdf54394d5b5aecfaac74d235c149d4c3168e8ba1f2f6369",
-      "size": 195868
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3076_00.png",
-      "hash": "30b3c67714202b85f0e6f09edd05a37859965662a32f14ea79fb0e0ec18d6812",
-      "size": 253236
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_3077_00.png",
-      "hash": "171ab3b40acbb86103dae58c995ecdc88005016132c970eb2175a62b4d5c628a",
-      "size": 162821
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4001_00.png",
-      "hash": "a750e58e976756212280db6c74523ee45beb5f5b93049a4c58b1701310c4d303",
-      "size": 230831
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4002_00.png",
-      "hash": "7f8d064c473bf603894c40c1f05c20e5b86e0e9527b20be26df8fb5cefb29c93",
-      "size": 166147
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4003_00.png",
-      "hash": "a282ee03237365ed9ba6ae7d61faf06bf04a008a0e7e751e87bea9bae7c974ee",
-      "size": 289557
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4004_00.png",
-      "hash": "3351405732c409d7ae93e25276443346454e260e1e6c5d64b242387496e99697",
-      "size": 220279
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4005_00.png",
-      "hash": "08469ba2191fc6d5f087d6851ba8ce59b9399861d898ccf668d9e44d38676ead",
-      "size": 267392
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4006_00.png",
-      "hash": "dc516f19530954ff98551678957a15c576c9f561043cb68e8f63b60f9e53cf40",
-      "size": 254310
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4007_00.png",
-      "hash": "1f679dfde571c77f39f4f9f7875be949baa4c702075744dfc05e306b02825e2e",
-      "size": 205717
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4008_00.png",
-      "hash": "dc5a7be679c62eb7f8351ff646ac4a57f46e08e9b410d2186cd7cd70e835277f",
-      "size": 225757
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4009_00.png",
-      "hash": "dd4a1547d9f8fa477aeb88970dcad897f42532f798f494455d981c2d0b7de06a",
-      "size": 276409
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4010_00.png",
-      "hash": "36509e7084819a0e6bdb6491d4c569d30d4a4f6bff30934b1fbd4923124ec2c7",
-      "size": 281304
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4011_00.png",
-      "hash": "d07c2db8666dde6b2e91492800d0f1a45525a8ba011f58e9a6c04fb4e76c5eb8",
-      "size": 248051
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4012_00.png",
-      "hash": "3d9458130a214ad8542041e0a13ea316124c3caecf8278a3f862b4ccf2d4490c",
-      "size": 251825
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4013_00.png",
-      "hash": "e44bea50a62f11955c5843e78883e3253f93b5dd9fb3a28550a6e555f1f441d4",
-      "size": 227483
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4014_00.png",
-      "hash": "a115313a217e7c30d46fc2dbfebb6ab1b5a77e5b0cadc4a0f65f9b788dba240e",
-      "size": 170555
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4015_00.png",
-      "hash": "4f6fb37095efd604d024e91ed930fe16174c3a2ec8262ef7455edec954df6126",
-      "size": 242052
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4016_00.png",
-      "hash": "1b87eed4e064c255b79c870350eac76487ba54d0d28925ec467c46dfc0704c94",
-      "size": 253696
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4017_00.png",
-      "hash": "6c974f1b2fc7f97891dd8379b8d7f2a3be25e8c7229a2330db9481acd1f7d193",
-      "size": 226815
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4018_00.png",
-      "hash": "6616b08bc78aa60638d8c89b0b58f50e27b1caed80ba651c8748b05e05cf66e7",
-      "size": 245659
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4019_00.png",
-      "hash": "e0637cee99df4a67853418e9d8a828d7b102228f35e4e06f8251335d6ff36eda",
-      "size": 194886
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4020_00.png",
-      "hash": "c8499f08a3336bbbfea0a991bb7777fbd3d10b54b52fa53ef0e79f4f7ce5f421",
-      "size": 235665
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4021_00.png",
-      "hash": "a3784a861129485bede57bb0cc667a84374ac2350521d54f2863748f428d027b",
-      "size": 255115
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4022_00.png",
-      "hash": "aedcf1d1beb672e42469f3a626c3c87808c5a48572038b28e6ba9051b93f9e4a",
-      "size": 234564
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4023_00.png",
-      "hash": "fe79215e21aef09c23fd671d932ff63bc0dcdd34f395aaec030255e011f91a26",
-      "size": 234006
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4024_00.png",
-      "hash": "3ce73d59edac77644e45c9b217a93c7727aa6222f37800c0c93bb3ffeaf180fa",
-      "size": 231354
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4025_00.png",
-      "hash": "b130b19d49ede3b105e0581e14f61f439f18902108e425c14dad3d3b4f844538",
-      "size": 242330
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4026_00.png",
-      "hash": "c0ff88a52e70c9cf9848c83065f62f3f13024fcad9f4dea3369ce23694d298c5",
-      "size": 222443
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4027_00.png",
-      "hash": "4c2f491d1527c319f84a97944d6705c7dd07adf4be9b13efe0b014f4a1b58c54",
-      "size": 224940
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4028_00.png",
-      "hash": "d8c195191495e912c5bd79e376d21e80f0bf40ca6d8ef2d8dcc8070f74676e75",
-      "size": 183996
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4030_00.png",
-      "hash": "61492fd4c401322c307a411b17c34e97abf669c7409c748d27a5d23179fd481c",
-      "size": 200464
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4031_00.png",
-      "hash": "92fda422f1acdb81a4ee47836ed7edbe4b7be84a07f73d206e739b0f32ef2be7",
-      "size": 221750
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4032_00.png",
-      "hash": "eb46d45fa778bde28089fd6445f674ede8250da545122d495187d11ba720aa8d",
-      "size": 269685
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4033_00.png",
-      "hash": "41a3d94ad6da8d949da01fdeddd338ec9029f06f2c34db1a874ea59fa63a74fe",
-      "size": 213396
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4035_00.png",
-      "hash": "749b4adaba325d32a3d388868c5b3658a6b3f230a7973118db1c50d8a3be77bf",
-      "size": 307599
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4036_00.png",
-      "hash": "8f635b579ba80817442aa3c7fb1172f9b712880f6d204343313a599aad543c58",
-      "size": 210003
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4037_00.png",
-      "hash": "3d070ea008d2c2fb86b1793c774a45fde87e24348eb74c3886eb808e5528b3de",
-      "size": 239985
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4038_00.png",
-      "hash": "82b9f46f5a861b6c704be75f99531d573e3f11358f8436b1a7de06b93e34eeb3",
-      "size": 284304
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4039_00.png",
-      "hash": "c50efc4861dbd3dbdf0daa9705815d76883934cf9ede9f37ddf1f96abccd2881",
-      "size": 234331
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4040_00.png",
-      "hash": "eb0fbcda0f45dc77a3b4754e0128457a1f03707ec21098ffb095b141bf524097",
-      "size": 177707
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4041_00.png",
-      "hash": "ce733606be1ee448a10973a67fa4ddc5c9b6e43f024f6c764295418db6891373",
-      "size": 228643
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4042_00.png",
-      "hash": "18d49c71b5072df55d2fea640df5ccd12c0c5cbf1cf1714624b4c8aac4c772df",
-      "size": 220146
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4043_00.png",
-      "hash": "925cc9e2ec333d780ed3d24939f332ff42222fbaaaf3ec2008e82aedc4d4e305",
-      "size": 250385
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4044_00.png",
-      "hash": "2917c63a333b1391330608de283140535fbf81712311766e30a36dab10e15e34",
-      "size": 337946
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4045_00.png",
-      "hash": "8847be432544843ab41c2c2c79aa4a8dcb254d2fa5c0e372115bb73687ae59d0",
-      "size": 244972
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4046_00.png",
-      "hash": "22e87b1e20b9c8dddb6cfeae886c21b2f9ff50696e2c3606b3b1e9f6d2a76225",
-      "size": 343852
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4047_00.png",
-      "hash": "8aa26f9643eee4bd13fc840a22271b390ab571343dd73fa5a42241741db147be",
-      "size": 230916
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4048_00.png",
-      "hash": "22599fefd0cb62267c396fca426e720516faa57ffd693252bb51cbcb7e0a2d9b",
-      "size": 228158
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4049_00.png",
-      "hash": "031420fb836ec36e8177bd343aaeb8e1d0c802df2013297b71f00531cfe5b0a7",
-      "size": 288593
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4050_00.png",
-      "hash": "1b520787dab88c3bd78361c338bd1fbba6a1b3b23138aea6cdedc7109a420dba",
-      "size": 194420
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4051_00.png",
-      "hash": "bf6cce298d1bcde5560bcd6ae7ae3df723f3537a6d5bc33d38418cce80b91b1c",
-      "size": 175598
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4052_00.png",
-      "hash": "cc55a81e7a29542bdf9d44c5ee986f22a1564b306fae9464fb1e1d810e00d72b",
-      "size": 225215
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4053_00.png",
-      "hash": "63d9c312714c103eb8dc55b532df5dfc681604e3eaf31a93ea42cb75015db96c",
-      "size": 177466
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4054_00.png",
-      "hash": "c39caba69101c26a13d30f7804a626424bdcb73e37345488c49e7ff9f5ddda25",
-      "size": 181647
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4055_00.png",
-      "hash": "9c55f8d1b5b364d6ce7b7eb69bb7a76878683dfda7d1fed3e7a52ec8613ea702",
-      "size": 211397
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4056_00.png",
-      "hash": "c55d50d382e72300c8b5e4aa27bb5e1de024a77fc7d29828219095d1b7762ab5",
-      "size": 243705
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4057_00.png",
-      "hash": "a9e9c68b76f7d2352b86c54bcfeb55628c2fc57947c44d93fbacec57ac80f640",
-      "size": 222981
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4058_00.png",
-      "hash": "6333830deda4b2b95e66cedfc17ae4330ac45371dfda81d6a3cd274c58dadfc2",
-      "size": 258004
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4059_00.png",
-      "hash": "2c9adda7f022acb511cd7a6c6a6a7da23092835a6ca21f98764abcbb7a39837c",
-      "size": 232979
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4060_00.png",
-      "hash": "bcede8484d00a5b820b4384338bc726b41fb2481a68a849ce10c31a31f11026a",
-      "size": 261470
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4061_00.png",
-      "hash": "7109f59894c0cdd1e7247bdc5006917dc0c82042e9d2c92c81deb7aa5aa925a5",
-      "size": 232884
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4062_00.png",
-      "hash": "78caa4d85e09bcccc9eaf5d14b1fa87a1dc4c57128c2144621c60b82028effc6",
-      "size": 234078
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4063_00.png",
-      "hash": "94e545c2e4488f698f1e11137a7dab7812214aa844ad59ec1080152e25770af6",
-      "size": 238295
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4064_00.png",
-      "hash": "f1ba807fe1f3aae516bc4faab781716790e9a56af087902033ffc0a3c296d847",
-      "size": 139013
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4065_00.png",
-      "hash": "ae300bf5bfb561c27ea472d881bced8a3cdc9c7c3cf0da73ba55c152b8397aeb",
-      "size": 232476
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4066_00.png",
-      "hash": "281ac4449bc91cd783c548834bfeba8359dfe5b2fc0cfce28ed0ebfe1e881029",
-      "size": 184469
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4068_00.png",
-      "hash": "3fd1ae083d1e2d9ab44d7cfc1b80a7a1a6bc80111d18b91c5f201e35491946ac",
-      "size": 378776
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4069_00.png",
-      "hash": "05c24ae52ecddd2d1a55fdd1dda58798722084dd4e4a5bc35358f8124fe2447c",
-      "size": 313145
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4070_00.png",
-      "hash": "13b237156d34c25147d67b538277501b5c9e86c03dec8b5d26e132e0b170a964",
-      "size": 151827
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4071_00.png",
-      "hash": "2f398347b4647a433deadf5f324bf41ac924b60664d6ce2fc11ebe6e5e799401",
-      "size": 313714
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4072_00.png",
-      "hash": "344b06a9a706ff050247654911c0369dddb80b9f9cd747fccf5c786a204cf829",
-      "size": 138819
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4073_00.png",
-      "hash": "dfe6ac6ea387567863fd2f483be6d27a5c8f0c431217c54337c094441641a934",
-      "size": 185063
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4074_00.png",
-      "hash": "bd19325b8fbc5b1ccdda6f344f07a7fb49f4077bf0c5aa7100c02b44faa58b1e",
-      "size": 170953
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4075_00.png",
-      "hash": "3c4e537714fddbc3a6b41c28330a5ca8477801b1ed80ebca78fbcde24e67f93a",
-      "size": 173242
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4076_00.png",
-      "hash": "c14c17722fcf359152b809ce4e1f71a2427229d9b09750d0355bb378154a2cba",
-      "size": 135896
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4077_00.png",
-      "hash": "8cc82a13959eedee031c1aeb2d3c4a9e5ca9034f756bb91f3aa6a17900a60770",
-      "size": 168639
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4078_00.png",
-      "hash": "61b7677db00901552adfaacd9589b455edbc9ef8f3cd550e62ef388a2a19599e",
-      "size": 203595
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4079_00.png",
-      "hash": "992ce754f84197af0ebac5cfb4cc3eccc25f92cbde712708d318a0fbdbe7869e",
-      "size": 133788
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4080_00.png",
-      "hash": "3dac3ade004e203e7bda20f8fcaee2f930b7c1efed253377d0cbe47400481e7a",
-      "size": 319648
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4081_00.png",
-      "hash": "358aa85835dc565956a45eb28154263b1571b86a9bd9e21391ca6c717b1d8f18",
-      "size": 128552
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4082_00.png",
-      "hash": "c21e54cd9660326771f3556b488713aab962c6e520cc40f68832394bf910dc0d",
-      "size": 234183
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4083_00.png",
-      "hash": "f43229fd6c7130b6b0f370a169d4f362d387965df80e04fedd432c8c0549c23a",
-      "size": 168094
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4084_00.png",
-      "hash": "ba835215059679d3195b7529d1790a06749fc127ad29cbb5113f97e36b53d5b9",
-      "size": 179781
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4085_00.png",
-      "hash": "8d23f0ba0b46976ba7eddb256ccbe46ea903a074af164eca04444946c354e2b7",
-      "size": 253351
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4086_00.png",
-      "hash": "a80ad9ce808fb2c3aa08b0a46a5ecc22fb393a877b5285e8cff527fe7f832138",
-      "size": 322295
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4087_00.png",
-      "hash": "b06ba722c8b198459191ece83d0948a50b354f04752ce649689b50bdb4b44515",
-      "size": 192798
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4088_00.png",
-      "hash": "e177747794ac7613b987933f42e5b38b7349a015eff9035e99837873c44a5670",
-      "size": 209303
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4089_00.png",
-      "hash": "9ace2f2ba4d51ea9d27d761ec44b41007bb6e2b57ac2090173be42a559710d8a",
-      "size": 238598
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4090_00.png",
-      "hash": "28e05f7f13d46945e937376c8ec700146645d6a655eceb30d3deef6659065af4",
-      "size": 278830
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4091_00.png",
-      "hash": "e6ba68e2922e8a94f5f1b728e3185769d6ce1428fafcd0474644184aa0e66e71",
-      "size": 191466
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4092_00.png",
-      "hash": "958cabb6f38f19067f9b77e72d05e985f77035facd1edbbc365451440a7f929b",
-      "size": 262790
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4093_00.png",
-      "hash": "f2e42cd84065dbb9304d3821c96082aab4823270ae2a7a6b1a315fdd86476c53",
-      "size": 230876
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4094_00.png",
-      "hash": "5fc591b06b6436fa7524d3d6623ec8256f00679b788f9824665fa0c86d3ab7e6",
-      "size": 257675
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4095_00.png",
-      "hash": "6f1c5740094d24d13924648f3ead0344a72b6eed4c7c8880cf3b97ad9bac7b6f",
-      "size": 248074
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4096_00.png",
-      "hash": "94f32d95e0c3df2253c6b6726f1833c70db7a3566ed14d31e9bb3d91ecd619d9",
-      "size": 163376
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4097_00.png",
-      "hash": "7179d2489a13638e2d9502f0a10ba41dd64c6da4d1a3f598f7649a062588b7c2",
-      "size": 296263
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4098_00.png",
-      "hash": "634b7d41ecc87e3671f1c838ab2af8c4704809e4ba0f8de95bf85f213a1045f7",
-      "size": 172646
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4099_00.png",
-      "hash": "4c00b3f0075596c01e29b7c0e7a0375eaa7640334e5fa522a391ad659c19da69",
-      "size": 182665
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4100_00.png",
-      "hash": "b7efc39129bf694ff108573b44d29293c41b32f323e11c0ea2cbc7bd5a97abdb",
-      "size": 256065
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4101_00.png",
-      "hash": "9477028d2128b0fe8890fe2297c0539dd77e7cbd8b4a06e41863256cf0beefda",
-      "size": 343452
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4102_00.png",
-      "hash": "368d4ae3d5fd585355dfc001d6d52b24712f9df216591fe381f52767eae703f0",
-      "size": 135261
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4103_00.png",
-      "hash": "6c7329d335fc81f19e73323990ec0230938644dbe0c4bca8e59c6a251de0dd7e",
-      "size": 414093
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4104_00.png",
-      "hash": "6ee8198a1cdc7c4891c8fba9cb0ff546881c2fec28273a53fe9af0903f40603c",
-      "size": 279402
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4105_00.png",
-      "hash": "e3f4caed4a2df19aa70f99bf17bc01c14c821446d501a0b40b60c4c944f7b65a",
-      "size": 282024
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4106_00.png",
-      "hash": "77b9145b9e3b2b6d0190cbba25b6f16f306c3dd9f487396aa3b4d377f2e1f979",
-      "size": 281435
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4107_00.png",
-      "hash": "efcab9b89a50005ce9ac0cb6d87d00709907d5bc42094a8d02fff094475c4c42",
-      "size": 211949
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4108_00.png",
-      "hash": "c1d2a7f8a6c62239826a156e9fb685d61f8f098b34c6cfd0f7ce61b22d460b0e",
-      "size": 300329
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4109_00.png",
-      "hash": "33fcaca32917d15903e5c0fa5e0a80b4ab64a356fbcb88f5561968b5e616375e",
-      "size": 235811
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4110_00.png",
-      "hash": "5a7027e08fff1930013d307e50a04eba324dafc74b252d2822ba40f6ee98004a",
-      "size": 257107
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4111_00.png",
-      "hash": "022fa11b247f20d1ecd7657946ab291e327a5f8c9d7f49720132271c87ba87cf",
-      "size": 197808
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4112_00.png",
-      "hash": "b007f1eff4937b7e366690f1888c9d9d82871ea7f75c9f5b382c5067a1774249",
-      "size": 220351
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4113_00.png",
-      "hash": "85f29461d860166aab22bb68f90fc1091b1f95eaaa6ee03b847c30f87d23874f",
-      "size": 251064
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4114_00.png",
-      "hash": "0b1bd78531d739581871d1a6a894233055b82d211f1d2cb3833a67dcc2c2cddd",
-      "size": 331942
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4115_00.png",
-      "hash": "912566e1d00983f2ef329aee397a77fc7a7489d9d2e92acfef6148585ed33eb6",
-      "size": 222507
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4116_00.png",
-      "hash": "081368268a313f6da2570b96b79a18a2b9769cc50b0f9b2fc95e21e101fe381e",
-      "size": 247140
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4117_00.png",
-      "hash": "3baff1c35957ec072f9ad6a17ff5c08ce9ce2bf1d06bab6129e1e574de4e782d",
-      "size": 317108
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4118_00.png",
-      "hash": "af312b6bff8ac0a3d0ab51115f1af7bf8ef4a61d1d1325578c7f05766ac05eb3",
-      "size": 296062
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4119_00.png",
-      "hash": "e8a74d03514c450815d34e7ca46356497ef22507d52c0d701f0ecfb45aa01a71",
-      "size": 227027
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4120_00.png",
-      "hash": "44eda9fdbc0e3562f7a3a777a35f11106f5d1a48b896d93fcd3870cf91889574",
-      "size": 262749
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4121_00.png",
-      "hash": "d50ed0d2ab7023e18f641d1204a75734b45abbe477a0bb74b7a729d8e9c17176",
-      "size": 246693
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4122_00.png",
-      "hash": "d6bd79e4505ac8ddba3641935ca7334caf8c0436746f4dde799839cd57d30c72",
-      "size": 265376
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4123_00.png",
-      "hash": "aa56da9ab313acb3f96a7ca002ab5d9fa24a14ae892b4dd224bb672a6b70bb19",
-      "size": 245484
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4501_00.png",
-      "hash": "e7419f3e0ba90f37a577818b60a372b6911ebb9b107830400530388967e4ac8b",
-      "size": 175064
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4502_00.png",
-      "hash": "a3da8e9c65d0867f685d8c60fa6f75a52f238911adf85fb0c9d73a2491018758",
-      "size": 149175
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4503_00.png",
-      "hash": "3782a3ff613c4b2956b1e87a6af75675f8db678d71e96a6c727739e09c24bc1e",
-      "size": 157040
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4504_00.png",
-      "hash": "1aec6f977f18c0aebb99e5756376cc09919ce6dbc150f8d3a6d7295db6ab3990",
-      "size": 154417
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4505_00.png",
-      "hash": "39689bb5b22645759f8997291a1baed03765c96d6076b9fa596ced3da0e29d33",
-      "size": 232585
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4506_00.png",
-      "hash": "2187b0bb81ac410132a14d768a7c05dc84f6e70bc3c5dea7b7937118206bfa64",
-      "size": 236238
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4507_00.png",
-      "hash": "85d0058f0caf97da1d977315375a24adb173518d917f4c4a91a7a8fe2ed145c3",
-      "size": 410515
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4508_00.png",
-      "hash": "79f4fe0cfa678c73287e4daf06babce976738755e087c38283819d3b9f866084",
-      "size": 313334
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4509_00.png",
-      "hash": "39b042e5049e3529eed829808815b5806f3ad508f4f82060908500f8a12e2433",
-      "size": 196593
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4510_00.png",
-      "hash": "f08ff01f319a7af22e4eb9fb5429c476cba45ea7f5f87d4fe09395488adf03e3",
-      "size": 181187
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4511_00.png",
-      "hash": "31314479029a640d7767049101a79ded542d6aa80b21dd9f5e418d8d0d0bda08",
-      "size": 218716
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4512_00.png",
-      "hash": "196bc7079a1ae66f6b33b736a47125e25d3f6cd7cbdd3b0fba0d72a03105b0e5",
-      "size": 217825
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4513_00.png",
-      "hash": "7b0d7a2b0d45116c07a1d1312a9648e3f6451f12b54f73288ca5ed870604d40a",
-      "size": 231519
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4514_00.png",
-      "hash": "ae728011637b6b1586e0765614fb562ca40e7cf12b4cf5db2837f2462efcbbd7",
-      "size": 197514
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4515_00.png",
-      "hash": "c7318e1880eb828d80ad589640aab6df514543f1af69b3c9eb2a77e58155a114",
-      "size": 196385
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4516_00.png",
-      "hash": "0677b87251ed4b856cee15fc6df723eae152bf76f7183360de0759df0422a17c",
-      "size": 220895
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4517_00.png",
-      "hash": "4e669f1a0c12d314e14c0ea6374bea356ed99903dc02cd380680de2e53f22dc2",
-      "size": 229927
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4518_00.png",
-      "hash": "9a3865ac1abc1cb932f68b1d73c9b413e6c96af5dc598c6691150527e5b29158",
-      "size": 216094
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4519_00.png",
-      "hash": "6c38afbba8c9d3829b09abe5b716a44b297de8982b17107a94d5e83a8e5d610b",
-      "size": 198626
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4520_00.png",
-      "hash": "93a33c759cce5d4350968e438f22a317c9ba43040343adad55934eeca0353df5",
-      "size": 242476
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4521_00.png",
-      "hash": "4855beef340c1cb8f053b1c50c241291a1cdfeb6b8ae0bdebfe6a6f63da22781",
-      "size": 169778
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4522_00.png",
-      "hash": "1beabca4a83f81e4f59c4ee01f543a4f51d9c2ef8cafe2eb0badc7d567c5bf54",
-      "size": 222706
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4523_00.png",
-      "hash": "a214507952cff34aa78b1f6df5774c210a56b61ca6237d605b762846223b25db",
-      "size": 158484
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4524_00.png",
-      "hash": "4980e40948d8a82b43b7c1a87893194cebe9819829209ac4b202f610e1b4e72b",
-      "size": 166829
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4525_00.png",
-      "hash": "674d686af975928dabf7ea5f2cb73877619eb876a15a5a663ce7fa3fccf3f9d8",
-      "size": 230581
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_4526_00.png",
-      "hash": "7131d19b8f4e138560b5f4c10085540217541ecba6f440f8b566e79ba6d232de",
-      "size": 159525
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5002_00.png",
-      "hash": "4837785bead724385dfbae240ff34dcaca9e9cf8f999900ca12e0bc9977a3b01",
-      "size": 128778
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5200_00.png",
-      "hash": "ac78fd9e72913c59d4c5cd77d3c94e1d02cd7513cbeb7bc02299e783abb604d6",
-      "size": 189417
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5801_00.png",
-      "hash": "f5e25bac80907729105bba04f580fe734e4c4c8602dd48af6006404a3cb2c8bd",
-      "size": 264632
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5802_00.png",
-      "hash": "a9e8943ea14ca47683fc90e28a5b8b8a6f62b5365198fae9e1f533d84339ef72",
-      "size": 313687
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5803_00.png",
-      "hash": "86ad9fc6bfedbad4f012fe368269eed6e0ac552fb42219420d091dd3e436d0ad",
-      "size": 265946
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5804_00.png",
-      "hash": "d2227391322923ab4e3e5c0bb1172872897c53b4a182e0dc3ed9c10844107a8f",
-      "size": 326829
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5805_00.png",
-      "hash": "def48dcacca4934882365c9c1c0f9f9d006a0aabef3a75c34e53bc9eb89a0c42",
-      "size": 319227
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5831_00.png",
-      "hash": "9c4c312e3274a2a518ec5936d0065d4e595d461cbc7ebfbc7ce6c466b4c617ed",
-      "size": 204497
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5832_00.png",
-      "hash": "6bcd3b8b56ce19f7813ec205bdca233ee589f556c598310d895000e540f66344",
-      "size": 254234
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5833_00.png",
-      "hash": "b1d464209ae94d0ad1eb93d7cd405879c78faa027d26cfceb738bf9563b97238",
-      "size": 205938
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5834_00.png",
-      "hash": "958f281673d451dbd7b9e516089c427ced6e4be1f81210e5b9c67b9d53e3503b",
-      "size": 266622
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5835_00.png",
-      "hash": "53fae09fa40ce5d24074f94d36b8cbe7e59ccb3743c02a262c6c88c56ff0f475",
-      "size": 257947
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5920_03.png",
-      "hash": "28681374ff840865155decca20a2050c708ef46caa97a4494f2c7d0cb2939846",
-      "size": 195067
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5921_03.png",
-      "hash": "721ecccaf10e6557f2e1d744ca71a874e2f085be227df26e421ec76ba75dae13",
-      "size": 195067
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5922_03.png",
-      "hash": "c4cf36b5909c054bcdc46067047ac916d9639b12790246b4939c933a46514d1e",
-      "size": 195067
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5930_03.png",
-      "hash": "6a061cff6ada69bc36eb2983a04b9ba805b69ad94d8b109173d45901d136b31e",
-      "size": 259139
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5935_03.png",
-      "hash": "1119a1bc03c67edc708f02d61393491d43c5d6042ea45a000c31abe7a2769b70",
-      "size": 228746
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5940_03.png",
-      "hash": "752c1bcc264632634c5548cb1cdfd8bf915ea2f0a9f02aee92965351e066f7ca",
-      "size": 237758
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5945_03.png",
-      "hash": "cbfe93783be740ffc9811d26073a4aeb0d154fa9adfa27c47c7b3b0a954ae2ba",
-      "size": 273463
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5946_03.png",
-      "hash": "cbfe93783be740ffc9811d26073a4aeb0d154fa9adfa27c47c7b3b0a954ae2ba",
-      "size": 273463
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5947_03.png",
-      "hash": "cbfe93783be740ffc9811d26073a4aeb0d154fa9adfa27c47c7b3b0a954ae2ba",
-      "size": 273463
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5950_03.png",
-      "hash": "98a1ea26aa8f4dda9bf185973c7a4aae0c9e02e370934e14b766b12269e4e0d6",
-      "size": 230250
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5955_03.png",
-      "hash": "130826053ff80a105e63a9e4f05579a38368990aa55c88785c1440d8a573b54a",
-      "size": 227341
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5960_03.png",
-      "hash": "d1e87453d3ba123d79e12efc31250df0843066f2fb1accf270fe741256261b4b",
-      "size": 219839
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5960_04.png",
-      "hash": "20a8ad2c4550b137793e17e177c5354ffb21f310e6d573cc74f434edf95c9f99",
-      "size": 278916
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5965_03.png",
-      "hash": "6d3baa03cb9955fc5029a2486ef0a8874cfa4bb7aef32e70b6da9dd9a5b011f2",
-      "size": 260875
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5970_03.png",
-      "hash": "73bd68fa604f5621945b04365bd8ce52ec6a1266433948f670ca3341b25f8a71",
-      "size": 198221
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5975_03.png",
-      "hash": "ce35d240475d90586f592e11d17d386b091e1964b35595f7ab1a308e210196d5",
-      "size": 230516
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_5980_03.png",
-      "hash": "e33cadc4f6299a18abb8da6c27d956687064d9c61134ca6b0c6c3cbb41b67536",
-      "size": 202448
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_11.png",
-      "hash": "a1f01733ef9ac5c154802b8b57545f154f42962222752aed5ce9b699c90bffca",
-      "size": 286824
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_12.png",
-      "hash": "b30a1e4210e2c8b5e7994ed9e6bf873be1a8f43fef65d9de16055f647f6c0bb9",
-      "size": 295021
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_13.png",
-      "hash": "d03ee71947a2c752494c503c2e564288f60a1123e4917eb62d4e157e4da37fe1",
-      "size": 296759
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_14.png",
-      "hash": "ff45192b506df5e29dbfef3b3412dac26d326f890ec06d4fbbed8439e6d2f82b",
-      "size": 289728
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_15.png",
-      "hash": "3ebdbd0320f060d4f809bde4692a172cecda2a618911ebbd523f2147603d67d9",
-      "size": 295036
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_21.png",
-      "hash": "1c202c0c9bbd429eb9c9afc2d42ad523523ae5fcdfbb5acb0ed535175205ac29",
-      "size": 296424
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_22.png",
-      "hash": "b9ba426597af53b9fedf88139516f324b357a96140ffe234f64b93b548874348",
-      "size": 303987
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_23.png",
-      "hash": "64b404d6109686924958172530723d6e692ff1afd2987662df5c230a481ebe52",
-      "size": 306042
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_24.png",
-      "hash": "cee5c01827d0b8ef63319791a5ddf16881fd17ee74b0320c9caae37b911d3ef9",
-      "size": 299287
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_25.png",
-      "hash": "144d93c2ec0cba706d4e54147e57ee4bf5d618ec74e36f87ae9159b7d6fe37ce",
-      "size": 304190
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_31.png",
-      "hash": "f41f2896c178563f73c7bd8d525d2b43aa13f06a087401890653e35435944a8f",
-      "size": 201888
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_11.png",
-      "hash": "ea79b035d827273cc15c59fb5a2ac0fa9a6e6a3909e39204ba0e5abca61e8548",
-      "size": 240777
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_12.png",
-      "hash": "e5580a4018e8d4cbadf760eec5e939e8e53806ca789b133a55c8930d24f89ed0",
-      "size": 249434
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_13.png",
-      "hash": "1204bc9af6f118d7e59f03612e3d72db5b3066f02555884b9c5ce12ba8c665f4",
-      "size": 251216
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_14.png",
-      "hash": "3de4c812b3e1e28c0a0aaec4cd8bb98a9c2c58ee2ca87356efbb9bc85ca3bc94",
-      "size": 244026
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_15.png",
-      "hash": "13b8d9648917ce95152b367465ca64d8c19ca33da83f3f9b18c6d8bf75576bf3",
-      "size": 249472
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_21.png",
-      "hash": "7bce0412fbf8119c2ff0af8d4b66c1b2e4bacc8086c59cad7850e627308ab7fc",
-      "size": 250844
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_22.png",
-      "hash": "af2f76be0973a6d08f5a2dd54d40ef1edf8d95745733476450a83cd7cbb0f8b1",
-      "size": 258832
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_23.png",
-      "hash": "fd480a9bd1e14c7e04b8eb3b474a950dc91af5ce1dc11be1ab6a895a3b29314b",
-      "size": 260735
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_24.png",
-      "hash": "8d22d01ed14d4cf766a575188040a9e858c2e527f862e0391239288c32beb931",
-      "size": 253730
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_25.png",
-      "hash": "36c01c509e216a8ff8832afedf9299a23c1c752bc00b8bda8ff5c914e5916fd4",
-      "size": 258974
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_31.png",
-      "hash": "e00d53f4ee1d97fab6d2a56050daef39a0a5c8284456cd786afc46ab2fcb3b62",
-      "size": 156397
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_11.png",
-      "hash": "b7f50b91e622a2546d7db4b258da73c4d8d5545df1ed0ea3861d7b0ba2807cbc",
-      "size": 317098
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_12.png",
-      "hash": "4a8f43540cb8e1e555c4e91a969a152b393fb25e8dddda874e98b44a115c2e27",
-      "size": 325302
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_13.png",
-      "hash": "32a50f09d4eae5e6b16e29d264e4653ff73829bc7510066c16d919f852007e2c",
-      "size": 327043
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_14.png",
-      "hash": "6add14aa925f424cc64e8e53c04d78b9a6fe4fa2a9e03490238bb02f04f6746c",
-      "size": 320024
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_15.png",
-      "hash": "e0d07fba4fb2e7f9d39a007c4f08ef27aed0c2d26888a24c54c0669fe62aeef2",
-      "size": 325320
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_21.png",
-      "hash": "edb3f645bf68bc2391f1401922c1dbe46895bffb02acbfab682258eaaedc4630",
-      "size": 326704
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_22.png",
-      "hash": "877db2ab1a033a044cee77f3b083b4a82ae325f0f8b0cb372eda539202f1aa95",
-      "size": 334306
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_23.png",
-      "hash": "60d6cb05239c47c62057de794450dbeae8935cb19611f1eeaeeaf14628690ff2",
-      "size": 336343
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_24.png",
-      "hash": "13e52915321d298fee6f093c7805bad1a3bdadbf72c6d28e707930691393eddb",
-      "size": 329571
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_25.png",
-      "hash": "0c4c0b392683ec0b47dc6a6bdef14ce733c7b802069f7ebb213ddf9e38673d3d",
-      "size": 334525
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_31.png",
-      "hash": "29768d64bdeeb611e16dc1b74b88b38e17fd5436354f057f6fa63f158e5eeb71",
-      "size": 232201
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_11.png",
-      "hash": "ba6dd30021fa02c2431b6030b3e1d63be7d4778374d02f7245a74200813670f5",
-      "size": 268551
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_12.png",
-      "hash": "ddb248bca8919641d03a0f7e30009431dee30565074b12bf2623de9f1305c562",
-      "size": 276387
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_13.png",
-      "hash": "f7375951a818d051cf453436495adb10a21614d322fd9406ec5a84f3b6038acd",
-      "size": 278226
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_14.png",
-      "hash": "89f12ba5e542ce8ff869244a0146f53cf1835f294b5020f8864e1321635c9e59",
-      "size": 270928
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_15.png",
-      "hash": "6fccf5ac8850a06a01cdde46de4d8f368c913d72164fa532222baf9668b69b8c",
-      "size": 276454
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_21.png",
-      "hash": "fc2d73c4ff87c12d0bcdd32a2a0ba6da55e8a8ade389a8181a59e808ec0e4c6d",
-      "size": 277806
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_22.png",
-      "hash": "61da8abf4cdc09602aad4e940929340504194855db79799f0e5c304285034e3a",
-      "size": 285853
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_23.png",
-      "hash": "e72a8f13fe4e0a858bc496a5e501eb62bd033d5198c53484887cb1043c4db72f",
-      "size": 287729
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_24.png",
-      "hash": "3e74b486ab62fa3f7ce6ab124d4e438c2e1a8fdca2bab09af724574b488c7233",
-      "size": 280710
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_25.png",
-      "hash": "059ed87c5a9d9f1b5476ad535b31cf56ddc4cbd78d3561add76aed2434a05caf",
-      "size": 285988
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_31.png",
-      "hash": "bb27cfa6554b2f1c5d7ef128c0ce186a3d2f1ec9f0022c82ba2c3ba46899589e",
-      "size": 183398
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_11.png",
-      "hash": "82fda9971339638dc99f7ffe6e4387c93541480b434d50a46947c0bd64303913",
-      "size": 246563
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_12.png",
-      "hash": "231b347e7a370a3d365a24d9be8e22de8c845c7a56c019f26872811ea38a5aef",
-      "size": 254808
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_13.png",
-      "hash": "22bafd294368fbd01ec87796c89fe38605a111cd7e9afdee0f25b580054c02ee",
-      "size": 256569
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_14.png",
-      "hash": "0e1192df2cca8e1302ab5394e7e2ea83bc92e16e8d6c887ce2f747cc421683bb",
-      "size": 249548
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_15.png",
-      "hash": "d17fb4aaf651b89b3de600d544094497133b156af2cb099903e493eeef0df13d",
-      "size": 254779
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_21.png",
-      "hash": "9c9baa742f56ef2f78449914a88958552e7e73882cdcdc7dc8584c980ae0dc61",
-      "size": 256256
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_22.png",
-      "hash": "2fcbff0f9c963c7a91ac0f42a17334930d7873da8da30bd7be6446d3d382ecb4",
-      "size": 264258
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_23.png",
-      "hash": "78b615f4d5323d2345799083d7fde5281deb99ee8bebfc68e9296cdc25b94471",
-      "size": 266159
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_24.png",
-      "hash": "de32379efe31f077849fabd7d4de71bb600597dbba538a2f8fbe756a51c69f1d",
-      "size": 259076
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_25.png",
-      "hash": "c4f256ff28d5cad1284a5b794e77ea82d2a8820aade43fd38cb61901d00add51",
-      "size": 264409
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_31.png",
-      "hash": "4686e56d4abbf6886c2af91a6447525788cad12a5de0a9a500e2bdf62c708c1c",
-      "size": 161788
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_01.png",
-      "hash": "63870d5ca840558e2d35384a329e306941f18b4012b0181dd29f6dd609c7b408",
-      "size": 132875
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_02.png",
-      "hash": "afb38155d60a8e7c32874b1b462028adf6c3e2cfc8abb035717ab135897470de",
-      "size": 146235
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_03.png",
-      "hash": "cef014572309801cf2333bfe1f104e548789f8e6a97064d15a9284e55dc009b4",
-      "size": 149669
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_04.png",
-      "hash": "fd91bb4502531d03de8c20c27068a58c0752ef4ebe90f5e9d5858a65b6514b43",
-      "size": 139935
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_05.png",
-      "hash": "d94d6ef996c203e81ac65483dd424d9f7546b26d132558cb2f21e8dbe1c75a68",
-      "size": 146815
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_01.png",
-      "hash": "a11790e86a2a0ea01f2eeeeee0eb60396a4ec9c5fbdb4c61ca427800c3779fc5",
-      "size": 95253
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_02.png",
-      "hash": "391431ce6e3581a4092c28000da6925ac94b20ee9fd3bc625d38d08f473b8e4c",
-      "size": 105074
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_03.png",
-      "hash": "ff1cc8f6e5752ab14fe18c9e437beea9778781c9e830f68f7598023fd8958797",
-      "size": 108892
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_04.png",
-      "hash": "5a584b7fbf76295233bf0425bfa241e113751a01901a8b770fcbb3794935fd3b",
-      "size": 100500
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_05.png",
-      "hash": "939483328f5156a8d4099a69bb31b3121be9e481c80d0c4a06d0869b3a8b39ec",
-      "size": 106428
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_01.png",
-      "hash": "d027f462aedd5ca6a84fb06d4b7ab0f0596fdc61a4927d08251e895d1533e643",
-      "size": 119833
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_02.png",
-      "hash": "d2bb4cb0ed4df1bc6cb5b6cd8ea32965ba784170fc04bd635510661e791e75f1",
-      "size": 133817
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_03.png",
-      "hash": "c86bcd96a4cfaa5c722910796430fb2e2325c042242847c31ad11c6f9d833cff",
-      "size": 137139
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_04.png",
-      "hash": "1e26243f2c2f7efa244a5c09cdb3d91fb6fdce0af9d084bba70dbae5f6208b95",
-      "size": 126540
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_05.png",
-      "hash": "1d43d31ba4ce526870345a6542d56ee39914e125e4f5326937853317adc18bfb",
-      "size": 134602
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_01.png",
-      "hash": "2b133616f8ba2d79d7e997d329b1659a50cd0cfecc1135b5eb8c164120966880",
-      "size": 137126
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_02.png",
-      "hash": "ccd8f0ab12cc20d37f0985d07442ccdcee2dda695c720a1be950f699932cc25a",
-      "size": 151051
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_03.png",
-      "hash": "3c83124cd517a6e6bf5627db9537e5d0e6f4efb6521c96139a23679f652142bb",
-      "size": 154141
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_04.png",
-      "hash": "b8ed90524e93314237fc106e58c0832b73a0bc5cb7032b5c3cfb0e9208ab529c",
-      "size": 143948
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_05.png",
-      "hash": "4a244ffeff6a2d474055aa84c2b135f467296640379b458ee4190b5bc888140a",
-      "size": 151636
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_06.png",
-      "hash": "72905fa8945f533683b2fa3552e9e3a7ee32ed97ad30bdab6f2482e6012deaee",
-      "size": 151475
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_07.png",
-      "hash": "e5678dd1f075f84b4ad3cd3137f3e114f8a8ff3f5c10d62a2bc5cdf505791bed",
-      "size": 144420
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_08.png",
-      "hash": "42fc9c84e39f98e6037c090f552f829e27bae65f6f98937897ed9f69324b758e",
-      "size": 152009
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_09.png",
-      "hash": "548cff63af8a603a1968a8ceb53902ed540878ae65b79a79a463872d4314f39f",
-      "size": 151508
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_10.png",
-      "hash": "a9f4178acd29069f6b82183267163c6e90afc13ff501a62c2a7c5b4157cbf254",
-      "size": 161929
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_11.png",
-      "hash": "12218f52a0be82bf08e52c6f9e10d6d0f00eb7feafd4bd410448d0251392d686",
-      "size": 137352
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_12.png",
-      "hash": "655fa9f94e06f6d42659826b306da57cbd47bb23d6135cb37a6a5e42ad9666b6",
-      "size": 162719
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_9002_00.png",
-      "hash": "8c025e0777023e6804e986faf0541e46acaebb21632333623dcff18361778a7b",
-      "size": 381566
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_9003_00.png",
-      "hash": "f25305c2fedeb49e19810a23f4608d9ac9e733538dac1bb12023e343eb6c806e",
-      "size": 396080
-    },
-    {
-      "path": "assets/textures/race/racetitle/tex_race_rt_000_9005_00.png",
-      "hash": "d1b6f0e7c2ef9dbce60660905dc03abc3e545b41febb22bb18b40a7c8e923b5b",
-      "size": 334527
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12005_00.png",
-      "hash": "552eabe7351bb177f46c406a0c0cc41c030d3cccc8a5f8367ec6462db2bb4764",
-      "size": 98065
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12006_00.png",
-      "hash": "42bdf913e51590d3aae3ee208ed6b7ef9de5959edd8aa7c3dc3c0cf01ea57d36",
-      "size": 103608
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12008_00.png",
-      "hash": "69ff95022859e30247d7431be489e3722b18cd6a8aeb1fee0ee741f894308eb6",
-      "size": 95057
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12014_00.png",
-      "hash": "c3dca19517ec9271c273618f32eb9cdf1334e9531f5de6801db899932bfcc9b5",
-      "size": 124154
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12025_00.png",
-      "hash": "2be5292155b8feeca372cdcd69879ab19d88d3ff5106344c701b8f206793bbff",
-      "size": 109677
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12027_00.png",
-      "hash": "9871a5d0ddf28e73dadc3c2f9f40a91621416eff5339aa750662dcc9ad26cde9",
-      "size": 103855
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2001_00.png",
-      "hash": "570bec9772da740ead5b77d052e4a7fe30487421461e7004280464841595718f",
-      "size": 104907
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2002_00.png",
-      "hash": "8427fa71b64d301416ba5be8eb77a54810044b0e5fc89445f33c809f6555a17f",
-      "size": 99446
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2003_00.png",
-      "hash": "5b2f33b2a319230c6bb919c6e3731566eac8cd06250f5c794724681f32b5af10",
-      "size": 104202
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2004_00.png",
-      "hash": "32914dfa626a713a734a7092f8474d24c07a3513ad346e61b02a30d3634349fc",
-      "size": 95154
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2005_00.png",
-      "hash": "fff7259c71a2ed050ec4cfb23cc23c3144f0d4adb9d6db49eb2bbb13834b2dfa",
-      "size": 103835
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2006_00.png",
-      "hash": "9164c521bc816c123dca52dbc0994e32cc16dd1aec7fa04852218de3900e87e9",
-      "size": 98072
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2007_00.png",
-      "hash": "0812670ef3b8c204d65dad9a49a586cbb262c255c11821e6cba4581009a6c606",
-      "size": 97450
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2008_00.png",
-      "hash": "b1c15a60de46fb690b8c32c7d53e7630c6ef0ae8fe7c7056b546c1d4021dc05d",
-      "size": 95264
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2009_00.png",
-      "hash": "cb97060b67008d3f348bfc96318142e75d159271243ab213720c5fa47439d315",
-      "size": 109311
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2010_00.png",
-      "hash": "ebdb5e8e58caa1c65e3d7710086cd918c8be3ac3f1f6e1eda5279b340cfdaafb",
-      "size": 103036
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2011_00.png",
-      "hash": "5e23d04ef078ac15bd1148e14aa3665226a27749ee70596e1ced10f69a7f4452",
-      "size": 95763
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2012_00.png",
-      "hash": "372090c778c11e86dc24f17f6e47471ff7f89693fefc95d9c70b6ba548f3de16",
-      "size": 122479
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2013_00.png",
-      "hash": "0d59037a13d9d61ad5aa045f7a484524039d76769ea4b4470e656b1648695038",
-      "size": 110786
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2014_00.png",
-      "hash": "4001b116f44b9e0e8912b11361843452facd49b8530c2b88c1daed5bf57a465c",
-      "size": 115014
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2015_00.png",
-      "hash": "a0a05f4600140ee8d91b7591afed6f89b41c7ef76dbafb1b7f55f7394bd02b7b",
-      "size": 101420
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2016_00.png",
-      "hash": "c85c23dab6b2202829a5a79fbf1b87f9b83e34264fc992e296cd173c3213985e",
-      "size": 97923
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2017_00.png",
-      "hash": "1e373caebafadee0d4d03da17503cec2977dbcb11458057269ecc2cb49926d2e",
-      "size": 109927
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2018_00.png",
-      "hash": "7d268503224a81b87a569282ca949a94eae7addcf0152b59e350d554c08a9199",
-      "size": 113433
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2019_00.png",
-      "hash": "56bcb72ee319cd5cd6d1bca552efbb7b0c6f1c9f13c2cae45ba0d69923ea8161",
-      "size": 102604
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2020_00.png",
-      "hash": "dc692c2fcb9eafd5c09af508bcd4f25906d66fa722447ed7afe6e5d5b32db710",
-      "size": 101424
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2021_00.png",
-      "hash": "6256fd3c12457df1b199f49a2f4509202e4bf923941cc664954969921c915d42",
-      "size": 110929
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2022_00.png",
-      "hash": "69989a8453e2a724624764ece4bbffb0e634dfb5cac708d593a5932f2fb95908",
-      "size": 100616
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2023_00.png",
-      "hash": "ce3a226fcb38677cccf176255d2237d76afc762bdcf185a0f331bcdacbaa49cf",
-      "size": 95778
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2024_00.png",
-      "hash": "7f10e3062423d14ae3f6c2c435c43b81388eb40913a91d79b07b3fac0b07c7ed",
-      "size": 109378
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2025_00.png",
-      "hash": "17750a9a84e5ed40bd96a5dee3dd9b9d3524aada03468e646b3eca95b5d7f117",
-      "size": 118692
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2026_00.png",
-      "hash": "653d6c34478835fafeb7e81dc33a4f7baa6910f2331bf4376372270722ce3045",
-      "size": 108546
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2027_00.png",
-      "hash": "0aaafffaf3dbbc5159978f5575599a5851cad4c318f67de76b03a936727f5ec2",
-      "size": 108104
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2028_00.png",
-      "hash": "acd57324a3704a3fc5eec75c644e02bd0bd64afa799be41a7c4d36686ac4eca4",
-      "size": 120015
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2029_00.png",
-      "hash": "530c0fbf585439b7013bdb45afc4e8b3b474bcbe0d74f3242763809c95141eee",
-      "size": 101383
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2030_00.png",
-      "hash": "e5afaf9ad0e2059e7a92b42723405c1de746a372e32864a181a9f059ff1ab0da",
-      "size": 117827
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2031_00.png",
-      "hash": "f0a29159124cb62a1468587f1efe161a54bddb59fcb0678c94e8669347673037",
-      "size": 119318
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2032_00.png",
-      "hash": "ac9ea36a1b53d45e74d61029fa61254dc7c2de79528302396c22acedfa3ac5e1",
-      "size": 115875
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2033_00.png",
-      "hash": "8ab7a16b40e96e92f2d3170d9afbe63287c9409bb8488cf27dd76d576d0a2edb",
-      "size": 111291
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2034_00.png",
-      "hash": "d2785d8681a5d185bf9375953b2f00c06edca6bb0ff1517fe66b2ffa3afd35ec",
-      "size": 98906
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2036_00.png",
-      "hash": "85194d494540a79cefe6016384f18e12a916d005dbdfaa2732a777eef6a9b841",
-      "size": 101663
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2037_00.png",
-      "hash": "6fe012d5160335f68c23d8df57cd1e31c7c720e004c5cb92f133cf869df62015",
-      "size": 94738
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2038_00.png",
-      "hash": "33317f80fef4bd0c8db4a7b5b08f6ae9ba6d7f2d701189a3aa0e4cb134edeec9",
-      "size": 96270
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2039_00.png",
-      "hash": "c77cd6287d1152594c1005cf9a9e98b91f18d5943b58de81905b3b63df73ba65",
-      "size": 102517
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2040_00.png",
-      "hash": "49c56745caa296d6bdb8037047cf7608d936f98f882e7660d6c18ae23f697ccf",
-      "size": 95313
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2041_00.png",
-      "hash": "ca867fd1528071496f1e8d1f6ff8cb3d64bc0791250b9258df67456a9b3e6741",
-      "size": 104647
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3001_00.png",
-      "hash": "031e0513973cf52f27074b8804047891b998f933cfedaf504a34fbdc0ee7fb05",
-      "size": 108515
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3002_00.png",
-      "hash": "0f500d5ac4a800c5f570aeb41ad287b81a6c1217855a4fe36e83dff9e1b80af4",
-      "size": 116339
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3003_00.png",
-      "hash": "0e987758488874046aaea58f4e7af8ff9e63895ac502192c4e0041d6ac149411",
-      "size": 109045
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3004_00.png",
-      "hash": "04602b966f17ffbc844294d3cb5131f469d5f334ef5012fb0c67b29ddf97a6b0",
-      "size": 109149
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3005_00.png",
-      "hash": "d49a22829eee2da6416dace2d517d31138b802f22cc3d5a50cd588706a5f3f92",
-      "size": 102048
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3006_00.png",
-      "hash": "a8b59a61267e0c5c133954410517b8ef48b47002964b55ea998070f30beced1f",
-      "size": 100488
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3007_00.png",
-      "hash": "2776b2b500d3fc2d960b89bc5675b8b09dc90294d6810a663b135e5bda9880b2",
-      "size": 122462
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3008_00.png",
-      "hash": "0ac9f12f5a7f3c73f5327e077da0c3376a8d3048a65b38fa24c7f2b41ff68ae5",
-      "size": 115854
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3009_00.png",
-      "hash": "2aeaf1c113d59b22c8f6a6130e2df6f1455fa8d2dbb6e2218290b173b2ff96aa",
-      "size": 112519
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3010_00.png",
-      "hash": "ed20c0789942bb7a0269577552c86b237c951b462cb97cd2441d5e8b65f19c9e",
-      "size": 119080
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3011_00.png",
-      "hash": "cf73d16d277a00d73de3bfd87083c135af6e668856ecabaab30f0fe834c8fbfb",
-      "size": 117777
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3012_00.png",
-      "hash": "89ba713f4d16782e0d4fde490bdfec8a281c0e4db5b187d6800ccb27def88040",
-      "size": 117107
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3013_00.png",
-      "hash": "81808813cb13f44cf1b676a59e9bb2fca69067ba0748a0b892f0c1f7d076ed3e",
-      "size": 131277
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3014_00.png",
-      "hash": "2573bf141c3377270754dde1480caf6b2997106263ebd0a6a28a91c44647fa3d",
-      "size": 120591
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3015_00.png",
-      "hash": "5614f6586b8463ede4c653f36433e64f0f72a3aa31be61399699e25660cf3345",
-      "size": 122818
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3016_00.png",
-      "hash": "8eede9a5ba86f870ff063a757d0ca6bfff7ab47836988ae20b8b840bfb7cb217",
-      "size": 113193
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3017_00.png",
-      "hash": "262cae88b587cd104163fac8b9181ee7cbd20dd92dbb8c2e823f4c7c29e5df00",
-      "size": 102736
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3018_00.png",
-      "hash": "b790f5e38861764d2526c4dfc47661064c1f79814d045361792643da7390e12d",
-      "size": 94853
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3019_00.png",
-      "hash": "7ba197c104e431cd7d15821de40de6ff9cfb88214d2dc1623d683344ab6233e9",
-      "size": 113308
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3020_00.png",
-      "hash": "6905344f834e561150a956b5000bda382aa7f12e22db427aa6913aa733ba9b46",
-      "size": 134828
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3021_00.png",
-      "hash": "f17c3af18ec836f21ea1b28695029f4b64a890b17b8dbb55ec47cc70e96f33ce",
-      "size": 117886
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3022_00.png",
-      "hash": "b70773c78947c98a83a1d69b8234f9b8861a4f41aadbf03472b9baaf94d2a08b",
-      "size": 109573
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3023_00.png",
-      "hash": "d2c90b011284a242d9601977065cd085dfa0a6d2f0bfccc9f94ac0a665a59de0",
-      "size": 106534
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3024_00.png",
-      "hash": "4bb86867cafdab227dfccd156ec9e5e6fef4e2ca26535f225d491600061fe770",
-      "size": 118345
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3025_00.png",
-      "hash": "3a3708de7f249817812061884b9aca5ba664bd7b6ff5a29562d0556fe6a22999",
-      "size": 131902
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3026_00.png",
-      "hash": "16bb4b55e336cecfa22d887c9ff7a26ec83e70365f8e73057952fa0e5b32f5ed",
-      "size": 119272
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3027_00.png",
-      "hash": "b3a344d9a4842340af4c7c044421527a5aea270147834ef341f8f0d9c772c820",
-      "size": 135418
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3028_00.png",
-      "hash": "2437196bade13e411a827b3df561090948b1afb175a136acb30dccf648d9fbfa",
-      "size": 118446
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3029_00.png",
-      "hash": "42cbf2232bb7205456bdd17c5dca8273c0a91da141c2e6559b2ae75475c9ba41",
-      "size": 108367
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3030_00.png",
-      "hash": "d5af89bc39e5ee8cb0a86e39b505b473393914b73af65f5dc70f3f0529b3fd17",
-      "size": 110078
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3031_00.png",
-      "hash": "26019f870423446a10d8d2716ab98c72defc4eb5d5f0ecee022e34571f2b95fe",
-      "size": 120065
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3032_00.png",
-      "hash": "18d458950b191766508123a201799d344a2ce366604a5bd1943bd6eb209be244",
-      "size": 107676
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3033_00.png",
-      "hash": "f5fb6af30a8e06e35411e99710900f58549857e7df1ab5b41a01314b1f9c0dcf",
-      "size": 117931
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3034_00.png",
-      "hash": "187ddba423047230c3d1667e2bb0cf4f1cb11f01792ec1b6e0ffd0ba01d4b3e3",
-      "size": 123864
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3035_00.png",
-      "hash": "2e4ff0bb10aa7656ae09343a62d4be2618bf72293896043aa69b9c2662c87f5f",
-      "size": 106210
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3036_00.png",
-      "hash": "42b00781ac8f82f43c74cbaac67616fd0a7ce44bc83cc1bcf9299f9e4c494c22",
-      "size": 116699
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3037_00.png",
-      "hash": "d1d4647d0a261b2c8e17ad3bccae9237642ee9c154beb87ce1345acd53599576",
-      "size": 119293
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3038_00.png",
-      "hash": "b2ee9315489373be82a71bc448dd3969717a33348448cb5e567990786430adb1",
-      "size": 108861
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3039_00.png",
-      "hash": "2e45e8c3ebdcffc5b7a223b4f84aab0df6727940551ae290339fa9e238cadd01",
-      "size": 111365
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3040_00.png",
-      "hash": "a253888339817dd2e17b8dc83562a887028cfcb29b42d4d02621de448d429268",
-      "size": 112294
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3041_00.png",
-      "hash": "0176dc510276af161806321f2e2b901c6c2737fc18bac99915b53c9d680a149a",
-      "size": 129180
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3042_00.png",
-      "hash": "116ba3f836426db2fcbc5774b7f320b9db46c2fe46ec3a9aa5ec9483e13dd52c",
-      "size": 115448
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3043_00.png",
-      "hash": "d08487ec7139bc0a946ed9c24fbfc3e8707e8182922ce1478109a8a1fc7da44d",
-      "size": 114251
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3044_00.png",
-      "hash": "2031eb9cafb2b592b9f395c7f3ff7d148615e26ca0241200931f5a62514ca6bf",
-      "size": 112574
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3045_00.png",
-      "hash": "8d3b2bb5aa72f916e28b982ca00255a7fb28e7fceb043fbf3adf847ed210bb10",
-      "size": 116822
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3046_00.png",
-      "hash": "fc9156fcd7212f8dcc98966d589fa23fb129ecbcc31ec1847569da0435670840",
-      "size": 109603
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3047_00.png",
-      "hash": "32195e98a96d4de5cab6654f22710993f853f610c4782e97286348d53a4b2df2",
-      "size": 108563
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3048_00.png",
-      "hash": "edb90319f7aad73f736fbba5ab7d0b6187725e72bfe98a5afce1a7649fcc7b1c",
-      "size": 114677
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3049_00.png",
-      "hash": "058e253d1ac1c239cb7e49499655204f45d86912a446b5ed9be14f7eedd4809b",
-      "size": 126138
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3050_00.png",
-      "hash": "f93a47c21bb68587ecad3604aa7193fd1091489c57a9d37b2b8c874d8522f37e",
-      "size": 108324
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3051_00.png",
-      "hash": "8ad2e2fdb9e0cf28141217ecba9169531ba262facba05884c910bdb63ea4bf77",
-      "size": 128031
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3052_00.png",
-      "hash": "eefae452299fe8df54f1eda4d3203cac5afc92a2551a6f38cd4269eb282851c8",
-      "size": 130276
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3053_00.png",
-      "hash": "be7beff02182c1d3e705026ecb625dd7683e06ae1965c880ca077d8b2c518e93",
-      "size": 108351
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3054_00.png",
-      "hash": "5aa52b692107498343cf97bc88cf70ebfb77a8cb7b0b3e1875e45e487ad37260",
-      "size": 110468
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3055_00.png",
-      "hash": "5bcd02d7e0561506ffe9a6df0b6c1ca20cb178630516301d4025e2798ca046f2",
-      "size": 128813
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3056_00.png",
-      "hash": "e711353107ac545f708130829a201eab2b803d16a674344c0468de797d67526a",
-      "size": 108369
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3057_00.png",
-      "hash": "868714f4ed787a26f287b5201e6983346e0d7a93a4a7be3a74e4b3ea73f67120",
-      "size": 130155
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3058_00.png",
-      "hash": "db4f1dbbd786624f70811079d96df831cacddeaebb541ef3b7e53981618301e9",
-      "size": 99106
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3059_00.png",
-      "hash": "95f1395fa30d746fdee78d931391e01b67a17aeaae57e56ff2a56642f9596c92",
-      "size": 118379
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3060_00.png",
-      "hash": "46dfa0e0f0eb288a8d3c34dd4ce18f0e668c311aa21734d910e4724b36e841ce",
-      "size": 117223
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3061_00.png",
-      "hash": "58e87ab5c382d55a84d2a68ee826e6f8c907a2709f1d7fd029956b69a4238ac3",
-      "size": 120636
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3062_00.png",
-      "hash": "349faf73a868acfced6f46a70256ba64033605891f96bfe37754d7727cb0cc1e",
-      "size": 123218
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3063_00.png",
-      "hash": "d5583e6668419fefdeaa6a3b415f47337c42ff63f604c8d66b8f1170063aa131",
-      "size": 112679
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3064_00.png",
-      "hash": "dafcf3646700d870179a66a18c08462086007571d8565be5b00ab492b279e50e",
-      "size": 141093
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3065_00.png",
-      "hash": "adbcef1aa0a50fbb946cae9bf0154ed5f320ef6c1bb190f899e75ee427a9837a",
-      "size": 124496
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3066_00.png",
-      "hash": "29e3d93c8caf2210efd43d2311a18938948fda56a8041c5926a7c65c897c2e41",
-      "size": 101429
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3067_00.png",
-      "hash": "683e31b276e339012e64c79b0bd6f6f24e7f62420817c12bb8cb9da143802b97",
-      "size": 112631
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3068_00.png",
-      "hash": "f4d22d7ff016ab65683b76392b8846d77968ca4e1e444a57606eec6c336d263d",
-      "size": 122579
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3069_00.png",
-      "hash": "bb93a132849a2f66fc585b0b7eafd30b1875e72953932e57397dba0f3a70249f",
-      "size": 115176
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3070_00.png",
-      "hash": "3af15935bf4255b1201815f3e38cbce050ca0e1bf8806b0f466004a2ed8aa3e5",
-      "size": 118594
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3071_00.png",
-      "hash": "71441eb1c3c22c73120c340f908fc95408cceb3b2c408c7bd02c288cb74d5e1d",
-      "size": 120446
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3072_00.png",
-      "hash": "daaf62c3f86bda5698d11b6c8dbeb031d71ab974894c98e4585147beaba68bd0",
-      "size": 109151
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3073_00.png",
-      "hash": "00d9283209d5366cfc87189c7375384dc5940fb0b01bcb2c64c61e6782add0aa",
-      "size": 124467
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3074_00.png",
-      "hash": "bb20733857492df128cacd354247c1f9ef3913ede593ce549edcdd0df017363e",
-      "size": 110240
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3075_00.png",
-      "hash": "9c9105cfd8b1b2aaeadb33cb6bd25004763d1d9fb3cccc14f07110db65d07f78",
-      "size": 108436
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3076_00.png",
-      "hash": "504e4e0f3343ac3e1933d91c7360e4effd2ce8e3bbedd613b4ec5e654677670f",
-      "size": 110900
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3077_00.png",
-      "hash": "4c07ddbc7fc46378f34f8966136c2ab3fdddaa127ec379677fe4330bdb63cc66",
-      "size": 105583
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4001_00.png",
-      "hash": "43140a33a5fb36bc5f6960f6108737ff1628ec062dd91212b32deade6b0d9c57",
-      "size": 114176
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4002_00.png",
-      "hash": "822c86396b1613551dd06fbb326bd91a9a30c0701fcbffc4767738c6fe9c3c4a",
-      "size": 101245
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4003_00.png",
-      "hash": "4e7517553b6011da7b9fa7717ffa81d93f96e58a8586190f4a8ff5a22fac7888",
-      "size": 119919
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4004_00.png",
-      "hash": "a86ab3b24abf408fa4ec245483bc933d27757f602bdc93da3deed3f87226116f",
-      "size": 108470
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4005_00.png",
-      "hash": "d052b1aeb1715e97009fe35f8da49233c439e3d2f742982de545bab2d44de2d6",
-      "size": 111662
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4006_00.png",
-      "hash": "4557239e2d3f632650f0ebf1214ea9ae879cc5f2ed8f43a9100b6c10e7d724d9",
-      "size": 114681
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4007_00.png",
-      "hash": "7b16aa5c2843a30a04358da04af8fc774e3fd4912b1fd32caf57fb1749705a74",
-      "size": 106466
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4008_00.png",
-      "hash": "d9848014e13dad4e1543dc03274e44faea5d5430faae1eb44f30cfec632d90ce",
-      "size": 104064
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4009_00.png",
-      "hash": "87c60eb2480a265405bb9e9a5166dc2d9132d89726c0849c665825fadb665e30",
-      "size": 119396
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4010_00.png",
-      "hash": "8eff6cc75c39346a63d58f5254e5614b5b002e0a9ac902359a00fb554703bc0e",
-      "size": 117243
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4011_00.png",
-      "hash": "b7a17399583aa315a5159f8153d6103acfc11fd4a9e9207244953b4c1f1acb2f",
-      "size": 113434
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4012_00.png",
-      "hash": "2d62635dcb203c0a40143be0e3ea6f4b97ac921442c27132519ce94d09df7bd2",
-      "size": 110999
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4013_00.png",
-      "hash": "409696ccad50d3ab5d30e1dcf10c4762381635eadec819e933ff535f8b75c512",
-      "size": 107908
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4014_00.png",
-      "hash": "fea0c52fbf7b5de09827e79ef42d5804c4e81ade025922e1fe1174d40746d21a",
-      "size": 102610
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4015_00.png",
-      "hash": "1ed15ad2319647718fc39f699e609a494f04eb19e696564fe76e03003c94a9c4",
-      "size": 107627
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4016_00.png",
-      "hash": "e5ca0af2ba7aaabd4a61767f221480ae20b380b6907f7da2359016f394212114",
-      "size": 113056
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4017_00.png",
-      "hash": "b9ce5b3368b963d7a9b92c89f5664b07e5ac84462750d627576943e1267c623b",
-      "size": 110753
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4018_00.png",
-      "hash": "a8d0e95dde694aa6c6ebe9475c6fe211dd32f7919094e00e014d1383ed285694",
-      "size": 112931
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4019_00.png",
-      "hash": "5f952ef0a28e938f21cdfc9d7055acbeb0218b4e292811f928b274390cbfc5e5",
-      "size": 104580
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4020_00.png",
-      "hash": "0f3a6df43b9860b06058069da5f82b7660302bce9215ad9b3ddb2a0fbe63678b",
-      "size": 105232
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4021_00.png",
-      "hash": "27016ce0d545a95279669d2da49b39ed215aa31900cd2ed2d4c555b359e8c7a6",
-      "size": 116793
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4022_00.png",
-      "hash": "984cda6ee583e8a0bd5971d1a334911e0b119c662146d57599b7fbbcca0cb003",
-      "size": 112564
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4023_00.png",
-      "hash": "9631121d1bcb76723276573dca8afca0070d9aa33b1459dda71274ebef15178f",
-      "size": 113746
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4024_00.png",
-      "hash": "4fdfe2f238223a2af8d30b7b2fd2295804218444ddc07a4a604d5f02aa0841f7",
-      "size": 112474
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4025_00.png",
-      "hash": "c7d5a3ea335a853bd75add5cb5f575da2edc8b0b95a3b07b631d4fd7ec5e4e21",
-      "size": 108036
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4026_00.png",
-      "hash": "a9052cef8eaabb9f53e6cc8db8dd2b014e52d2a16eef4f514ce25bd871ffb8a7",
-      "size": 108110
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4027_00.png",
-      "hash": "0362d8d7f2c32749d137eaeaf0a2bbcc6454097d1b772a7e88ae24b2bd715a56",
-      "size": 112340
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4028_00.png",
-      "hash": "19120ab536d18159bf0c3a5e1b6ddd9d3328da8c07a43b994032584b4baf4d0e",
-      "size": 105289
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4030_00.png",
-      "hash": "010c4dbf4f48d6455075f453fe2317e876615dd028f75fe3cb1a35f26d8b3b15",
-      "size": 104591
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4031_00.png",
-      "hash": "088998870c29ac37b430820fb91d54334b77e94220cf111630f4ce27e7c45bf0",
-      "size": 107567
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4032_00.png",
-      "hash": "4ef9e322d7caecfaca31a0bbc6db0363c78cd417c46a24837fb7c68491ebcc78",
-      "size": 115326
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4033_00.png",
-      "hash": "c723b9a05889ea1e2443357e43df68d13faa7a8f797543c36f5b0a656e82a94f",
-      "size": 109369
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4035_00.png",
-      "hash": "337de567aaef4bc78ea096e1ac3e7db9dacf772092138f78113f0b3f2c0846b5",
-      "size": 115554
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4036_00.png",
-      "hash": "207e6a2babd57610de3313dfec48bd51fe1511847a4e18508330aff25555799c",
-      "size": 106684
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4037_00.png",
-      "hash": "415cc777e4fcbb7cbc3286c1ace379ca6d607018beffe1e1600fa5543ef6e699",
-      "size": 113056
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4038_00.png",
-      "hash": "0d1cec61cbf5773b88facd8cc5276b664dae7006bc8f54c7157cc95abb157e0a",
-      "size": 118916
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4039_00.png",
-      "hash": "2101251f3fee32e41af7ee6822aad01b71167eeb08f3cdc29fae1690a941c99e",
-      "size": 111899
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4040_00.png",
-      "hash": "726fa579b1be80e673f442176f243f6f622016cb792873bfeb675556365bf332",
-      "size": 103401
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4041_00.png",
-      "hash": "db945656ae86daaa61f7ccf99f2ba855e031c182fa31e7ec891857dd9fdd908e",
-      "size": 110643
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4042_00.png",
-      "hash": "756b6694b573431a2114eab6cabb5fb02766438cb54cb447f7997f4b8de2f388",
-      "size": 107104
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4043_00.png",
-      "hash": "2187550325508b47749e930e0b05202767b89e93125df2400a9d5d9fd02919a2",
-      "size": 113570
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4044_00.png",
-      "hash": "a676034d29b46fae64972de800a2fa3e741b054fde371f82b1da8ed3364a62c0",
-      "size": 118184
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4045_00.png",
-      "hash": "f9fed9a25fe689c1561f5310bb8383d78cb2f0f3ffb2ce2052f73d5a64ce2062",
-      "size": 113034
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4046_00.png",
-      "hash": "f4f672adf98347f92073df718824f5ac38621ab5a6261b443ccf25010b0f373c",
-      "size": 117689
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4047_00.png",
-      "hash": "ebc6befda469352ed97994caaeb9a40ab147c6cd02fe76fba0502c3f9b1fabbf",
-      "size": 112638
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4048_00.png",
-      "hash": "de69cab2950fbf78d784beb66c1c5ae491ecae8d8425adb6526a63439ba0941b",
-      "size": 109725
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4049_00.png",
-      "hash": "68cf1e8323ad521e208c4dbe4bdadb17286f8fb1ae67235c6cfcc05eda51c238",
-      "size": 120432
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4050_00.png",
-      "hash": "aadc3230ae310fd01995e6087c81eeb06d23f2c52f4c9ef909daf8734cdd90a9",
-      "size": 110518
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4051_00.png",
-      "hash": "9b5b66f9082e5f99a76d5a0dcb26839888e99b3be0104f0e6586742c1c39e1e2",
-      "size": 104530
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4052_00.png",
-      "hash": "9c021c43824d3ee0ec5f8c96af506ec94d34f8d894e46a6c46252a64d02f9678",
-      "size": 104218
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4053_00.png",
-      "hash": "cac49b2022438c965d54d5750a84b113327b7cf395f7db1a09d27f2ab86efbe2",
-      "size": 105286
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4054_00.png",
-      "hash": "2eb258d99fb1a7707fe3259547c3c0fac3da89ba2275edd672c72ab929745cd2",
-      "size": 104886
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4055_00.png",
-      "hash": "0b2fa093627615cc8c4866d0d6a612a3b5a426e49f1f4f0652119c7706412afa",
-      "size": 103355
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4056_00.png",
-      "hash": "2d4e786144425476b1c4dbed7bea81f3ababbb6e6a0e8515c408e36f4bb22a05",
-      "size": 113444
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4057_00.png",
-      "hash": "020dcb44accb1de4fc30e99e798767a1488d6525bc3774c470e67c2655c1574d",
-      "size": 104129
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4058_00.png",
-      "hash": "bf07cd4468bf8f8b8713a3fa0afd60ef6dd145927ace09d6301ebe8b948e4fc3",
-      "size": 115659
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4059_00.png",
-      "hash": "315318ce7f111507bd9f4f21710e59ba97262920d9cf318eca3f8ddb2991130b",
-      "size": 110516
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4060_00.png",
-      "hash": "1394438859898cec5f2af1ecfc0c3f0a27134b65f2f91804da059eed0cd48497",
-      "size": 114964
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4061_00.png",
-      "hash": "17fdd72d6312425b3c08145d212b9a9c7c94f35baba348555ca19715cb8b0783",
-      "size": 113864
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4062_00.png",
-      "hash": "3a38573fdd2ea6810b916f68ddcac7b309a2274ad90bc2aa0b4618615ae43d6a",
-      "size": 109169
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4063_00.png",
-      "hash": "2f198ff14a6258e860e1c0867bfdb540cb29f7e12e8cec89413f994543e751fe",
-      "size": 111865
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4064_00.png",
-      "hash": "1696755f9fef0730b4a74d58a8cd4328c33b31a151060bed74bfd2e21008ec53",
-      "size": 99924
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4065_00.png",
-      "hash": "a7f537bcda8e1e9501ca07f5bb1d8e1c23206957a801257cc6fcad97ae877183",
-      "size": 106471
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4066_00.png",
-      "hash": "da6b32163c222577f5eea2860f0d8e2a4443a358319e34c6d5e5e2ff94e63efe",
-      "size": 100698
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4068_00.png",
-      "hash": "d86dec39cd367b2f3291b0ea540986f0dde310d6c260382ee4b56a0db1adc92a",
-      "size": 120000
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4069_00.png",
-      "hash": "4debaef8a9fcd6b0a62992f1274cee1deb64578cff5b40042b44085e221e307d",
-      "size": 114316
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4070_00.png",
-      "hash": "27bc72676255a1cc41a63931742e00d7a7d35169c9e3095f164929baa480ad0b",
-      "size": 100015
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4071_00.png",
-      "hash": "bea93d48b93fee4ba21eeca78a79dd5a1f07ea25882f4c9ad48e225f4ebc6d4e",
-      "size": 114068
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4072_00.png",
-      "hash": "af830addceeb0781c6bf854f167f37e47621234614a3160200b3591ccd54c963",
-      "size": 100070
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4073_00.png",
-      "hash": "8b913a1dc29ec9d7f833ea799a0a46a00e092dd61fa9188e057235b3a5c9baba",
-      "size": 104354
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4074_00.png",
-      "hash": "cf878a4003dcc142d035642dcfda4d976e51743dabdf09c1e1b1300db4e661eb",
-      "size": 102673
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4075_00.png",
-      "hash": "44a19532527f5f5c607df2fe3d0861979d79dae9b774ec907fab69f7cfed2dec",
-      "size": 104130
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4076_00.png",
-      "hash": "834c720fe6124b6a6ed32d78a36c4b4afdbd481f09d3534291b49c446911d03d",
-      "size": 98928
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4077_00.png",
-      "hash": "d2c1c6e097ad36ba63f37a08d777bb8ef3efc95a2808fa4e56d51c808acf770b",
-      "size": 104099
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4078_00.png",
-      "hash": "e985e51b9bb152c15fadf6d518fa3857f13080078d352304af7f1b9d0dcb09b9",
-      "size": 107160
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4079_00.png",
-      "hash": "cb6c3d0298bc22d62017d4f8c0756fd314efe86d7d71464dc37b9926dd72cbdb",
-      "size": 100716
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4080_00.png",
-      "hash": "9d7a645bc61974d2f6007d69ff678e690c73d64216eebb5cbe2930d936d1090e",
-      "size": 113791
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4081_00.png",
-      "hash": "c26359e586fac36d4582e33ed83059599312c11d0f8a9e290f5b566f6888fd88",
-      "size": 102733
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4082_00.png",
-      "hash": "e457281e0644cc9297b7cc3e2ecb65b2ed6432264c48ab9b7cb120994e88a528",
-      "size": 108105
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4083_00.png",
-      "hash": "df055b9ae23ab6d649de3d1cb745a055fea5cdf70c99bc6eee0418ef446467af",
-      "size": 103520
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4084_00.png",
-      "hash": "79b69cdac3123456853124a226a94c02c409fd847cbdb2d128746cd11e4a008c",
-      "size": 101872
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4085_00.png",
-      "hash": "c9903d89db0779a6909641df0fd8c34e2837b766dd14d666734b00498b564ec6",
-      "size": 114374
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4086_00.png",
-      "hash": "a92b39ab9c29bc59ea94f26822530230096257b1f3d07f4db1d5df1acc9a7561",
-      "size": 112207
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4087_00.png",
-      "hash": "004369ee1c80ba6affa1c78d5a00bc74998a3af32a41ebf0ce7384d87163c51d",
-      "size": 106850
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4088_00.png",
-      "hash": "959589c64a8a818aa7432beafdaf6a3774fc9bd30d383b6a221ab4cb46a6df6d",
-      "size": 106316
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4089_00.png",
-      "hash": "327ed6613ef85c5d24723e69e716d942171072111b56e3883e631c567a70d8c2",
-      "size": 104665
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4090_00.png",
-      "hash": "0fa561d77ea0cd615118f92b0d6d472160280943f982bad62de22f39260a0e33",
-      "size": 117079
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4091_00.png",
-      "hash": "5e1aba57f4673107b7b11d2b4740480196cf714e1c808c82bdd0535800852e51",
-      "size": 104540
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4092_00.png",
-      "hash": "0a26c4e5f6973158a72429fff5373fdd3f0e3f0341a2570360417634c2117d5e",
-      "size": 109704
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4093_00.png",
-      "hash": "27f62a225a51821444af7ecc7286715215fdbc569da44de22cb25a91996921d8",
-      "size": 109831
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4094_00.png",
-      "hash": "bf8e99b1379bf28e1270e7ee4651432995da477c0a63cf5fd5b85b0c95a55256",
-      "size": 115237
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4095_00.png",
-      "hash": "0567a1fe332e060242ef38e17c22e568cdf1df09dbf373ce9cc8209870f298ad",
-      "size": 112897
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4096_00.png",
-      "hash": "9be695dbad8cca7dc2fd05178311112212b9798d38d31c26d9cb5569f9dae9e6",
-      "size": 103408
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4097_00.png",
-      "hash": "f817e3bf0dbda12f042129b3289710221056ab2b86a0a81a991b35fd4817fe57",
-      "size": 120143
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4098_00.png",
-      "hash": "67ac2e420f0094fedc7c15d1ae79e300667c333c4ad3831e78ea26cdca5f80d8",
-      "size": 101216
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4099_00.png",
-      "hash": "14a61e72d91c9350292c913a7ffa23142121744bf683e741a24e3bde5e0d0a1e",
-      "size": 103346
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4100_00.png",
-      "hash": "0a881f6a256f68c0b1f05e50a639a42bfb00864fad39fd903ede526b02462fda",
-      "size": 114888
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4101_00.png",
-      "hash": "6a9621221b940866ab977b55f56c3c17e4af658541929afcdce849efb2e17c1d",
-      "size": 115211
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4102_00.png",
-      "hash": "63d09b6468d1f237371979b464de77fd614120372c6d081a72048358bd4f18a7",
-      "size": 101013
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4103_00.png",
-      "hash": "1214d4b36bb1999c70fada8bb501b58aac1aa1ae83e2e078e21ca86be9ce3cec",
-      "size": 124759
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4104_00.png",
-      "hash": "79fb34cf2e4c124f9e368678d1b911848c5c85295bf3447f3086d743be923503",
-      "size": 117800
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4105_00.png",
-      "hash": "919a5e3df38efd303ac005a7dc7fe549173f10692b4ad0dcd5f49f38d9e57959",
-      "size": 117947
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4106_00.png",
-      "hash": "c03968faa122ca02fe39ae24d9f4e2f1cc0f8a2f7abceae71f1184639a51e1a3",
-      "size": 119218
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4107_00.png",
-      "hash": "caf1588ee26034498d182225ea08dc80e0981b4042233a6d60bc254891f257cd",
-      "size": 104278
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4108_00.png",
-      "hash": "77da666c9983496521fb3df4007e7148ba48560fd653ab35342c001d5b59e891",
-      "size": 115537
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4109_00.png",
-      "hash": "508651733e0805bfb960b70ce40d3afcac6ac47ddf93b16967a2167477da14e8",
-      "size": 111555
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4110_00.png",
-      "hash": "ddd9f67380c8cbd3ddd81f51dff7b4a7057c53bf95f68626d1ece0e3f392d25d",
-      "size": 115981
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4111_00.png",
-      "hash": "4e0308b8e1f9d5c644d0c928723d95c1ced85cc04ea1695487a36f23ee715f94",
-      "size": 104349
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4112_00.png",
-      "hash": "2c42eea2751e5c66edb90b97a90774b4c1eb68a27aa3e953be2aeab44d6fbdb8",
-      "size": 109571
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4113_00.png",
-      "hash": "5fd1192c4920acb3c76ec05d1d67466c37e9e4ae20e17e50969bec7ba0aa71a4",
-      "size": 111799
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4114_00.png",
-      "hash": "e138a64840b5ab6d7b9c5dbf7c1ac1f0b6b41eccee71f3da1b586d545938e634",
-      "size": 122047
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4115_00.png",
-      "hash": "6a7e3d69cfb07f5720d840b70d8aed96fdfc86711f3850db8ecd81ef9b452aed",
-      "size": 107706
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4116_00.png",
-      "hash": "3c845e9fb096be5bc8b6e039518d711b892525b4d910ddf4b938b16f99cf5c38",
-      "size": 111284
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4117_00.png",
-      "hash": "c8788f7607337bfb81adee74d14b9965e4f09f92731971be49fa3229e493428f",
-      "size": 132430
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4118_00.png",
-      "hash": "88fe3bbbdcb5ef560b18459d281aaea76b7c20aa7fb6bcb56b43318aa616d82f",
-      "size": 119524
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4119_00.png",
-      "hash": "44d9cd3ac60b22682d88ab561aa10949637c7c8e0ff305ffceaba9c9e1cfd845",
-      "size": 110004
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4120_00.png",
-      "hash": "1ba255c979d7e3cbe6aedcab7fa36d494318c08773caf8d2210482efb1365dfe",
-      "size": 117510
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4121_00.png",
-      "hash": "323bb9e197d364440b15febfa137802f86b7880a2e1bc1b601f24e1fa11142ee",
-      "size": 113553
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4122_00.png",
-      "hash": "9aef6ef47e582669d8b77a8097380a6a0955db92bc4408c0acbef19406e2c43e",
-      "size": 116454
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4123_00.png",
-      "hash": "d9bf817904df79655c4bf5561bebc1574b635959240d31a56ef87e4f39928cc2",
-      "size": 113836
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4501_00.png",
-      "hash": "b55a0c5fc7de18d691520efba89345f5dc8defa5047d855d076c93062ee1533f",
-      "size": 102934
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4502_00.png",
-      "hash": "deb156221414831e4758c7f1a0bf6c59ba703676a5c29924404d84437ee5befb",
-      "size": 101653
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4503_00.png",
-      "hash": "f5076a1f5c34f10b1ee31aa6e3bcdfb43b1989cc5ed56751ac8a9d9387f5528b",
-      "size": 100304
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4504_00.png",
-      "hash": "c61ab26484d192e4dc1914c509e6e7483241e93f85bfac5a8cd887c62319d269",
-      "size": 100735
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4505_00.png",
-      "hash": "801136e064cad0eb93ee0f591ca510bdcff23abef50b9e545842a00bd4f2cfbd",
-      "size": 106504
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4506_00.png",
-      "hash": "f235adc83d68e9ed893ea552aa83c8768473d276806dfc5ecb60fcc900b7c6ad",
-      "size": 106726
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4507_00.png",
-      "hash": "26b8a3a23a12ca15b84805de436fb0c4dbb35b91961b9e388d0d7f317aa57e77",
-      "size": 122519
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4508_00.png",
-      "hash": "7809eb33d2d9e1cd3ffb4f1dc88e946a0d448538792446a918b81128dd4f5125",
-      "size": 120163
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4509_00.png",
-      "hash": "d4ab327a36ea7b7cab43eed261b474b3b8312fcc88c92cbeb585432e130e7723",
-      "size": 106253
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4510_00.png",
-      "hash": "c7be5919fc37d28ae6167c9e61b2180d96536c4b2ab36bc8bcaceb181080ed22",
-      "size": 103768
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4511_00.png",
-      "hash": "b077b926a65140076af0e88dd8804bb44c5266fbf287e54ae33938686301a34f",
-      "size": 111122
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4512_00.png",
-      "hash": "1c86b71a6262ffc477971697853452611aa4e3b4a69f90a8681f12b6a212997b",
-      "size": 109244
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4513_00.png",
-      "hash": "b724ac3ad91f9199465d6e008751c5129bb2d7ae8576a45ffe21cceffab77407",
-      "size": 111145
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4514_00.png",
-      "hash": "3048f164d2ce59daaf93c54258ed829d088aa3c7edc795cbff376a4f8f86ea0b",
-      "size": 105210
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4515_00.png",
-      "hash": "9d393b02181b7e592e0ce9a2c7c1985ca82115f0ad20f28698334980c1ce5102",
-      "size": 105086
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4516_00.png",
-      "hash": "0991893d6603075a93e6537ce210008d24fa5262b5128dd057f45a1d827de9f4",
-      "size": 104133
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4517_00.png",
-      "hash": "717d1e76deb19925f108dbc685f4bc1c7e52a93246ac2a6293972783dec5b0e4",
-      "size": 103252
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4518_00.png",
-      "hash": "9e1d788ca53db88df340f4ce40ab69e13f005e0431f7584b6ff6fb2998353e4d",
-      "size": 107615
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4519_00.png",
-      "hash": "cb24c193e7aa0230cb6634d701fd563402faa0ec7f63bb9189e1a9bcf2b44cf2",
-      "size": 106860
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4520_00.png",
-      "hash": "405cedee3fdc8f81fcb1c3f16f19ed6580a512400acbe69b73296ec9ab758d7e",
-      "size": 113619
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4521_00.png",
-      "hash": "960b53c3e294326a8e454301cbef25d149ff168ac58778483839716a1b4f7f85",
-      "size": 102621
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4522_00.png",
-      "hash": "ac8d23cef26e386ed3894b456aeb7e557c49f226ef0ad03c185967db38439378",
-      "size": 110936
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4523_00.png",
-      "hash": "14de36d44f7f6f95dbfad7992958e49187c88a9124b7108b55d4562b2ce7ecab",
-      "size": 102319
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4524_00.png",
-      "hash": "8ff7ed222185e0b841351a3feead48c2acf03fa1dc4c346e9a48a90c663c9dc3",
-      "size": 102648
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4525_00.png",
-      "hash": "b8a52619e374a9a58c85bdbe669dffdcb80c1e168c9d99623a2d64aeab09f072",
-      "size": 111509
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4526_00.png",
-      "hash": "f2c7875fac05f892e8d43fbfeefaf9f448cc3f3291894cd6e90f16eb6a928ae1",
-      "size": 101031
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5002_00.png",
-      "hash": "a65885badcf3e78c79fbb6ca7840fedc9d767fc002ac91f4734974fbaaf59d92",
-      "size": 96947
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5801_00.png",
-      "hash": "b9ce0a5c0d7f4b138dc9d545e33144d85705854bd5175507e6d076f364dd43d6",
-      "size": 111302
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5831_00.png",
-      "hash": "f8f77f9a72853ff4fca4d55e32e9d932523f79c8d55335271450b28d2b9f2818",
-      "size": 101028
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5920_00.png",
-      "hash": "84bd34c1143daa8948dc3055b4ce20397c93ce96fef5efb3971e64928687e6d0",
-      "size": 98920
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5930_00.png",
-      "hash": "041e57b0de077b303fa2601618d9a10202e1d9f42383d9ae734d2b98fdb415f3",
-      "size": 117313
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5935_00.png",
-      "hash": "5296949832481668f74989b3564167444efa4fd9edaaa7927122902bc0265d55",
-      "size": 101364
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5940_00.png",
-      "hash": "157075348a5ee080d4a0b63d24557e37ca54e3ee567d376b5d965a1d85fc1818",
-      "size": 104500
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5945_00.png",
-      "hash": "c6384e8c94a8084ade031e9b6bfa2c00c3d4c853ce591d87d8c040e41599a42d",
-      "size": 112022
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5950_00.png",
-      "hash": "bc3bba5a1725bacf42138f480bd29069527bc7bf768f155dffa69c2b83446e4c",
-      "size": 104841
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5955_00.png",
-      "hash": "6427aa1f5a45b5a0cc2c863829c648d4c3a4f9c2556bf2aa31f0f9820fe14276",
-      "size": 102387
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5960_00.png",
-      "hash": "2ca4fcc3cf91b80b0efbcae7ce50885d9af1bc1be0cf92d88ba11c9e8204e385",
-      "size": 122477
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5965_00.png",
-      "hash": "af6334d462c6e2b0d0e26a97ad4ebc4c296bfd59b2d76403e3130873af338cde",
-      "size": 116573
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5970_00.png",
-      "hash": "448e71d897e0d185e0197a6b9cd8d4015d0ef2d25e8264e8221be8bb05c7b0dd",
-      "size": 114372
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5975_00.png",
-      "hash": "d4fbf7ff85b4f8b5d9ab9cac9235dab3cb286c6593c21af118e892fb3e296569",
-      "size": 103226
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5980_00.png",
-      "hash": "1a2a84897bf4b13fdb43605cf02c3217d601524f92973e2cacd36fe53f621b3b",
-      "size": 101270
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_01.png",
-      "hash": "40fbd7bada1a81dac2e708e07d2e3564cd1f1616dde0a1d824404d22d394adc5",
-      "size": 97594
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_02.png",
-      "hash": "291691322eb2124f457a4007fdafd365cdb997f90299e841d2f9c8a0383f1ca6",
-      "size": 100720
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_03.png",
-      "hash": "55af41effa892f70770bde97f06b3db6689ed948929dcd08fc6158f0ee768405",
-      "size": 100513
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_04.png",
-      "hash": "23b29824374458a7b3113b84b7fbf5e5da8dd3c3d7a9c3a4447bd87bee6e1225",
-      "size": 97643
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_05.png",
-      "hash": "0647f5755fbb1c2bfd61da5598ae5f9212eaeb15c6ad56d8ec9c335caf38fc5b",
-      "size": 98811
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_9002_00.png",
-      "hash": "19b1c3a97ad86a677b761672e8da647e50b651ff5875b60e634af8445801fb44",
-      "size": 123476
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_9003_00.png",
-      "hash": "0ad299e5518adcce56f2396177746f6ad81e52a336515c85e577adca03127963",
-      "size": 124597
-    },
-    {
-      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_9005_00.png",
-      "hash": "eb86b512444dba622342865d2b17a97075c001519568aacc98f73d923b35a919",
-      "size": 118903
-    },
-    {
-      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_00.png",
-      "hash": "f1c88d034c2cbe7c457e4e057bef35013976b35b2d34d25795ba3bc6def27d71",
-      "size": 182801
-    },
-    {
-      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_txt_00.png",
-      "hash": "58d47b16cd2898f85884cf23c2462080f2a9425d423753d87cb89ac13ba9fc44",
-      "size": 194248
-    },
-    {
-      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_txt_01.png",
-      "hash": "3ba93e63ce352fff7542f4980288148a616c25a998243c7ddcf2d629880975f8",
-      "size": 188967
-    },
-    {
-      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_txt_02.png",
-      "hash": "7e072c27f89803ff5e5cf5550a78c07498f950e66273ac2b4ab626df3e557993",
-      "size": 182654
-    },
-    {
-      "path": "assets/textures/race/teamstadium/teamstadium_race_teambonus_0100.png",
-      "hash": "a022c15ba6340d5bca4695de0e4ffbe5acaec2a543922cfc834ea59e1b9d5493",
-      "size": 43464
-    },
-    {
-      "path": "assets/textures/race/teamstadium/teamstadium_race_teambonus_0101.png",
-      "hash": "3cfbc81abba4f17c1ad07d64a5cefb04d5bf1df340cd583913497a3c888dab44",
-      "size": 42906
-    },
-    {
-      "path": "assets/textures/race/teamstadium/teamstadium_race_teambonus_0102.png",
-      "hash": "85ac8d83eeb0a1f789a55be12dc0ccb5d12bc0e8718cb193dd4c4c609cc2254a",
-      "size": 48084
-    },
-    {
-      "path": "assets/textures/race/teamstadium/tex_race_tr_score_000_001.png",
-      "hash": "73f6dd103e96a0d46d24de43fdf59ca6d540c07583801b5e8fbd946c1d1984e5",
-      "size": 18697
-    },
-    {
-      "path": "assets/textures/race/teamstadium/tex_race_tr_score_000_002.png",
-      "hash": "135db57e14440d53c4493f98202796d6e297313f527eaa15037e44335fb8d904",
-      "size": 14764
-    },
-    {
-      "path": "assets/textures/race/teamstadium/tex_race_tr_score_000_003.png",
-      "hash": "db0f2d4296aef643315aab1a15d4ec505075b469d36d91675d0b5cea7c896214",
-      "size": 17711
-    },
-    {
-      "path": "assets/textures/single/menu/utx_btn_helpandword_00.png",
-      "hash": "0629cecae14f507e934c182cc5693f412a19556b95caa957177747d96cf2574d",
-      "size": 212609
-    },
-    {
-      "path": "assets/textures/single/scenariocook/utx_txt_cooking_possible_00.png",
-      "hash": "67c80e28b4a8e0eea25d15a4b7c7fdef274b6e7dcfd276e1e1d87158f69a0bcd",
-      "size": 183954
-    },
-    {
-      "path": "assets/textures/single/scenariolive/utx_txt_livefever_update_00.png",
-      "hash": "88a32c76e6c2400c3670d2b16eb2d0a40dc817693d6f384816bfefc4888eda1f",
-      "size": 197487
-    },
-    {
-      "path": "assets/textures/single/scenariomecha/utx_txt_chip_open_dialog.png",
-      "hash": "ae4058f795527c3efebc75f3d7b1a4440855d2c30330ab0ead5ce5d3ef24fb7b",
-      "size": 129800
-    },
-    {
-      "path": "assets/textures/single/scenariopioneer/checkpoint/utx_txt_report_cover_00.diff.png",
-      "hash": "d7bccc34832ae1663c8a5f7ccaf1269a5bb59e6c3911fa53751a55cd6ab5402e",
+      "path": "assets/story/data/02/0006/storytimeline_020006141.json",
+      "hash": "b5b95eb8a0af8c58987e413250d962ba2ecc1a33f887616d8f634bff1cfea194",
       "size": 8248
     },
     {
-      "path": "assets/textures/single/scenariosport/utx_txt_advice_update_00.png",
-      "hash": "8ab7c0e19201d86ac053fb4accc8044c2debf16cbb8fc8e2ed3793cad85945f8",
-      "size": 72851
+      "path": "assets/story/data/02/0006/storytimeline_020006151.json",
+      "hash": "a3d8384609cb4a738bc9d6fa1248e1d861921663852c7380a2e6d99d6e237098",
+      "size": 12215
     },
     {
-      "path": "assets/textures/single/scenariovenus/utx_txt_venusspirit_get_00.png",
-      "hash": "3de82cb8a8e0be2d4aa4868e45970bdd24bcf44c6dc4a5eea4c9c2d44e5d5d22",
-      "size": 214453
+      "path": "assets/story/data/02/0006/storytimeline_020006161.json",
+      "hash": "6478a2f1edfb066ee1563921991743f3e90243a88709258928c212e9996a0421",
+      "size": 12048
     },
     {
-      "path": "assets/textures/story/telop/tex_telop_080000007_001.diff.png",
-      "hash": "f00304a78b080d287e2ea807f1f7925f2dc24932ebc21f535a118ab144d46b50",
-      "size": 12793
+      "path": "assets/story/data/02/0006/storytimeline_020006171.json",
+      "hash": "f8c8cac7f60be01758a3fb57ed616cb77a386f7aed994140e35a8e47a1d8921f",
+      "size": 11362
     },
     {
-      "path": "assets/textures/story/telop/tex_telop_080000007_003.diff.png",
-      "hash": "9d2e5adafcb1e2ab03eeeed9b6b8701e6b481fd9e2c2a7b9519d6df70e5037e6",
-      "size": 23288
+      "path": "assets/story/data/02/0006/storytimeline_020006181.json",
+      "hash": "c5ff1eedcbd83643a0c666a13cc33ffea549ed03d250abea9d252feeb7fd9ef9",
+      "size": 9349
     },
     {
-      "path": "assets/textures/story/telop/tex_telop_080000007_004.diff.png",
-      "hash": "63a5f361197c7aaa76d26dbf5dc5d99f0228b95d3ce91283bf9499baed71a016",
-      "size": 31338
+      "path": "assets/story/data/02/0006/storytimeline_020006191.json",
+      "hash": "47cc1310f1b59db460bb68f355f786e8352221a5f13251778abd91b0b7c842df",
+      "size": 20000
     },
     {
-      "path": "assets/textures/story/telop/tex_telop_080000011_000.png",
-      "hash": "7bc943b38a0920cb72c93d603bbe727476ac58055fea11c20b72f555f1c77a9f",
-      "size": 16913
+      "path": "assets/story/data/02/0006/storytimeline_020006201.json",
+      "hash": "107a8e7ccc9045ec72db63b1091313cd055c20f5a560fa4a8aa72dd19b6dba4c",
+      "size": 10574
     },
     {
-      "path": "assets/textures/story/telop/tex_telop_080000011_001.png",
-      "hash": "27ec2c501914106de1565473e795b36175d85294c37f4d82b7fc8eb4f3554cef",
-      "size": 34414
+      "path": "assets/story/data/02/0006/storytimeline_020006211.json",
+      "hash": "10a79ddade7a9070f997ef6cc3b6d8233ff83bfcfe076abc3d02decd460d8f4c",
+      "size": 14698
     },
     {
-      "path": "assets/textures/transferevent/00001/transfer_event_logo_00001.png",
-      "hash": "925d3951a7338b3157735a9792784be01aee485f0ea9c880efe66b2f27b56f57",
-      "size": 194350
+      "path": "assets/story/data/02/0006/storytimeline_020006213.json",
+      "hash": "5e9c7789e18b7daa4f18259da7bfb60e8b44b1ce147eef665ed4a569524edf15",
+      "size": 7658
     },
     {
-      "path": "assets/textures/uianimation/flash/race/raceplaying/texture/skillname/skill_name_100971.png",
-      "hash": "b0c44e57ef6c17f3b06363ce575632e7d7ac60b6e57aff2ae1acd8ce35693e8f",
-      "size": 152656
+      "path": "assets/story/data/02/0006/storytimeline_020006221.json",
+      "hash": "c502d961da61efce8e26adaf52465ee0562822317dba4e7a20b8ea572d1f30e8",
+      "size": 9663
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/racechampion/utx_RaceChampion_000.png",
-      "hash": "0f6519506bf460b05fda26dbbd7ecfb641a6d549aeae0cf8544f165b4db88418",
-      "size": 308458
+      "path": "assets/story/data/02/0006/storytimeline_020006231.json",
+      "hash": "6fd295b959bae2953b6eaa6e70d2c0e0b9835648c974b18cb5cfca008b649a86",
+      "size": 5177
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/sectionstart/utx_sectionstart_10.png",
-      "hash": "fbdc0a99f28e0e4701fa0298f6cba8256580f91c4afc2b1a44be007c07f532f1",
-      "size": 323652
+      "path": "assets/story/data/02/0006/storytimeline_020006232.json",
+      "hash": "79b3747a87911d6891e89ac1786b228ae1f16c87c2247ceda456e9b3408ca415",
+      "size": 4285
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_00.diff.png",
-      "hash": "0de8a17d86cfdfee7c7cddd5c279d02f47b252cc0ee0a73dee852f1b90939823",
-      "size": 22907
+      "path": "assets/story/data/04/1001/storytimeline_041001001.json",
+      "hash": "aa332918509dfbafc65238ecbd6a47803e75cfd5e6be4665b977141e94c15c7b",
+      "size": 9640
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_01.diff.png",
-      "hash": "309a31f2cecd83e820235609be251978d5582ddf886c60b4496ceafba134d854",
-      "size": 22117
+      "path": "assets/story/data/04/1001/storytimeline_041001002.json",
+      "hash": "981bb36eb86b13b2f04b777ddfa08ad39e1e6ac79d9c13cbb8083289831f773b",
+      "size": 9202
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_02.diff.png",
-      "hash": "bbb2b6457f0c7b32f595de33b5992e4f643788c8c1d2e4d2a2c7bbe269c78bec",
-      "size": 21870
+      "path": "assets/story/data/04/1001/storytimeline_041001003.json",
+      "hash": "8f9320440fbb1ee16031d4f644753fc9aceaa7a61a5e8cee9d5ced063129810d",
+      "size": 8827
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_03.diff.png",
-      "hash": "8b1e46d262e957920033ce6631c73dab88c47c4b108a84b5f6b772f953d9d8c1",
-      "size": 24465
+      "path": "assets/story/data/04/1001/storytimeline_041001004.json",
+      "hash": "8a1a0de54d8258d26dcfbfc338660f9d341cf6cb1f657f9bac2012059af75c80",
+      "size": 9844
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_04.diff.png",
-      "hash": "d7afb0fb319b2a944e608d3ddb2a015f2e7151a5f340be9625ee7ad5483b4ce8",
-      "size": 24543
+      "path": "assets/story/data/04/1001/storytimeline_041001005.json",
+      "hash": "7a357da0121216cc9a082e6863357a15751c947c27cb48d79d625adf8538cb2f",
+      "size": 6004
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_txt_charastatus_l_00.diff.png",
-      "hash": "675953d54b625b069f29a5e2807d344f1d2e3597a94b19264f9f47dc10774ec3",
-      "size": 8465
+      "path": "assets/story/data/04/1001/storytimeline_041001006.json",
+      "hash": "58bc065f6129877f10a2e143679edadc9f17374c1d05436211a7d99c2bd289d2",
+      "size": 9434
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_txt_charastatus_l_01.diff.png",
-      "hash": "b49638da91fdfcbc7da0154a07ae80480085ac8d4f50e79ca9aa30559f1f1254",
-      "size": 13548
+      "path": "assets/story/data/04/1001/storytimeline_041001007.json",
+      "hash": "a3a093c752ab49fbd774fce74fab1de3f28e800135f77f0cd8cd3ab67e4b83f3",
+      "size": 9188
     },
     {
-      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_txt_charastatus_l_02.diff.png",
-      "hash": "f48a0dd6ad44a41a046727dce2910d5daea03011f820f08fad012dba5e505642",
-      "size": 15205
+      "path": "assets/story/data/04/1002/storytimeline_041002001.json",
+      "hash": "41a22df2589d9b50255242c66fe957ae25f6c956159741c61ac0463cfc91733e",
+      "size": 8189
     },
     {
-      "path": "assets/uianimation/flash/champions/pf_fl_champions_result_finalranking00.json",
-      "hash": "9b488cbbb212cec1327e055643c81b8e8131ca3bafeaf3a7e5a1eb3350735e4f",
-      "size": 166
+      "path": "assets/story/data/04/1002/storytimeline_041002002.json",
+      "hash": "12d861c539c12d7b90bdb4a38d78418f769761111b486bea1dad5c9ca86f8bdc",
+      "size": 6673
     },
     {
-      "path": "assets/uianimation/flash/chara/prefab/pf_fl_chara_txt_hint_lvup00.json",
-      "hash": "3118bde83424c56d9d0cc63179eee4878879e5b6f142d38d7ca2bfe96b314c03",
-      "size": 166
+      "path": "assets/story/data/04/1002/storytimeline_041002003.json",
+      "hash": "97f0667d219da35738d5526b7b66fb8312f85c207f6497f9490f4a6a1fd0f7d8",
+      "size": 9234
     },
     {
-      "path": "assets/uianimation/flash/common/pf_fl_cmn_badge00.json",
-      "hash": "a60f640470ebf31eabbc8d03cb7a9e40cba18f308d1e441ee832e4902ff81759",
-      "size": 166
+      "path": "assets/story/data/04/1002/storytimeline_041002004.json",
+      "hash": "95659454911fde15326a30699a49c9abe2e19fd5ec4035fa5b9bfc0c84606f81",
+      "size": 9153
     },
     {
-      "path": "assets/uianimation/flash/common/pf_fl_cmn_txt_event_reward00.json",
-      "hash": "72762778aca553800a3de70ccb21e1be1200ff93bbd49ff79d92969a8d63dc07",
-      "size": 166
+      "path": "assets/story/data/04/1002/storytimeline_041002005.json",
+      "hash": "0c1c158682c4c9a79c45d5308db89acb2b7a4e443e3dcfe93eb0c445a7b425d2",
+      "size": 4681
     },
     {
-      "path": "assets/uianimation/flash/factorresearch/pf_fl_factorresearch_gauge00.json",
-      "hash": "97730a2423b65acbe4cf9bf45eb2fcd0403b524d09d6198d96e394ee818b4638",
-      "size": 166
+      "path": "assets/story/data/04/1002/storytimeline_041002006.json",
+      "hash": "53cac9b841909bb904a0f205c74165e688006866734beb8d7e0b5bfd5c96c81c",
+      "size": 7948
     },
     {
-      "path": "assets/uianimation/flash/factorresearch/pf_fl_factorresearch_reward_txt_title00.json",
-      "hash": "1956b2b83ad44acaecf6a90963ca003febe740e810018c1ccc89e20728d1dc29",
-      "size": 166
+      "path": "assets/story/data/04/1002/storytimeline_041002007.json",
+      "hash": "3fbad7964f1c1c8223a53f028e2306aaadfffa1369d5ad9687b59eed860dbce6",
+      "size": 9321
     },
     {
-      "path": "assets/uianimation/flash/footer/pf_fl_footer_landscape_btn00.json",
-      "hash": "54fbd2fc730116a3002f3686308ced361c45c085667da7ad6cb8ddaefc444fc8",
-      "size": 166
+      "path": "assets/story/data/04/1003/storytimeline_041003001.json",
+      "hash": "72368941183458d98a765bf3ac56a8f18e8654771cc841d689bd21a56d4a9ead",
+      "size": 8069
     },
     {
-      "path": "assets/uianimation/flash/gacha/pf_fl_gacha_chara_piece00.json",
-      "hash": "e99050b0aadd81bcb009e983cffad945dd65d8816f4444fc3d62186a25181b0a",
-      "size": 166
+      "path": "assets/story/data/04/1003/storytimeline_041003002.json",
+      "hash": "d076a313067aac0ab465bee2bebe4b76629acb1c0499b74ea24d9bc47cea106d",
+      "size": 9416
     },
     {
-      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_btn_get_heroskill00.json",
-      "hash": "b2dd3a5b279f61428448edfadd71e340564aa06028d9a3b6538bbacc92f38b3d",
-      "size": 166
+      "path": "assets/story/data/04/1003/storytimeline_041003003.json",
+      "hash": "4b43d496e29b1d01d4352d6a823d6042d3e9cb8b08f38a32bc9da3c56732b121",
+      "size": 8278
     },
     {
-      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_get_heroskill00.json",
-      "hash": "05559f64d8848eb59e8d431e214759376f7c525a5d998ce64c82c5820f32f24f",
-      "size": 166
+      "path": "assets/story/data/04/1003/storytimeline_041003004.json",
+      "hash": "7adcb814a76284638cfce2bc71d5e0710279f772a260f18e189d54167fdcf4f3",
+      "size": 7640
     },
     {
-      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_matching_comp00.json",
-      "hash": "17df667123a624d4a2e90abcb323cecb0415f87227bf1bf9f2fdb9f1ffef8f9e",
-      "size": 166
+      "path": "assets/story/data/04/1003/storytimeline_041003005.json",
+      "hash": "216135dcdb1d42819c9f3e3d4bfe14560e0259295568c282a41ad0f4111ff0f0",
+      "size": 6039
     },
     {
-      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_raceresult_gaugemax00.json",
-      "hash": "c22ddd973ccfab3ac1d6fa96ff0156d50eac0721cd29147512cb323d07595ac3",
-      "size": 166
+      "path": "assets/story/data/04/1003/storytimeline_041003006.json",
+      "hash": "ed13f903389014ee3acde7b7b098890847052b1ea0f9b0bfa34fd5264cb163ac",
+      "size": 9125
     },
     {
-      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_raceresult_raceend_pt00.json",
-      "hash": "a3fd19e9c16903702e9b9ed45de9079f5ac301357cb9334bc0b69f87bfc01305",
-      "size": 166
+      "path": "assets/story/data/04/1003/storytimeline_041003007.json",
+      "hash": "b9b5b4300c5b904adbcf8607e42b5beffedf8234807a0d96c426563f9be08b58",
+      "size": 9747
     },
     {
-      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_txt_racereward00.json",
-      "hash": "98073572c5083dfd7ba61583c3a66d0d29b4158d8ddeb6e231c73806e0e3e4d8",
-      "size": 166
+      "path": "assets/story/data/04/1004/storytimeline_041004001.json",
+      "hash": "b4a1b2602c79ab0795cda2cd981e882c80d3eef18886d40fdf56765cda91e2c1",
+      "size": 8412
     },
     {
-      "path": "assets/uianimation/flash/loginbonus/pf_fl_login_normal_title00.json",
-      "hash": "7568dc9c94cb9c8dce113dfc696a611964694f4691254017ff52b893288de046",
-      "size": 166
+      "path": "assets/story/data/04/1004/storytimeline_041004002.json",
+      "hash": "431c02f2daea909f7f44c03f02769a03001ae2d6a956366be06941f5c2c6fef3",
+      "size": 10545
     },
     {
-      "path": "assets/uianimation/flash/minigame/mng_0001/pf_fl_mng_credit00.json",
-      "hash": "2124fc7923d5ee809e1541a1171ede2111fd26981e70ab9d24410a10d9434a6d",
-      "size": 166
+      "path": "assets/story/data/04/1004/storytimeline_041004003.json",
+      "hash": "7941ada557a208e47def857e8b7fcd6a9b2104e7920bf9c5787a8111c33c14eb",
+      "size": 9711
     },
     {
-      "path": "assets/uianimation/flash/minigame/mng_0001/pf_fl_mng_dialog_get00.json",
-      "hash": "cff798628e5ea3d64a1f2cefe597ebf2649e78b30da10a39a5e5ecb63d8d33d6",
-      "size": 166
+      "path": "assets/story/data/04/1004/storytimeline_041004004.json",
+      "hash": "107b91f9cc59906b3f2d893ea08bdd92b482910c9156d7d9c15b41f5a15f4e3d",
+      "size": 10325
     },
     {
-      "path": "assets/uianimation/flash/outgame/pf_fl_trainingreport_reward00.json",
-      "hash": "e9717e2ca1f10f91082000c9967bedaaf3424c5c78b1363eb6586cb8066be2ec",
-      "size": 166
+      "path": "assets/story/data/04/1004/storytimeline_041004005.json",
+      "hash": "33f7833b3ab2892c0ca44682ee27f330fad668b49aa98d4012d403959455da54",
+      "size": 6474
     },
     {
-      "path": "assets/uianimation/flash/outgame/pf_fl_transfer_txt_negotiation00.json",
-      "hash": "77b21caffdff23c9a3a7510fb17c454584683dbe87841044fdef51caead09091",
-      "size": 166
+      "path": "assets/story/data/04/1004/storytimeline_041004006.json",
+      "hash": "cccfb3f1466faf263c427fb5361035a237809154f554526b72301aac5ba3a0c5",
+      "size": 9846
     },
     {
-      "path": "assets/uianimation/flash/outgame/prefab/pf_fl_contactcard_photolibrary_icon00.json",
-      "hash": "dd54f8708dc9a10b1d40b0c686d8ecefd9cbb7b21304f447e1067ff56fa409c2",
-      "size": 166
+      "path": "assets/story/data/04/1004/storytimeline_041004007.json",
+      "hash": "f8fdc48ceaec786b8ff9a958d5bc2951c79aea5643ffb825df458cce14c60384",
+      "size": 11487
     },
     {
-      "path": "assets/uianimation/flash/race/raceresult/prefab/pf_fl_race_result_rank00.json",
-      "hash": "26d4bdef11764d066a5d8def892e4a874052b4fcafe6b275af7327bb2dc46e84",
-      "size": 166
+      "path": "assets/story/data/04/1005/storytimeline_041005001.json",
+      "hash": "5b26b3363b1aa85fc1011449876d55f7c491adc81b80899ccea5a24274fea100",
+      "size": 8766
     },
     {
-      "path": "assets/uianimation/flash/race/racetitle/prefab/pf_fl_race_rt_04_00.json",
-      "hash": "356ea2d9266a9bed422c6a82dbcdead6f4eed9e36e0214db2e52381dde0b3deb",
-      "size": 166
+      "path": "assets/story/data/04/1005/storytimeline_041005002.json",
+      "hash": "5cafefe4a90f922588da05a82f3cdc888cc39155b898692b44554034b3785d71",
+      "size": 9754
     },
     {
-      "path": "assets/uianimation/flash/race/racetitle/prefab/pf_fl_race_rt_06_00.json",
-      "hash": "74236f37c9a2981ae4abb60b5ce4e26dd0bb3e31d5640e0ee339eac5ba8970fb",
-      "size": 166
+      "path": "assets/story/data/04/1005/storytimeline_041005003.json",
+      "hash": "f31593860feb7d331a945499ee693515b9b2d1e82341b6425b637c04b6226a66",
+      "size": 9144
     },
     {
-      "path": "assets/uianimation/flash/ratingrace/pf_fl_ratingrace_result_rank00.json",
-      "hash": "fe24b5d6f145a338b85e409847058f8f2d297168f5ad27f6ce1371975e004d50",
-      "size": 166
+      "path": "assets/story/data/04/1005/storytimeline_041005004.json",
+      "hash": "ba9ec48eb58f515fed1f6dc99946605c40a3795ff73dc11498f69c5f1a15aad9",
+      "size": 10556
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_abroad_expedition00.json",
-      "hash": "07805c13db160da8a8f4cac6fc3a06cbbe1217060104cf18eee175f5e28aa942",
-      "size": 166
+      "path": "assets/story/data/04/1005/storytimeline_041005005.json",
+      "hash": "d0663f0243eb17000197b9c58fc7de39c915c06f53ed3de42b9795c683b94ab6",
+      "size": 5167
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_btn_trainingmenu_ssmatch00.json",
-      "hash": "0220080a1aa6b43bab17914d20595a927760890d4bee73706e5d790d132b1f9c",
-      "size": 2380
+      "path": "assets/story/data/04/1005/storytimeline_041005006.json",
+      "hash": "b482985d4066f50d549505dc03c1bc65ab9fc2d6c88a817e98b7aae26491e6c8",
+      "size": 8641
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_event_racebonus00.json",
-      "hash": "e20826dda2b489ca1f771ce5b356aa1d639e1ea4d85e31f74bd86c1e78e93e34",
-      "size": 166
+      "path": "assets/story/data/04/1005/storytimeline_041005007.json",
+      "hash": "f528b7387e99ebcfe9472c9c6c3d1828bd2bb8a7148443a719dd140f75f3c498",
+      "size": 8643
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_event_stargauge_up00.json",
-      "hash": "ac0926895b920d4967b2e77598d8b3c244048b1df3297accb39414881e4bc86c",
-      "size": 166
+      "path": "assets/story/data/04/1008/storytimeline_041008001.json",
+      "hash": "eb88d804e1f54053434895fc9292170f704bff8fcbc2e86ede01a7a696186fdf",
+      "size": 8616
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_extrarace_result00.json",
-      "hash": "3782209dc27d9f9a47472c02272d2ca37ca7cea6b35a1107ac889b8e42e9c6c1",
-      "size": 166
+      "path": "assets/story/data/04/1008/storytimeline_041008002.json",
+      "hash": "d91e6cc936184feca9bd5ec90c082b3f1fbc492042a2c39b552b8fd689e99b36",
+      "size": 8514
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_get_response00.json",
-      "hash": "b18dfb96fb4b43f3ef9c92177c3233f63fa11460321f45a1f84e27e2e1b75bd8",
-      "size": 166
+      "path": "assets/story/data/04/1008/storytimeline_041008003.json",
+      "hash": "8f81020c9e6aa7b093185406e476de359476f5179943533515be0b89058c0932",
+      "size": 6899
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_header_turncounter00.json",
-      "hash": "b1a3c103990f0c69ee592ec6320388b9694899af29160fddae149fee979be486",
-      "size": 2159
+      "path": "assets/story/data/04/1008/storytimeline_041008004.json",
+      "hash": "5766d1cba7dc75a71ef070af3554d292a4362bf37be165060b9f8035c64c6277",
+      "size": 8468
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_next_target00.json",
-      "hash": "39a6958eea233d21b436f75d68ee9bc9c7194a9a0cc5bc9814e5b9d597144faa",
-      "size": 166
+      "path": "assets/story/data/04/1008/storytimeline_041008005.json",
+      "hash": "3c77e3dff768745246a1e2398c8580a9ddd0e73a7ee7d4eee55e2e7de5721664",
+      "size": 5540
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_remind_turn00.json",
-      "hash": "f119fec67bf6ec5524761ac7e0fd7216bfc689dc5ec8b1f085d7f718880151cc",
-      "size": 166
+      "path": "assets/story/data/04/1008/storytimeline_041008006.json",
+      "hash": "8266d94fb68838c54a61f4d55ec0e42ba2f42a9f4b2d7629c35c4cffcfeca7d8",
+      "size": 7719
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_speech_bubble00.json",
-      "hash": "c7bfa5e84f5a4a8f9866973c9be968829db18c6fab560635961e017355b83918",
-      "size": 166
+      "path": "assets/story/data/04/1008/storytimeline_041008007.json",
+      "hash": "57bde3fd8662417f98801be78b16db565f2d402cf10903ab64497e9ebcf989d0",
+      "size": 9257
     },
     {
-      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_txt_lvup_response00.json",
-      "hash": "96f59bb265c29f23c712a74913a54e884b9739fb465ef234224bc477e8b7b5e1",
-      "size": 166
+      "path": "assets/story/data/04/1009/storytimeline_041009001.json",
+      "hash": "c3085c61f85b620a61524c6baf19b9f0daa00da1344cccebaaeb12d90daf3ea8",
+      "size": 7006
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_badge_garden_reinforcement00.json",
-      "hash": "c2b814fdee212314694fbe5dc9866bb2c493373d29dbf73a3c5cb8c36e633f5f",
-      "size": 166
+      "path": "assets/story/data/04/1009/storytimeline_041009002.json",
+      "hash": "5b4c9462dcf74bc7bb119fc6d1ff818bba658f65d3ca5da6c9015578279a72a6",
+      "size": 7483
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_btn_recommend_dish00.json",
-      "hash": "d5b7d6eccb2369ac1c8ca3ef79ad6e6097f96a2352e523c055ca23cb209ffe11",
-      "size": 166
+      "path": "assets/story/data/04/1009/storytimeline_041009003.json",
+      "hash": "203b5e055d6ac6e227f70ac1bbc40d8d80359c25c4e03f70111e867e64323148",
+      "size": 8720
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_btn_trainingmenu00.json",
-      "hash": "ddac3300711137195c1e36500ef71bc7e1e403de3dee45169c1de8018a0311b8",
-      "size": 166
+      "path": "assets/story/data/04/1009/storytimeline_041009004.json",
+      "hash": "ffe5ef3731829409d709f856419d050a34e9682dba1b5e09897a225e6912d2fb",
+      "size": 7688
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_care_harvestup00.json",
-      "hash": "45e28f07142b28d63d8b6ae6968a061204487f8fad99146239dd610704fc28b4",
-      "size": 166
+      "path": "assets/story/data/04/1009/storytimeline_041009005.json",
+      "hash": "41bf6ba5489db1721bde96f2a54d1296e4703e81cb419cf2d7e2c4049c33f790",
+      "size": 5994
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_care_title00.json",
-      "hash": "6e9ed4a64f4209d6914520d59d5385251af2fd7ed22d194cbe471ae2db6bad92",
-      "size": 166
+      "path": "assets/story/data/04/1009/storytimeline_041009006.json",
+      "hash": "89d12040e6ab1e45bac1f71978b0f8882384fc284627d3d2892d8689d1ecbe9e",
+      "size": 9531
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_btn_kaien00.json",
-      "hash": "a8062b8da0c4fb1b24ebb566738454438dee900f2a9e9753d66f5e1e20843d68",
-      "size": 166
+      "path": "assets/story/data/04/1009/storytimeline_041009007.json",
+      "hash": "a29537ab4515b1c8a46af13b0ca7d7591cf10b606c8217edcd1c8df31cfa2793",
+      "size": 9413
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_dish_add00.json",
-      "hash": "9d5244370053acccd959c08940154915d59020d8574af4f4c561be23219f4007",
-      "size": 166
+      "path": "assets/story/data/04/1010/storytimeline_041010001.json",
+      "hash": "af70a13d37218a45baea9d0557f49365a3541511b7403a6510c694cfa8972612",
+      "size": 7460
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_dish_efficacy_up00.json",
-      "hash": "0c8ba52524113eb1240845b4e2538998624627a921476dda02b6642b982a5064",
-      "size": 166
+      "path": "assets/story/data/04/1010/storytimeline_041010002.json",
+      "hash": "ed4034bda1ca7c93b831166b9bfdaa83ab5354c52ca427680c46deb5b24644f0",
+      "size": 8808
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_join00.json",
-      "hash": "3dc23e0c65fd856eb42d196796242c71969ab6b6108b162895c75e73ac024723",
-      "size": 166
+      "path": "assets/story/data/04/1010/storytimeline_041010003.json",
+      "hash": "0cbe8f26090049c74318512296699cf44aa5211367527afc8d4e7d0428419d63",
+      "size": 9179
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_uptrainingeffect00.json",
-      "hash": "20fd4b2854c4bf29ed7ab91f67b4551eaa3913b0ac006e168bfad7688587cf58",
-      "size": 166
+      "path": "assets/story/data/04/1010/storytimeline_041010004.json",
+      "hash": "e1e499b30fc2cf1f0e63f1bd017ae5eac7936b5199d2dfb651a74546795819d2",
+      "size": 7226
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_vegetables_lv_maxup00.json",
-      "hash": "dc38d0514d25568b0f82523928d17d1f94432ba07e6b207385d6d6fca1cf8c73",
-      "size": 166
+      "path": "assets/story/data/04/1010/storytimeline_041010005.json",
+      "hash": "4a7c2b44e52845c78b6198716b6f3303163007fa46b7a73a3fbe7a79f15b8351",
+      "size": 4776
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_get_vegetables00.json",
-      "hash": "9c4c75135888347145e930e1f42a72ddfa281970fcb8d47abb682958f8fac585",
-      "size": 166
+      "path": "assets/story/data/04/1010/storytimeline_041010006.json",
+      "hash": "34c9721a34ef8d7d639f9dc035640f65c50b2cdc024ae1d7834dc5b947a746aa",
+      "size": 7887
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_header_turncounter00.json",
-      "hash": "136901cff19f1301c847c015dfba766ecc79cb7cb6b7916e920a83d8a4b9a830",
-      "size": 2273
+      "path": "assets/story/data/04/1010/storytimeline_041010007.json",
+      "hash": "6a1472dcca91600ec367f33b35959443eb351a7f780f85255bb4d89ed54ecefd",
+      "size": 8663
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_premonition00.json",
-      "hash": "5abcee5f5e2053043ceca5b2b19676535b6498f0a71874e7b06f8fa705e11775",
-      "size": 166
+      "path": "assets/story/data/04/1011/storytimeline_041011001.json",
+      "hash": "2cc2a8cb4168b92b2ba4bec43823edb65c8aba2f09628e66a90ae855d5f23fd6",
+      "size": 8517
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_ptup00.json",
-      "hash": "a08e2efd40b7bd1cc9ac225b132717f862220ab8b151311910c7eff90ce96411",
-      "size": 166
+      "path": "assets/story/data/04/1011/storytimeline_041011002.json",
+      "hash": "8e92bd1c492f98d55a4ee9b425ceb527ea18886e4b5e24a3eb4771f6ae83efce",
+      "size": 8361
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_remind_turn00.json",
-      "hash": "9bceacc4f03aa4706d56dd6bdd21697c559e5e8dff7c8bab32f547f2af6b0380",
-      "size": 166
+      "path": "assets/story/data/04/1011/storytimeline_041011003.json",
+      "hash": "ba7be5d25238d386a2de015980621c7955e1d773c81f8e3b5c9c924e717ee7f5",
+      "size": 7406
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_training_multiple00.json",
-      "hash": "229594caad57d0933925a7ca3ffdf7c268b2d3a9256ae049cd6d88d030af0a04",
-      "size": 166
+      "path": "assets/story/data/04/1011/storytimeline_041011004.json",
+      "hash": "be8371e5f6d781e5202cf00b486163015153dab88541b1e21a29886cd3cc2818",
+      "size": 9425
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_txt_harvest00.json",
-      "hash": "0026876c9e101f19ef9ac12035a61d086d2d4565538da90297074fc23fc2a250",
-      "size": 166
+      "path": "assets/story/data/04/1011/storytimeline_041011005.json",
+      "hash": "c4901559b2dd18082bca37eb64e0e3f6089c16be7ef322067cccd6a4ea67def6",
+      "size": 5447
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_txt_manzoku00.json",
-      "hash": "fccfc72f982f3da663afc8a6976d49ce765a79b23e487f81eb4b516183850230",
-      "size": 166
+      "path": "assets/story/data/04/1011/storytimeline_041011006.json",
+      "hash": "57b4d42e83c32e41c7b12e24648801385ef98af220a9f176c2281f0e185b997a",
+      "size": 8031
     },
     {
-      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_txt_success00.json",
-      "hash": "6e0a6037a143a6a2c121a91fdc0d60f972123320fc83f06862d8e0728284937f",
-      "size": 166
+      "path": "assets/story/data/04/1011/storytimeline_041011007.json",
+      "hash": "62eadca66a4ee9cab267d7c8ee65bec73db0d0f35f06c85d309b7b9d82e3c0b2",
+      "size": 8167
     },
     {
-      "path": "assets/uianimation/flash/singlemode/free/pf_fl_singlemode_free_header_turncounter00.json",
-      "hash": "ad4fb862ed0e56a05a89486642a2a2d4c7e134f1bd018f55580c9aa500296abe",
+      "path": "assets/story/data/04/1013/storytimeline_041013001.json",
+      "hash": "8a85b7d3bcfb1672912f6b93bae6e0cfb8176e6b466a2825010a3296b2433637",
+      "size": 6537
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017001.json",
+      "hash": "e06e1c305778492461e5a48a41fb7a4ea68dcf21b47b975e0140336b89f60159",
+      "size": 6197
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017002.json",
+      "hash": "70ba8d0a0bb1033f9cbc429256e12b3cf20c4512a7d9d3c91345277a537eb369",
+      "size": 9016
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018001.json",
+      "hash": "09c4b1ccba3849dc5122bc400318addd33fdf5d625abe63674bd5c0b9ab7db2d",
+      "size": 7701
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018002.json",
+      "hash": "3a942f3ceecb67482c60532e8e13454b73113f5842e77b30e02b34dc7bc198c6",
+      "size": 9296
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018003.json",
+      "hash": "6a4efba4ed405eb5331a1d237f8b45b8549eb23b2691ed33a8e975d0d2103dcf",
+      "size": 9179
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018004.json",
+      "hash": "546d65db94f07b865f61e04a55f8eda1b570c8b91142385b5c18a76779f28a34",
+      "size": 10075
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018005.json",
+      "hash": "35d57664217c1b996472ef1091e839d42e22458018490e280e03481e30afa44b",
+      "size": 5684
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018006.json",
+      "hash": "d49d25f7f03407e2b5e3ea6ee909a7ff5cecb6fc4665fb226848976e54d17509",
+      "size": 9120
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018007.json",
+      "hash": "171f48c7b0fa45b0fced95487767d28b98a3b57594363dc8dfb803c65f5f231c",
+      "size": 8986
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020001.json",
+      "hash": "2817f94dc5cd8890e756f40445bc64d78dc1b50936c877d42bb3c407a507bf8d",
+      "size": 9261
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020002.json",
+      "hash": "338c57c01eb579d57d55209143c98251b458cf24a02729a87570e8d0b907200c",
+      "size": 9197
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020003.json",
+      "hash": "e033641a18eb1713e25ab3f017371d27bad91021cd1df7e92f9ebc3e5a08288f",
+      "size": 9182
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020004.json",
+      "hash": "f160bb8eae01d9d815c29d39c6672b9eca46ffcc22df827f279885172979353e",
+      "size": 9762
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020005.json",
+      "hash": "6737e0ac0827d5d213e5893cd8d543db94b3e0518e3f035a05eb0bb3494f28e9",
+      "size": 5243
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020006.json",
+      "hash": "1ae4c28077450daa7cbd2bacbce961f11082608f46f944a6669fcc88d29852d1",
+      "size": 6967
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020007.json",
+      "hash": "86ba60875283dbed1d29ee4d829744bc7d79febeaae4ecb72aff4480aa57a315",
+      "size": 7942
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021001.json",
+      "hash": "f45dab00ada67dd562ff87573c5bfc27807b2a72a030242a22e7eb20bde3eda9",
+      "size": 10479
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021002.json",
+      "hash": "42e6d050d03849051705ae0472efa67e3b94d3ac12199285ac858d5707e04e17",
+      "size": 8749
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021003.json",
+      "hash": "d7ed3d409253db7f00d86eeadd366147682cda7eda818c74e2275c786f279fd5",
+      "size": 8646
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021004.json",
+      "hash": "a1c5b6d898b4d45f8ecfec38fc03d8987a3a268ae8aff99948588ed0af12724e",
+      "size": 8413
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021005.json",
+      "hash": "721315a8bd2e9a60b427ad8880c118539fab8ae831f9a74832b466c35591232f",
+      "size": 6363
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021006.json",
+      "hash": "a58fe8bd1f85ad4f7ec0da119ccad35333a86ef98bf481822b54c51e5f98bd2b",
+      "size": 10044
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021007.json",
+      "hash": "d0e63ba54e385b98c1360fd6a0d50e1140835a71f44d777e7db06ac8f670d75e",
+      "size": 10816
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022001.json",
+      "hash": "64da899bcb9af226c6bb1920896a3b66589779f15c3fc217e3d950a666b49acc",
+      "size": 7194
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022002.json",
+      "hash": "94ef702dd62582385a7930c0b80c38136f20f8331ecd6b5300c9401c1a552d3a",
+      "size": 9837
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022003.json",
+      "hash": "e7587c0befbbdf0330726056ad86c11438754ee0fb72b132f788b2f95fde4cd1",
+      "size": 9458
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022004.json",
+      "hash": "1ef66828933a953358e6703fa6b1a76d90194995a739b50febdd04f726cae0ce",
+      "size": 8314
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022005.json",
+      "hash": "4eb480abc2e329b646f5e0175e0aae0b62a2e45460aae4008aa6d5d8ca05ae61",
+      "size": 5993
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022006.json",
+      "hash": "14745c6ce244d4aad3fd88e2e714916607993ed0b7a36f9776d3fd08969772ac",
+      "size": 10083
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022007.json",
+      "hash": "a7242912e5cd87c6b76ec1102c1661c5468b2c48f6d47ea78d44919399515e45",
+      "size": 10046
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025001.json",
+      "hash": "2139b581cd153222fb1ac6312e4e5d4128b0e2fc7c9e30d6ecc080c1f247887b",
+      "size": 7507
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025002.json",
+      "hash": "3b6f658f0b9385b864722a69d6b97036f05605569df8b27f065f278516422675",
+      "size": 8069
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025003.json",
+      "hash": "381bc2ba23ca558a9ae2f8ce5b361027b6f2f5e60abe10618620c3db7b1b0a9f",
+      "size": 9472
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025004.json",
+      "hash": "51b60fca6150e290f73629e00fa8d1684203fa1abbc9e7f08513f20b9f84ddb7",
+      "size": 9408
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025005.json",
+      "hash": "b4a8f8dc785df09fd5d9360a8d6067477fbf9392e3313efe5a9147a85dc2a24b",
+      "size": 5179
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025006.json",
+      "hash": "f4f0e82dcb3f0ac74b89227512a18119278ab83901b9fc90134840c5ca3ba354",
+      "size": 9052
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025007.json",
+      "hash": "a1be87dd0d187769f3c7bc25da2cf0f725116b4c21819e85ba7f024f1c7662c4",
+      "size": 9227
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026001.json",
+      "hash": "e631fe4aadf79d236a5139e4a9fcd16dd00a1bf967e59abfe174efab469ff781",
+      "size": 8396
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026002.json",
+      "hash": "3b2b36074582d96572a37808da723f4c62ad992a0d98b6f33a1d2ed2a2e11844",
+      "size": 10321
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026003.json",
+      "hash": "d1ccee9475f9f3587cd9cf81b2ea993258017298e5282343e5aa9e3b441b69f9",
+      "size": 10551
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026004.json",
+      "hash": "65b46600abb8689f6842b457f54849c831dd26ba382599a43225bd0c81957cf4",
+      "size": 10760
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026005.json",
+      "hash": "d4503e87b6d1509bbc11e62c9b3107be1cb097e79a6d8228968b2a1ff830ac37",
+      "size": 6474
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026006.json",
+      "hash": "52216cd943c2732dd6866b19d949d7f2162371aabbf20bf3e75861e0ea0d8cb5",
+      "size": 8567
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026007.json",
+      "hash": "befb410b4b8ff045feef7edfd52b100e9dece513509d3c45d5ef139422113bf2",
+      "size": 9890
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030001.json",
+      "hash": "9db885228cfa18e75407e5fa48f04bf798c82a2165c76bc2fa4429340ee7c572",
+      "size": 7602
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030002.json",
+      "hash": "aa28a646a94b3138dc29f952310b3f67d3ca2dd85cd980e5ea0206482b9fa54e",
+      "size": 10472
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030003.json",
+      "hash": "c8846cadafbf0c8964164987f4258608107c9b07919a34162b3038f6473713e5",
+      "size": 10891
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030004.json",
+      "hash": "09274ddb34b9b0c447a7b3e4bde5864a765a0cc7ea2a92faab95cd017bd0369e",
+      "size": 9006
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031001.json",
+      "hash": "fb9552be2da59707ea69d7fb25f8b6e91afdfe8eb75d1b24830d6f1f4144f43c",
+      "size": 6176
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031002.json",
+      "hash": "b356a83f7766abe8512e1176fc732ca075d2902f6a717e73aa2ef94cddd40aac",
+      "size": 7753
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031003.json",
+      "hash": "eaf73b267a551fe4d666602ac4c3dcb1798fe94f6b0c791c87e47b8376653190",
+      "size": 9987
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031004.json",
+      "hash": "8de7cfb4d3e2541f6a7da061ea58dd7c82440410595651615354ee1c50896f7b",
+      "size": 9870
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032001.json",
+      "hash": "dcf19fd644736e588189ec02cc093a3594cd9308beef8ccc08c1788de59b0ac6",
+      "size": 9762
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032002.json",
+      "hash": "b17f06905188f8bba7449c9f78bd77afae8d9b599c5e163c33bd177a4f70f09c",
+      "size": 10757
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032003.json",
+      "hash": "39e565a4c6445182f7d552e652fdf5c7ec05d376e1d89843cb2493f4c7461b1a",
+      "size": 9722
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032004.json",
+      "hash": "add18abdc239d1b9cb5c7560784af5a281fe83a52163fbc67db564fb7a0c0bbd",
+      "size": 9581
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032005.json",
+      "hash": "372c0bd7eb31f4b7c257382f393817d6895cf2f1d0cd983fbab757bc6a7d5c79",
+      "size": 7152
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032006.json",
+      "hash": "7e5bd4bb456343855bc7dfc4020158e79caa1bb9ca44373d9cf698f36e5af621",
+      "size": 10003
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032007.json",
+      "hash": "9f72d28ba9c0ec36d2a07be885be338fd82022f16822c6807d6b0f6083476433",
+      "size": 11491
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033001.json",
+      "hash": "84c535e2a12db03ac3a66214d0e51455e7be4559f1558e567e3da019a7e4ac98",
+      "size": 7454
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033002.json",
+      "hash": "b925c50ded91b38041c7f27cf2ebb6101d8897c657990d586642cc7d16559644",
+      "size": 8115
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033003.json",
+      "hash": "d5ffe17d6557bbd2a14db0c1972b2d98aa255e1d0c94494b204994970b35de93",
+      "size": 5649
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033004.json",
+      "hash": "f55beae255db091b92e62b6b4058348eae63a982dbb0e5a409952c16eda4b31d",
+      "size": 10804
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033005.json",
+      "hash": "766f89c0a4b43f0465f3d1ea280e2469975d5d2a1c75a42369a59bebd13dfd55",
+      "size": 5021
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033006.json",
+      "hash": "cf17ba5660486637862d38444ae043892fbfd7681cfe0c1c844c89af1c707dc7",
+      "size": 5977
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033007.json",
+      "hash": "5312f24d4ba60f3657b391b5c646efdb9cdfc1384ef941ba4dee2c08e10ebb4c",
+      "size": 7270
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034001.json",
+      "hash": "b383561e7dbd6a4e1dac8cab8545802c018d1b38d9f3b1e5362c4f874d117257",
+      "size": 11718
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034002.json",
+      "hash": "33be5bd95563f7dd3859415b3984f447bc34e181732206fc44cb9533725376f5",
+      "size": 9083
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034003.json",
+      "hash": "c8908533be6ff1df9e5b3bb386c9af625279ad4968f4c03e592fabd6d9b70965",
+      "size": 9032
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034004.json",
+      "hash": "0310dd7b8e2d4933ba619889ee1aa25010aa5a14fbe320b8cf9263588bc4f982",
+      "size": 7948
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034005.json",
+      "hash": "f777b83692182daeb1b5294bcf982f5259d08fcb64f9ea2206a5869db006374e",
+      "size": 7423
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034006.json",
+      "hash": "b95600a3ed60fc96a75ceb975d09f68dff2d12d6c7e070bd5f200e9abfcaaa28",
+      "size": 10475
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034007.json",
+      "hash": "67f399435f386c564f30109052b17cb11041bb13748f10dee48a2e733fad6e03",
+      "size": 10882
+    },
+    {
+      "path": "assets/story/data/04/1037/storytimeline_041037001.json",
+      "hash": "522b37babfe167c980bad8bca0ed5c3627821ec9fd212a148a04d316912cc815",
+      "size": 7065
+    },
+    {
+      "path": "assets/story/data/04/1037/storytimeline_041037002.json",
+      "hash": "b365fbcfc0283934c7106f14449fcdeb1c0cd0b08745c9097d2cf58236a24272",
+      "size": 10043
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038001.json",
+      "hash": "8cdd8677ba8fb03fc74556068a55bf3f68c0e83247573302c8c51fd28f872cd0",
+      "size": 10596
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038002.json",
+      "hash": "a1f593d4378dcd582d0a11fa08a294491cb031d91ab104f5c8f8282ce2064d6b",
+      "size": 10176
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038003.json",
+      "hash": "3327249ebc930717acef9e6049298ca27038d95cb4d3ca098bd8db253055f34a",
+      "size": 11048
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038004.json",
+      "hash": "587700e2576308d96ea873af80e3f75fc1b6755ce0c5457410960943200bf63f",
+      "size": 11313
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038005.json",
+      "hash": "58f72c064f7b751cb31efe18dea773ce3d53d423e96378005aa87279e36b0623",
+      "size": 7624
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038006.json",
+      "hash": "ad41b9150b41b8d469b1fae9a19c02a1efc02171288e3606e06dede2712659a6",
+      "size": 10284
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038007.json",
+      "hash": "f1e46ea67b8b1828ce161af5c51fb2795dde1fac908f450c2d73cee042cd5cdd",
+      "size": 11114
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040001.json",
+      "hash": "aba922dded2d08ca767610f9b453ec1a725a4d586af8479ff3bd27c3f8dfca20",
+      "size": 8133
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040002.json",
+      "hash": "28e8b77d13a4a2552e160f03cabdaca30a66f4f49649a33c877f7f330d44539b",
+      "size": 8071
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040003.json",
+      "hash": "29401d3c26abeb6b1d299c07f2de33f47e7fcd838bddf10da91b46f748bfc372",
+      "size": 8762
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040004.json",
+      "hash": "ca6ba51bfb8788976cd2a7d985f5e759a545c7f7161655dc25cfda81155a44e2",
+      "size": 9698
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040005.json",
+      "hash": "f11ba8479607febda9491809288d9f3c158e9dee5005a981029ba8277631bf42",
+      "size": 5827
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040006.json",
+      "hash": "9b3b7044f82021f318605c24bb0de93f2cca34389863452222f7ce7d98fb43cf",
+      "size": 10673
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040007.json",
+      "hash": "b010a85d5ee21c36d0050e9d9bf2826177aa487b62576277c0a0d870cf9d7245",
+      "size": 9442
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041001.json",
+      "hash": "def1bef4cce86e06b8b1a109c8007eb90ed1a6d36cab2b18a54579ab97b17f69",
+      "size": 8983
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041002.json",
+      "hash": "a2c5417824ae8116de6a5165a43a14e700aa0c34cd2bf482425f749160d367f0",
+      "size": 8807
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041003.json",
+      "hash": "108daeb611e205301b5dd315b01ac9c06867fbe3fa77384383c860917955f806",
+      "size": 8063
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041004.json",
+      "hash": "fd9701d2546d76bfb16722b20552b99f8f8dbe00c2fced417692257e438c1fc2",
+      "size": 8682
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041005.json",
+      "hash": "d3c012a92c47b1336824a39f0b24b9dd08b6480a8d7024b09a7dd207e448f070",
+      "size": 5853
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041006.json",
+      "hash": "84ee4170cec95c2510ff0ffd3213db1ce47fcad6cb0aec1fa7e9a622f14ae975",
+      "size": 10226
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041007.json",
+      "hash": "0eb14bdc4fceae13c6263fbce13306292ab7c894c149427e75cfcdc88a8e5ca3",
+      "size": 8227
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043001.json",
+      "hash": "a870227133efe83cd6c07533888e21d8c4304ddc37808f0c717174f33ff7ad20",
+      "size": 7857
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043002.json",
+      "hash": "f116f7780013dd52b12aff5cebc1639257b571dbc9d7510d821dfb79f8ddbd06",
+      "size": 6625
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043003.json",
+      "hash": "43521545f5557424dfd054f3e97566c3bdcb11b1fe820b8c79a920b265e18fab",
+      "size": 9931
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043004.json",
+      "hash": "fae53a4598e7185ee59eff4c0fbd218a6c7fe288319831f6a3f509e08f0718b5",
+      "size": 7766
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043005.json",
+      "hash": "b19a7af392ecf3965bdd253dcf6a9b358d177975f75a60200a105aaf00587957",
+      "size": 6072
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043006.json",
+      "hash": "524be10b977ef454b9e1dfe92d6a9430f71aac47c7121f248e974defcfc8ec24",
+      "size": 8101
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043007.json",
+      "hash": "1de2cdaefce996604645b9bf2cf495f6b547b89e843cd1ed818aa9db3f81dac0",
+      "size": 8140
+    },
+    {
+      "path": "assets/story/data/04/1045/storytimeline_041045001.json",
+      "hash": "4460c22aa392c5f72af978cd447c2689fa14cd4f7ca57436e5caf7204ad18935",
+      "size": 7548
+    },
+    {
+      "path": "assets/story/data/04/1045/storytimeline_041045002.json",
+      "hash": "7cb36c107b26f032bb6e34d9b35966de8e349f89b6974cdb9b3aee99d4b6572f",
+      "size": 6548
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046001.json",
+      "hash": "104662f694819975da940edd3263b0a6621d961fbf12c295a7ef580fdcf80650",
+      "size": 9089
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046002.json",
+      "hash": "9cfa0223bc75c44f7e1b6864de09131bf41a99163adc6e0e26485aab46260b0b",
+      "size": 9889
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046003.json",
+      "hash": "81172ec12c692272041810fadcd4d50b179ed0692cce99bd912692dfa627fe5e",
+      "size": 11085
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046004.json",
+      "hash": "6f6f652a149b04a9085bd7078c254fbbf64bd9359d43dd9cf9e8f4a065ffbcd7",
+      "size": 11035
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046005.json",
+      "hash": "19293dbb1f0a10a1ef2c4a3896782b8f3b5dbed735330ce5d9e4dc397db48499",
+      "size": 6405
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046006.json",
+      "hash": "6488ffbd310c4fce1b64220343fc93f6c500029e9fbf73c4297c93e379fa9073",
+      "size": 9578
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046007.json",
+      "hash": "b67aa31bdde28a0c4c619061eecf43b02339fb2afe30fdd499ad8733a89bbe9c",
+      "size": 10279
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047001.json",
+      "hash": "376a150304a2f350b270d6700ee5f1945967df3f3cd92ff69366e1cdb7e5520e",
+      "size": 7043
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047002.json",
+      "hash": "92cc6abf5ebd4701df50fcfc8624dae8b40f9fcdd4c895f4af8921f79dfbd654",
+      "size": 8736
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047003.json",
+      "hash": "9a2e7b2a486d28c7862d796dd2fe502efa6483b70b68e5535e51ef82d6dbcddc",
+      "size": 10945
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047004.json",
+      "hash": "08e10c88d7b4ad3de1dcad7f173498ce2f2caab5b48f8b36bc0038e5517c7be6",
+      "size": 10267
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047005.json",
+      "hash": "1eba1eceb7300260c74afa3009552ed69ee17fd126914cd5d7902a0d27a8133e",
+      "size": 5414
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047006.json",
+      "hash": "8079009955aeb63ef87f84db1b878aebdf910bdf77025126522b8b72d62b922d",
+      "size": 8863
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047007.json",
+      "hash": "9e6c7688ae6ebd56bdfd6d74931127ce1cc5b8de3ad2f985391af63586036aab",
+      "size": 9632
+    },
+    {
+      "path": "assets/story/data/04/1052/storytimeline_041052001.json",
+      "hash": "089216a0166e8e549f680f00e2fc5d733507b8625b4ebcf265512fcc721dc5cb",
+      "size": 5988
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055001.json",
+      "hash": "f63aa8b7e51d79e72b606bd3a63a747cf63871355f13e30f21aaa7d6178a0762",
+      "size": 7371
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055002.json",
+      "hash": "60d10aae6bf07620750d5db6af91d607db0fc1d27869d9a2648a8ad5234b8c2a",
+      "size": 8486
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055003.json",
+      "hash": "659135c9c8c9824a849aa5e784a040fa9944c8362eb8720871d9e2484343bb2e",
+      "size": 10735
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055004.json",
+      "hash": "c8d366a2ab376d03a9552054d00c8774fbd72db26a6e1ba099dca182746ae582",
+      "size": 10469
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055005.json",
+      "hash": "14c317d7b2b1e5645c3e6120b6041590ba244e3fd39013479ce85d85602e89e8",
+      "size": 5579
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055006.json",
+      "hash": "afcbabeae4309936e4d2b003c4d23930eea12397d8e7a95fc8529d286b7499f8",
+      "size": 9520
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055007.json",
+      "hash": "18536b6567c92483c243c6ddc91b1ff4c59622bf1d24f3e7f897bede0048d273",
+      "size": 8657
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059001.json",
+      "hash": "2015e68b54f53b7326a68d6f95ce0bce0cbfed03b574bbb58288079ffb1fd611",
+      "size": 8826
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059002.json",
+      "hash": "c09c5edecf0b71ea7af1b0e76a96f9343b6648b4e95fee06e2eb99a48bf07b5c",
+      "size": 12525
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059003.json",
+      "hash": "515637c572259236fc29823b1a9844a4a8840cbf2683b4682f97a2deb30e2de3",
+      "size": 11150
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059004.json",
+      "hash": "8e277e0f82980539887eb84da9e3c1141161070ebd1753deac7b0d377d13884a",
+      "size": 11090
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059005.json",
+      "hash": "298712934372540621e56dac9a365d456bc26986435eb724d0654e40a5b8c639",
+      "size": 9361
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059006.json",
+      "hash": "021d8b86b987707c6f2667a3cbe6982e0fa50d6d4fddf672f9eb4adfec169b73",
+      "size": 14683
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059007.json",
+      "hash": "95ddfe1b436603b4d52c30daea91161204d9aaf5a89d0a00e99a491f9f79041f",
+      "size": 13547
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060001.json",
+      "hash": "d46d563c1635558f78d72fe779cfc440f85440f8db2778b8ce6b135711d00a32",
+      "size": 9254
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060002.json",
+      "hash": "29699ce0934331b3f10d0bb5e7413d9fef95ddcd51b0ab5c2e9e6061c75d74a3",
+      "size": 10017
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060003.json",
+      "hash": "bfbb1ecf4aa94f3f919d66499fc4da1f549e0393fc45bfae751fc3e021db757e",
+      "size": 8759
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060004.json",
+      "hash": "2f7cf503bddf43fba9af4f1fb4bc42d842052354f9a5422ac93eb303eb57426d",
+      "size": 9047
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060005.json",
+      "hash": "f9ebfde044b147653c720d491ca0cca1ef7a8b25eb2bd8fea2a9abe061b336ec",
+      "size": 6411
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060006.json",
+      "hash": "046875bc94153b4dcb334280e5529068145173011256f0452dd738ab39dcf283",
+      "size": 7676
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060007.json",
+      "hash": "2df19e3ab815d3dd1bf0eb8dbc2b82b437929b546000515d3c6c1bf77f8d1061",
+      "size": 9435
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061001.json",
+      "hash": "8a11e355f33ba4daeb7f3cc06584f36c1e60f9e836c3550be92b3c9e7ac9339e",
+      "size": 7752
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061002.json",
+      "hash": "57ee886eb5466a540e445c25276be404316b51fbf6727067cbf1fbead7aa4bfb",
+      "size": 8128
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061003.json",
+      "hash": "8dd8dfb026310161249c0df6f7df434ec7de42b7b8554a7ed7a708322e3080a1",
+      "size": 8870
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061004.json",
+      "hash": "0ec0b75cf8ae47b76f2fa2e3ba85635a77b95edd534cf6e0af2dc81d1f4847d4",
+      "size": 9321
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061005.json",
+      "hash": "21ad91587981616e1f2d4f5647d3dcf0e7c21deb7d438bfa18167fd7167a206b",
+      "size": 5492
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061006.json",
+      "hash": "940ebd1b9dc6bde2dfecfc98267aa32f4330a6977e7df54f407c253cd7832b62",
+      "size": 8531
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061007.json",
+      "hash": "533b130437f191692235b10e7fc8852bd5e64798c62277ee39377f96b7479144",
+      "size": 9275
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065001.json",
+      "hash": "955a804d491b714f60b872e4538cb6202cb3ed636b50c9759414d6d31e29ecf5",
+      "size": 8710
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065002.json",
+      "hash": "e28550bee6d5ea202e2898b72a6d7e50bded3a7940be5c96d614d08cee0982b6",
+      "size": 10308
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065003.json",
+      "hash": "7487957d63c77112e17cbff2eb0719525e74f0a27853daf16d3bda8e47abe5a7",
+      "size": 10630
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065004.json",
+      "hash": "5ebc119dcd12b90c7791de9c79df2e8c4c451f2b66dd0f4e5b3558da9f29c5e8",
+      "size": 12274
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065005.json",
+      "hash": "a300bc16b1e98a68b63e571773e6cf3df1457d976f17e129af2e22bd6be768b2",
+      "size": 6159
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065006.json",
+      "hash": "426e227766e620502073cb8e30c0e22ce52d23eeab204896c5333a7bbe9b8892",
+      "size": 8395
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065007.json",
+      "hash": "d4a701f32ebb44abdecc8a2d916ff636bba91ad902e1994c46e5a17e368bf740",
+      "size": 9450
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066001.json",
+      "hash": "282e43726ef937aa4d4e5c43b9e643e24ed5cfe850c3a760eadbd8508d92570a",
+      "size": 8877
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066002.json",
+      "hash": "ebe9d2da8b88703876208bde64b874d5bd8011509a7e4f1b9d91ab3051d2f6c5",
+      "size": 5899
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066003.json",
+      "hash": "d5650f034a32b7ca9e527b1b8fcf23d2958c1ace01a7719a53cb4e7eb00e0646",
+      "size": 8491
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066004.json",
+      "hash": "d9192f2961801bb66e0cfc2095c37eaa3898a9d3fd645339567b81bd728dbdb2",
+      "size": 8605
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066005.json",
+      "hash": "16f4fc350ed4bce147389a1b81f4912d075257b0b6aca38ef5f9a5cfb3674ebe",
+      "size": 4983
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066006.json",
+      "hash": "3d33e77a9ca3654c8fed65d7c895ce9dfcd6c5b2c08478b23af61dfe8571bcc0",
+      "size": 8085
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066007.json",
+      "hash": "8e66aa4351a65d1cb89c3bca1b251f02a9022eb7fa9c4bffceaeeff10a18923d",
+      "size": 8454
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068001.json",
+      "hash": "fd4e6a2808520dc57e45480e2077b77b49371ab62d3a4cf4b538d1abcbb096a2",
+      "size": 10021
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068002.json",
+      "hash": "dea50163f844072a2d6a91eeb1c8855379b9c2735c2f401e020958cfe05823f6",
+      "size": 9929
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068003.json",
+      "hash": "3171026792f4c0a7a24fbc546bc60005a5f491d3c363e856a5fbae1b0306677e",
+      "size": 7390
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068004.json",
+      "hash": "887d5a4af2d18363b299b6250484bcff629ec57603326d17a1cb87af93a73c24",
+      "size": 10354
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068005.json",
+      "hash": "2b2bb01ba98ef8f7270793972186adae46f06998012bb2f31e366d5e8aba5b7a",
+      "size": 5988
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068006.json",
+      "hash": "cea96e11415428bb8735c3859a5ebf8898dc9cec188a7ea2ff5f47377d3296a0",
+      "size": 7981
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068007.json",
+      "hash": "53982ec86789c3658e4c6d7877400f9c498478a8aaa1e45a9b25901d3e378e1e",
+      "size": 9115
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069001.json",
+      "hash": "801c8f2297cbd1762cd82dccf8fc8877095260020a0e322ce7d2452b81951b6f",
+      "size": 8466
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069002.json",
+      "hash": "73040957d2d645abd053debe0301a94a6cdb418b147b81ab54da57fcf26bcdc2",
+      "size": 7935
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069003.json",
+      "hash": "3d18fc10cc0fb682c6fce155cae79f2cc5820c91a737d069f95fca7a9afda14e",
+      "size": 8013
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069004.json",
+      "hash": "de2080048e3bd066b40aff05199d501fc91d631c538f816eec42c7a61573b316",
+      "size": 9007
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069005.json",
+      "hash": "a648eb873a321ecc159543dc642456a2fa9210cca2353836388e28284897b0d3",
+      "size": 6341
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069006.json",
+      "hash": "20365a25edcc991fb7aae1e6e6c0a60e7ec73122e9c1e38957f509b98d8ba3de",
+      "size": 7000
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069007.json",
+      "hash": "74cb000e98369576d4ff3cd7420b6824dfc8eb7c816fade42a8587be1f3cc7eb",
+      "size": 10349
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071001.json",
+      "hash": "eb16a9cc4043b436688fadaed377ce1f939ee9a53768b2f88216f06da287ac84",
+      "size": 7753
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071002.json",
+      "hash": "d35077e5ba6ec675e2caf81ba1ac0927aab009b1843c7a804625759708f1cbf9",
+      "size": 7739
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071003.json",
+      "hash": "4d45a33631cac784d4bd7d7b7fc27914334b36a2f0de419d6c3d1c5edd5e4395",
+      "size": 9726
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071004.json",
+      "hash": "92e7b8d0b2b05e0f31018fc6912025971cabd53867aa6a16024f1446ff5cc494",
+      "size": 9730
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071005.json",
+      "hash": "6e198c3115b05063013fee4eb438b48a0db45eb47c79ff007481bf03bc675433",
+      "size": 7895
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071006.json",
+      "hash": "97faf379e29ffb4bab696b54c4222a647c100dc6decce5ee1c4330a0deff5cad",
+      "size": 9679
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071007.json",
+      "hash": "3a8fe425928995c75443a96ad014adcb0cc87f47edaa757caccbaff948d28f0d",
+      "size": 9234
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072001.json",
+      "hash": "d139b37bd556f02d2c09e4b1df8eac6a2e184b61c3f26566d8aa67fa913fe44d",
+      "size": 10280
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072002.json",
+      "hash": "edbac4c4db8ba375c3a556e15ab15628632e53496c4aa1031960197ecebc575a",
+      "size": 9893
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072003.json",
+      "hash": "d4c6fdad77ff44de35447bb3c97603b65645f8c8aa5a8ea16202e79b758d024a",
+      "size": 9974
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072004.json",
+      "hash": "775565395f0fc59bcb5ab251bbcfb24df8602e88ea26a1209dc12e062f05c63b",
+      "size": 9038
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072005.json",
+      "hash": "eebd61aa760003106b231bf612cc559d26333ec5e9813ffafe9490e1b3c07deb",
+      "size": 5857
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072006.json",
+      "hash": "cea119b811079d39c66c0a9d0dca96bb4da74f9aab49b56466ce41b66372e01a",
+      "size": 8457
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072007.json",
+      "hash": "dd47407976bcc21ff2f452a244e970e1bdee135b129f19a7dfd781ec5375ae29",
+      "size": 10043
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077001.json",
+      "hash": "ba3c7fea85994db17c365e5b3ea752a9b1690d30d4b1b0531d605087e2686929",
+      "size": 10164
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077002.json",
+      "hash": "4f74a12057bf53731c4323cf2ed86912a5514a2d5586ce1d501d2ed3284d17de",
+      "size": 6745
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077003.json",
+      "hash": "f23cc6a09ac17e3757f1bb6a503379110ee338272d733fb3fa00396effa48897",
+      "size": 7686
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077004.json",
+      "hash": "a15357217cb6b40cd9ed6e9b67487cb162905125f8693e704d9b01bfce3be2ad",
+      "size": 9876
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077005.json",
+      "hash": "bfc9363f1cca1149989d15cfacf729419be38c04797f15a9aa20d013181344fe",
+      "size": 6256
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077006.json",
+      "hash": "a6d39602097425526ed35dc0f75a5849acf254ddc1c6ad08ae9584534e872ed6",
+      "size": 11354
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077007.json",
+      "hash": "ba9ec5146f6d9b378bcdee85a88741790c2e9c7f0d427ea4494b406e5fac27b6",
+      "size": 8535
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078001.json",
+      "hash": "c11ec6f7da74c7f0a9c9db2775b054622861377c37757e88609698e3e55d7ec2",
+      "size": 7586
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078002.json",
+      "hash": "cc1dbaee0fc3b5b8ca26736de08830d694d0c81d26c49eda8348aa335ed19429",
+      "size": 7742
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078003.json",
+      "hash": "07bd93bd91c80e2d1312fc1d84ef6aa4449dfb7cc13781e1316e1cc1dd1b62d6",
+      "size": 10678
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078004.json",
+      "hash": "7addb0b3341042b60b9ff62c783578a4ea46e1508d58bf0ce1dd891bb92840bf",
+      "size": 8632
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078005.json",
+      "hash": "eac6de10b99d24d2f28b796a9a33b282681fcb1f4ffe353837cef1ed6f4220ef",
+      "size": 6288
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078006.json",
+      "hash": "fdf509fdd38ea8d080d58091bee9853b6905f6dcba8c2f1bcf054c0ee0482b93",
+      "size": 7474
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078007.json",
+      "hash": "b5cafa32e62e0c727352e9dd580c8cde9f709e93efee479dae09e3d03eaf5ab7",
+      "size": 9335
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083001.json",
+      "hash": "c8508a62e40eb83ec93a38487a6ae980d4b01cfa57a37abca9ddbfb0d2102019",
+      "size": 8312
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083002.json",
+      "hash": "ffaad7b0dd0ab123b34ecca3a873cbc381641c00583077fbf4aae0540dd906ab",
+      "size": 7950
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083003.json",
+      "hash": "1bb35fa8319b1cd358f04bb52b6e020b51c703cbb238a6a3514a39dff62a2126",
+      "size": 10353
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083004.json",
+      "hash": "7d9302de23f98ea0bf4eb45decd2ccdcca8d50a5b671ce9dcb1c3d920b01b9cf",
+      "size": 7794
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083005.json",
+      "hash": "06b41822111bee86ca986389e5538005754fc8bac11b77dcbf780c7d39fe2346",
+      "size": 5471
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083006.json",
+      "hash": "7167e0237913b4fd64379f39f877ab1304a623250631d2995a040c1f46fe9197",
+      "size": 8190
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083007.json",
+      "hash": "dcdc8e9fc37cc0a9ab9b552c1ffce9f77688f3278162c3cf22f55a93be44cdd3",
+      "size": 9204
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085001.json",
+      "hash": "8326a6aca604a674e6ce22b70767707132248d3acc41dd9d338c916f41e46592",
+      "size": 8687
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085002.json",
+      "hash": "f2d8ef67c44c77e820dc567f70495ec079f1619c7e86438cfe0d3b537fcc5d43",
+      "size": 8818
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085003.json",
+      "hash": "559c7b13223143f41a4fc180fd6125cb152f5a616822c81b941cea9bd8888a11",
+      "size": 7591
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085004.json",
+      "hash": "afbd23f37f2273a44d81fbff5eb3f354bd12238b41a82afc75142021c82e3e12",
+      "size": 6816
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085005.json",
+      "hash": "003f38d210cce3711e0803b65dc3ac32185aa238985467f1a8c63499e50d6451",
+      "size": 5988
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085006.json",
+      "hash": "e4f7f37b099f2fb5ef68a2918d99d07eb5142c5a4c728a7c75fc0989d3e68070",
+      "size": 7416
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085007.json",
+      "hash": "1e5a4dbde5716628cf9ea34b1ed78e04dabcf6ff6be6b4ba5d5847eb53933d4b",
+      "size": 6205
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086001.json",
+      "hash": "400c72b2f644147bc46f36d03aabed59bedc07f5fc90cb5bf1658cc44f20332a",
+      "size": 8424
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086002.json",
+      "hash": "931c53e4587a2dd093f5d91b78623080b411e4dc19eccad18a53b94222db58cd",
+      "size": 9663
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086003.json",
+      "hash": "3cc4c5ebb8f47551fc18a3d26787757a4b196a7dd4c7f7a6229926624b90d662",
+      "size": 8482
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086004.json",
+      "hash": "ae054b19019e6445070a773c5f2bd02b99c797aab740927c75a44d4a075f3c09",
+      "size": 10234
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086005.json",
+      "hash": "9f860634b076d124ab482dcebedbcbecd760d009d2741ddfa666ac2c848e3d88",
+      "size": 6108
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086006.json",
+      "hash": "6d867d059010fdb03a258aef1a043ce03e699fe8bf2dbc471d0adfcee04a1f16",
+      "size": 8300
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086007.json",
+      "hash": "df78f167b8fcc6a549d4e7ea8aa0a35f8ecffd7c033707091538c9d4f8a3bb66",
+      "size": 10135
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088001.json",
+      "hash": "2c6058d29485ecbd5ccc9b9052158066a62ff0781ee290e74fe0d41794f7ad23",
+      "size": 11100
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088002.json",
+      "hash": "47004d83b62fd83f1ed45bc199c1b2642cd2eb30d55fe754c2a0d24194fed7fd",
+      "size": 7538
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088003.json",
+      "hash": "f956f4ac46c25013c8cb35756027350009828142d5aab0f4b55be0b3e2ead553",
+      "size": 9827
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088004.json",
+      "hash": "446f57296c37ca21abcdefd0c4563c2501977e6f99c6ad98d9383a4477c479ca",
+      "size": 8695
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088007.json",
+      "hash": "10ec5a638b725f5bc4acf536bd8805e92c10c258692107bbecd5f863de9919fa",
+      "size": 9928
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091001.json",
+      "hash": "b74f0e93e8d30abd9939644bfc632ed56c48998f4fb3e44de6c74417bac4c076",
+      "size": 10051
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091002.json",
+      "hash": "6c7624004f2ab55763c538de942104b2ee7a074085b16e5f77c162c0b3754249",
+      "size": 9322
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091003.json",
+      "hash": "e85faf38985de138c36b8f9f93a80d6e632f50c21437c6024554604dd794e89e",
+      "size": 10665
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091004.json",
+      "hash": "3f8fa7497627f4d76a9435a06984a6921969c1b9c13bb0b8f8ca9bc9bbd8475c",
+      "size": 9678
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091005.json",
+      "hash": "ad6b2a469aa8676b1681714ff72bf37eac3206982ac9101be0412bc50dc10218",
+      "size": 5677
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091006.json",
+      "hash": "79cbd823b367e70d4f4edec0127a36507e754a30801bf0fcc4e7dbb10e753f91",
+      "size": 9564
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091007.json",
+      "hash": "c166d86d5e8cc8c6c8f5844e6f84411c714faf2abe0c1ac5216e78ecc91bc933",
+      "size": 9974
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098001.json",
+      "hash": "9337a4e31925c59c1bd02d4d5ff3cdf8167a8786c4d6125ebfe43dd1d9741a83",
+      "size": 8853
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098002.json",
+      "hash": "2f71345a03394976f80105b9767b3be5530297128c8fa92ce5f7982c6336f627",
+      "size": 9883
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098003.json",
+      "hash": "ae4077a86724624a44aa8eea9c8c60ada8fb2bbaa261550b84348e2ac148b74a",
+      "size": 11470
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098004.json",
+      "hash": "850cfd21bf552e4135ba7ea7a32cb8d86be2be21c74b520c5047960ebdde615a",
+      "size": 8464
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098005.json",
+      "hash": "0b25f3f9cd80394422762445c5178f3665038b67c4909e201d37aeb716eb5a55",
+      "size": 6668
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098006.json",
+      "hash": "f9b16fbe243dd367e9ddccbd2d9db19d1f89691aaddd9c8932a37f99f9741045",
+      "size": 10027
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098007.json",
+      "hash": "db44cd9e96781a96fd36ffb5ed84663bcd4d116986601ec44a454574765fbbfa",
+      "size": 10210
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099001.json",
+      "hash": "bf2652a4e5121e7714776f784f51980dbb5750528112e4d63fd7b0376af37928",
+      "size": 8345
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099002.json",
+      "hash": "ad319347402f8eac535f0d7a24e7cfa10ac12b07dc135a7510efd170fb03d008",
+      "size": 6843
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099003.json",
+      "hash": "bb58dfc8ae0d3f97ed7c4b2771de8392114f04bbca7a182439d25629302a3fc8",
+      "size": 10353
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099004.json",
+      "hash": "a403226b01e3556f2a31fe6d8395579b767f0018264d293b01d62350e43f2620",
+      "size": 6382
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099005.json",
+      "hash": "e4ed31ac8c1b3c4349fbb436431d92e6708377852e647268db20a9f4a083886a",
+      "size": 6395
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099006.json",
+      "hash": "0b9b9b8c0d1d6920b101372e765e230f6d9db4f388da595db9bbf96f7b45febc",
+      "size": 11115
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099007.json",
+      "hash": "8f4155c4c618b0c912c9e4ad69acc2a298ef11b571bdbc193d3eaa681283160e",
+      "size": 10311
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104001.json",
+      "hash": "1226244fc32541cbc4c2edede6ac9e7e5378f99ad8240758fb35b5269d126af3",
+      "size": 8747
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104002.json",
+      "hash": "1a8a6c9bfa378b767403f3dcf2bda8768826e97c90be600989d958e3137fc6c7",
+      "size": 8579
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104003.json",
+      "hash": "1b50eb5c362b2f01c1af61dcb9f771d87136d3d877c7785001b17051b7ce7573",
+      "size": 7766
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104004.json",
+      "hash": "70df52b985510a2a6580b3cfec433b709182f4e13bd7fab570db59b995779d65",
+      "size": 9036
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104005.json",
+      "hash": "7cd4e3008c1fbfa2badfef0f9aeb8e3e29f1bb6797819c3c0a26f8452440e963",
+      "size": 7477
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104006.json",
+      "hash": "8b732fce6d6998e6193818fcccea1fc3e4df11d0d0c316b493e92b27e88341cd",
+      "size": 10423
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104007.json",
+      "hash": "933d0691633b8840f0e0f6616a497e7a14b17408e7a530a0c511f13437581df6",
+      "size": 9859
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105001.json",
+      "hash": "cf8f0550cd786a4618568d8af547e1903463878299ed875b7ed2748a36b07bb1",
+      "size": 6036
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105002.json",
+      "hash": "85e5951782616c34b3807a0d9b7e7567274b677e7898221ebbfa0a0ad17617df",
+      "size": 8473
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105003.json",
+      "hash": "e9fabfa9a0369aa161f59e5b6c9daee871b75c8ca67dcf7b51ad06327d7f906e",
+      "size": 10084
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105004.json",
+      "hash": "b34b2906959f39adfd40384b361a4e15f9fccea05854d649c71f59aeacf01c35",
+      "size": 9101
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105005.json",
+      "hash": "497464d2a6d6ff9ec92f13456209c50fedb9047eda5d764c73d55f6506f36715",
+      "size": 4708
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105006.json",
+      "hash": "316f3eeb3430b43d87ea7a8f179400f5e785b8c92f1aa8f72cae19b4b00cd190",
+      "size": 9148
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105007.json",
+      "hash": "46577f49410361517bb3fc2c8a096f8e4a746cd6186debb232663bb03afd1288",
+      "size": 8688
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106001.json",
+      "hash": "611e97febf203e9112b778835ce11e3bda09e4cd01a365fae54daa8b7c73dfeb",
+      "size": 7632
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106002.json",
+      "hash": "1db96753cfaf4f0e5f0e30a28bd167189b81698e9a7cb9ea3c15fc1ec56d9932",
+      "size": 8965
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106003.json",
+      "hash": "54df4f2e13a5318cc4eb311945202f668613297fabb5fa3fb2e77a979791fdc9",
+      "size": 11018
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106004.json",
+      "hash": "cc79925265ac46f9521cac5ee8300fcfb7be488fd110a11823faf3e611ee25af",
+      "size": 9167
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106005.json",
+      "hash": "9e2c29b47e21cdcaafbb13552eb3b77e952bbbcac56a7b44e7dad529ef46304e",
+      "size": 6350
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106006.json",
+      "hash": "f33a3d7c826d2dabbd6aff8c110b97ce18599af617d05fe14c6d84ee38c7de50",
+      "size": 10490
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106007.json",
+      "hash": "000d93413d0836771846883a688b5f5d93568f3c3de64d9e4278aa67ae115ce2",
+      "size": 10840
+    },
+    {
+      "path": "assets/story/data/08/0000/storytimeline_080000001.json",
+      "hash": "af7c597149ec796f5ddf0aaed1cef4b164e9fd8575e7611a0c227ceffb036530",
+      "size": 3537
+    },
+    {
+      "path": "assets/story/data/08/0000/storytimeline_080000002.json",
+      "hash": "40343b5f5ff14d9859931c684e3b2522c91cf5e9c98134dfe40a3e11bcdca179",
+      "size": 1952
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002001.json",
+      "hash": "3f8c48d40b834582a59e914667352fa83c1c3128de6f38b4b56e11dd1d2e3ef2",
+      "size": 9911
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002002.json",
+      "hash": "810820df0e78295d781e336a68d5c08eb40976ebcc0ae2ada0a479c5cd4d2885",
+      "size": 7079
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002003.json",
+      "hash": "c6fb9f08490db494a6e6c2e3802a713159b8fd23d1b38dd9de7f9fd425f3fb79",
+      "size": 6418
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002004.json",
+      "hash": "e55731f960b4d8bf327bfa93a7f3d11bd8a67a0ecc96e13d57833501edd91349",
+      "size": 6926
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002005.json",
+      "hash": "e12ddecada6bd0f79e600ac626c17716a220874884ba8533fd4ee2e61950a671",
+      "size": 6798
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002006.json",
+      "hash": "f98e633e77e61461cde0f89c53c68e8d160b0e6661090dbd2fefaeea0d0cacef",
+      "size": 5389
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002007.json",
+      "hash": "a77e8f7069ed57ea6b02048fd0f75d367bff9eacb4272c0da5cff91cb806a859",
+      "size": 7592
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002008.json",
+      "hash": "d3e133b197b8a2bb2ad2d65725e6210ba96b4e768374a30d38471faf1ddac6c6",
+      "size": 6487
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006001.json",
+      "hash": "4e8a3a5a32abde44e235916e9030c281b9550cb536539f96efc94f4ac1557c88",
+      "size": 7577
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006002.json",
+      "hash": "fb03ae3c3c7eb6d1d2eae44393ec893337ecd16d6c5a44b9349f8a5502cd6dd5",
+      "size": 6237
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006003.json",
+      "hash": "438117a9b96e3adff7e32fa0590d451c2a2c05d0bc51045fb3621ade2fed5345",
+      "size": 10541
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006004.json",
+      "hash": "beb1f3c0c32a75cd85f04cec967a40e5f384c116ce12fe2a54760da10e7d8309",
+      "size": 6401
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006005.json",
+      "hash": "33515ad3eee7a576fc5d251a54abb7468852590819ed17e8e0b25b4dbd0cbb77",
+      "size": 7935
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006006.json",
+      "hash": "4d42472da498322a3d6812477dd16b13291407f06187c39c09442ac2e2be0b5d",
+      "size": 6436
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006007.json",
+      "hash": "6752532d7081b7566845b3abb8b97e394c2129ffd55ea6e6d79977bf349266f6",
+      "size": 5655
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006008.json",
+      "hash": "e82c20f2038d67c07c71919ea23d4af4605cc4de67fa50278b5aeae1e1072b63",
+      "size": 10674
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008001.json",
+      "hash": "9edd490cbe1e31011208d4ae39719f1ef5f63bc93669462bdbca25ce10b548b1",
+      "size": 9255
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008002.json",
+      "hash": "3d64a4c804ca45006838441a48d4735e8d1aa257a1548abe88a61aff9d991bc3",
+      "size": 8714
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008003.json",
+      "hash": "788338a2e156dfa31a11e21a74241ce2abbd3c3735401e9cbbccab81f9a3fb25",
+      "size": 7217
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008004.json",
+      "hash": "ef887cd703d0591a38df6ce4bd28f8fb31a7dfd4926f961dc2bf38e6d088a9d9",
+      "size": 7566
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008005.json",
+      "hash": "7dfc5d10605921ac7e81d166d33996ed9a9833e341163dc2a120a059fab064d5",
+      "size": 8360
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008006.json",
+      "hash": "ac2b04ca732fcbd90692f584642d487781fa1608342931d6cd2a21fbf2a02c85",
+      "size": 10556
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008007.json",
+      "hash": "60bd5d2966bcadc6ef1f5e50e987c040449de596756cb24a7749ebcbb054ff9a",
+      "size": 7501
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008008.json",
+      "hash": "d41256225c29611383fa9e12b1eb7b98e2209bb928b50f28d18dda13920420a1",
+      "size": 7124
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010001.json",
+      "hash": "03de37712824ff8a9e278d55c17d48e50a716ec1d5a6f8352c89764d9818cd03",
+      "size": 10088
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010002.json",
+      "hash": "4c66f2f5127cb38926b4d75667feb7ad94b797eec018368fcf56cf02b4f6c930",
+      "size": 9577
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010003.json",
+      "hash": "aad0b06a6b5eba88ef32d42e03102e4573040194e02607fc488048c2d4ff60b3",
+      "size": 8817
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010004.json",
+      "hash": "1bf7d6a673de8e4d423aa3c5403e6cb8ba07d2a27c39290505cf77a709771f28",
+      "size": 8822
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010005.json",
+      "hash": "d2d178fb700cce540ad808a5a15f24756b72c3ec8966eb880649a09a7d4ce5f7",
+      "size": 6717
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010006.json",
+      "hash": "56f777b76af01955c0c46efa2ba1116cbd9a82fdeecb96d301530e557e534460",
+      "size": 5309
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010007.json",
+      "hash": "f98bd7f1e1646994c76dbac9e69e5514810ec15e31e40d90b246939bf2e12a7b",
+      "size": 7134
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010008.json",
+      "hash": "745fb81bbc539fd3ff734ac5f566c2351bde8327e2f2f4585e277cca61ebc0d8",
+      "size": 7537
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011001.json",
+      "hash": "5e0f95d81dfc0461033ca6da70cbb117c26aa4d8314fa053aaac2fbf7eb1a2fd",
+      "size": 6901
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011002.json",
+      "hash": "f6a4805f08e3ad7231900bfc42a855b53c5e312bb7108e5c6d5aa35c42f3f787",
+      "size": 7860
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011003.json",
+      "hash": "4e502551a9488c36925db1d6b9ffe7bb2f4cc54b82a9b88cdd9fc7d96e4be06f",
+      "size": 10453
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011004.json",
+      "hash": "aab44bfd7db9359a9010a50ee434bb7eb043c364aaa8d3be2e9a5f13579400c2",
+      "size": 5631
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011005.json",
+      "hash": "55e9cfc5cd14af35cbc67c86f988d639ff81045403f5a222a572575877533c3d",
+      "size": 9017
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011006.json",
+      "hash": "c7236b46323f8772b471f058632b20998d91a6fcdcf66c1e69ef1c4e04858cde",
+      "size": 7203
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011007.json",
+      "hash": "194c0fce89c4f8d7cda293e31313ab84a5906be49604bee71bf6108752c2bf36",
+      "size": 6007
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011008.json",
+      "hash": "52c70c39f90ca5e117dac7993f0bf356dd3178ffeb7b0fce1558136f612909af",
+      "size": 6045
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011009.json",
+      "hash": "2ca865a921ffe039b79c88b2e3b0a465fa6b86a2928ce32167ef26275a74321e",
+      "size": 8890
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011010.json",
+      "hash": "acdf57b2b60702fae447861db06ec0595e34b10df69c0be03a97675be6a8c234",
+      "size": 10734
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012001.json",
+      "hash": "ac2e9c1c2cd80b4f68d231f0ea9922cba31bce2377f59b63eecad690dd67988e",
+      "size": 8620
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012002.json",
+      "hash": "ca181d46b4dde2a836f2df3a4d55a278601eb80ad91128af75383bfee345e93e",
+      "size": 8514
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012003.json",
+      "hash": "60b955ce7c2836b3160161f56ce26696111b563c9cd2cf8e414e3c5bb56abddf",
+      "size": 7690
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012004.json",
+      "hash": "9b0c1b49dd3ae1d456193f2c639b88b7b4c309111b558eea093e7930afa79322",
+      "size": 8971
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012005.json",
+      "hash": "4efff286434855234f1c86de30e23ba6f47e860b4575fcec1ae30592d6d81a94",
+      "size": 9273
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012006.json",
+      "hash": "dd5bc5de42e5390f5f6c41fa0e5ae1b479ba9fa17ab0c7a5201dd3c530c9cad0",
+      "size": 7668
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012007.json",
+      "hash": "7c39c8f77f107e08894b8c98a690ca0c969023ca001fc66bdd1940c475ca45a4",
+      "size": 9502
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012008.json",
+      "hash": "3dcebb6c3b4eafcfc4681ebc79aa28d0ddc036b22825083d87a5a0406f97631d",
+      "size": 6298
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013001.json",
+      "hash": "c6134c7e5b96710da684d2b8cd96ee0fa15183b8d11ef97ab360121bf806fdbc",
+      "size": 6862
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013002.json",
+      "hash": "d79385e47a1d8df9a7474c27fe93f716fb9aa9fb08db1fcd53460d1bf8fda286",
+      "size": 10163
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013003.json",
+      "hash": "aafcae0dcadda28a4ec800dd65e9075212369c673ef64b33901da37fa8939a3b",
+      "size": 11917
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013004.json",
+      "hash": "d89373aae8dcd68fbc08a75a98e37299a5993a1073db5fa648f4ea0d12570a76",
+      "size": 10121
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013005.json",
+      "hash": "54c6d68609cdc9d27df715242620b4e247d63c361223fab0d07657b8a7f3faec",
+      "size": 8383
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013006.json",
+      "hash": "8c7192c5c9c17092ccff666658b84f211284fe34d89a891f23e44df8e363d78e",
+      "size": 7791
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013007.json",
+      "hash": "bbdec74783340ca46ff98d1abd94a6a2b957f4f0297bf523bff062491da406ea",
+      "size": 9862
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013008.json",
+      "hash": "52bb7e1c24ef4a3e52effdf4666283df543802b8d300b4afca711d91d9c7cf06",
+      "size": 4180
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015001.json",
+      "hash": "e3acc84c158241f2678d40b59507ec27094943c68198f3c6580aaf4fb06abd54",
+      "size": 7647
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015002.json",
+      "hash": "b7b5a7576bfb1bcf819f1bbd6a276a7cff0de938ace46ab3c989bbe010e66d88",
+      "size": 8335
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015003.json",
+      "hash": "b4254297a7c0a3927ee1fa07330b1fa0a62098fca5d939dcd18fcba97531732c",
+      "size": 7569
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015004.json",
+      "hash": "05f9c9ae25645628be44053ade96c932a39202f15fea1281c98702282f112456",
+      "size": 6410
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015005.json",
+      "hash": "b815827d3efe3ee7eb87a08906a9a56feebc940803d0a56038887039f76ba3ce",
+      "size": 7714
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015006.json",
+      "hash": "a26e0e7803a82146df44cc09cc74f6c897164c30d962c40d05aa5f4766ef1ff4",
+      "size": 9942
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015007.json",
+      "hash": "8e693f6b68ce5f85cb8f71670e38d54c1207cb50892a53ed208f283aca1dffb3",
+      "size": 9499
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015008.json",
+      "hash": "0c039f0f91359b2de2ea8eadc4a91a4eb53637b270e39c24499389d6406e73ee",
+      "size": 7700
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017001.json",
+      "hash": "9711b623dca3dd3e83bde0f5e0e512904cc1e7e6b93111ed29593fbb09112cba",
+      "size": 6627
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017002.json",
+      "hash": "99d1be99ab8cfa1c25ffbf1285543baa9e3f4f792cdff0a8d44ac2a2ed892855",
+      "size": 8386
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017003.json",
+      "hash": "742fc074738e167547284777df8513aabfc4be5474beb61cfc94d49eab32582b",
+      "size": 10371
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017004.json",
+      "hash": "7150b1297de23162196145622c20c3c119d1358819084711078e90bf8a6c8e37",
+      "size": 7974
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017005.json",
+      "hash": "9f4e5438e57331465b39b579f6e1d713025451c7587c16fb2661dc7a229e61fe",
+      "size": 8067
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017006.json",
+      "hash": "6d8a3efb18a91999c707ed46115ecce89d5ab84d80aeb39d6e3a6eefa162bd17",
+      "size": 8193
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017007.json",
+      "hash": "b0df182303f59f73660a886e025963f4d1fc6b44f5627c966731a115e071d6a9",
+      "size": 7883
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017008.json",
+      "hash": "170137b6b861cf01904137e43d8fcf6fc53cde4c835d81a16a35e4d85632eadc",
+      "size": 8429
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018001.json",
+      "hash": "d4094883cc4f371ced8d9dd2c77f9c30bf6f17ee5c6519ef604ad504574bf3cc",
+      "size": 7496
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018002.json",
+      "hash": "02de30ee018c87b27af17c6d580ac733d8e6f67eccd71ca7a6d2e6506e738565",
+      "size": 9179
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018003.json",
+      "hash": "421692dc02eef50f28d7874c010b225ac0b191031ccf28faf2c57354d8b77bf4",
+      "size": 7091
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018004.json",
+      "hash": "590c9893a5961ec30364866afaf1b22ccf510da45d79760b6c54416f5ddb17cb",
+      "size": 7329
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018005.json",
+      "hash": "32cb2db5cafe806c81fd14dce4f6ee46eb4d126607d1c5e9ea7123be7961cf32",
+      "size": 9328
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018006.json",
+      "hash": "bbaa4e935d2864a335c9cb3a0148910569fca5366e410a03137f5e85b82683c1",
+      "size": 9118
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018007.json",
+      "hash": "403dc7c7d5f202c7773a6740090d39f8953eb881ed8821d8f754e393f01a77f2",
+      "size": 7764
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018008.json",
+      "hash": "c45fb25d8175ae89ba4f08ccea763906d2284cef798b23910948d8a1ab8c2b0e",
+      "size": 6556
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020001.json",
+      "hash": "be8de8f0016e25f2a443a1285ebe97cdbf367023507e9da223c92de8c733bbc6",
+      "size": 7276
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020002.json",
+      "hash": "7f928a00f3f9c4875e64cc8a9fbfb4585743e2384ae4fe1166a55fcd3986ccb0",
+      "size": 7301
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020003.json",
+      "hash": "322e1c86dc56470e67d8d62b21cf99d663dd17b4a8cc35445a8bc78b3c5917c9",
+      "size": 7130
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020004.json",
+      "hash": "f322fb5c6122570ea7afe7ded8a4ed47eae959882f9bc3d40531af02139305bb",
+      "size": 7233
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020005.json",
+      "hash": "7367f27c1e3fdd77c4a653398c705d5c59ebc4e29ae06cefe686c07a3a01227e",
+      "size": 8200
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020006.json",
+      "hash": "8e16c0bd8a78a292c3f94251427d8add73f25a8d07b9c2ddac4a14fdde34a852",
+      "size": 7140
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020007.json",
+      "hash": "39ab3bd9c955c01dc3b384058a879da254cecafdf80e34cadc875cecec14da4e",
+      "size": 6308
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020008.json",
+      "hash": "6567f1bba3cab9bdab2e1995379cd9812f7d65bcf66d5ca6ca2c2d4bf5558ef5",
+      "size": 7243
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022001.json",
+      "hash": "b1bdacb6ad3ff76e0e90a04e6f7ceae46cd87ff47d8aae9500f4badd69ea3794",
+      "size": 8404
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022002.json",
+      "hash": "39744aafb5e3753c062232ebce8ec2fd653bdc602d5cc686bdfa4ee96f2a915e",
+      "size": 5765
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022003.json",
+      "hash": "6dab648f80fa545d462bdbe90e186211e53e9150353991ff5012b968fb9ab3c2",
+      "size": 8283
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022004.json",
+      "hash": "5c01fbb8a4817b45cdb28590fd4beb144d6a8bdbcc0e021e8ace1e2af7bf1b83",
+      "size": 4841
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022005.json",
+      "hash": "8dc224c9f76f9274bdfb19e3fbb12d2c107925d44fffa2bb91595622194c45b0",
+      "size": 7846
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022006.json",
+      "hash": "801d4b14e77c284d27e6da1850cdf426e7d9ab2698a19d289e41954f27d226e3",
+      "size": 8190
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022007.json",
+      "hash": "bc38afefcbb60f456d9ff5035c62ea439ba0ce7dbfcf5dae3201193301cbee5e",
+      "size": 8471
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022008.json",
+      "hash": "1c1d99cde9b755a6ccae903924a5196ac514c4521708c16e82a4b790329f9f32",
+      "size": 4655
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023001.json",
+      "hash": "a7466ad3e3537ddcbd4fb1e4cac66435774ff18161490245e5884b57de895b2a",
+      "size": 5554
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023002.json",
+      "hash": "fd1d270b5e02652b52f4384162478e1eb0e9000c7d5ba4524a42f51ba961d2eb",
+      "size": 7148
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023003.json",
+      "hash": "970c0ec146e599a9edd4404f6a9da87dac1fd36441ff7a580037dc5eccbb770b",
+      "size": 9141
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023004.json",
+      "hash": "83cfae0bc50469e5f399f8e7649143cf761aa984148e8d736f46743f0dc32a4a",
+      "size": 6955
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023005.json",
+      "hash": "79fe5e6413f7530228df58cb1831e937c5932ac5dfd20c24253753f82fce07ec",
+      "size": 8215
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023006.json",
+      "hash": "101a0c7c6c716fdde0c97905b2a511f9645a4a9e0053c2649243a8ba2dd359b8",
+      "size": 9359
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023007.json",
+      "hash": "852b375a886664303a284019323c01a883759e51cc8ed55cc3cfafd45d0570f7",
+      "size": 7397
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023008.json",
+      "hash": "28d757e140d6f524dbdac7fc88bfea0a167c64031f39a76bbebce9f4c6189efa",
+      "size": 8362
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023009.json",
+      "hash": "cb3f3200773317de62de30059b722d85956a59f83e9b3ab58530120cc9419d72",
+      "size": 9527
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023010.json",
+      "hash": "f40233ff0822fe46971a3aed4a7d331709a73e5c9310fd382c1db0b66604e68a",
+      "size": 7424
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029001.json",
+      "hash": "0a6867cca347a4e1abcd98e5806a15c4b385f034652791d1fc3fe41b0f2ccb6c",
+      "size": 8256
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029002.json",
+      "hash": "20af186b273daef57b4899e37ef90d701eabc46fb50d873b697dadee978558d8",
+      "size": 7348
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000001.json",
+      "hash": "44a6e9a7dcb5f8a820349d0a690788e78a54a934422d3effc134cfc8968cb8d8",
+      "size": 2037
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000002.json",
+      "hash": "e8caa7da411998d83524e995dd63ea8549a9d87845cd7c465ea3e3294555c071",
+      "size": 1563
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000004.json",
+      "hash": "320fba38169be526921a3f0c71eeaf46f8771e2c82841fd9901e457d4ff026b0",
+      "size": 1614
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000005.json",
+      "hash": "a09760c37c8796982f629c474fd12c5c2ba3acaaba80b2f403822fd89f2ac045",
+      "size": 1876
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000006.json",
+      "hash": "1359c4f9039c145bf8ef0141e9e9e22b3c576ac830a15d2b85be6f2b7db1fea1",
+      "size": 1771
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000007.json",
+      "hash": "b6ceac177d9966261108d00e2a8986d2145cb3ec588fdf606081d0d65e68c23d",
+      "size": 3377
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000008.json",
+      "hash": "fc487ef745a2185061c1fd1e1fe462379451e965febd6128f8523024f0a44a6b",
+      "size": 3213
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000010.json",
+      "hash": "b9a7f5b79f288fcb73bb56c5c6ff1efb7aaa99d13b35a6a5d6c96eec9ab5615e",
+      "size": 2724
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000011.json",
+      "hash": "c46c96b5318607c7c87b2e334c8688c3fc2266c23ad58925da7d13c748d5cf46",
+      "size": 2847
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000012.json",
+      "hash": "cc8796e603f42073bab636efb05730f4461560d4a5b41642ced46f1bfbadb802",
+      "size": 3801
+    },
+    {
+      "path": "assets/story/data/10/0001/storytimeline_100001001.json",
+      "hash": "e7f5be215911f4a313a421b3f8f7e9b3ecd0e0edfd1065d510ef913b193f750e",
+      "size": 7615
+    },
+    {
+      "path": "assets/story/data/10/0001/storytimeline_100001002.json",
+      "hash": "75595d24e4448495f770d62ffc12bec30adc8d52df2f43ac0c5e891837bef82a",
+      "size": 7917
+    },
+    {
+      "path": "assets/story/data/10/0001/storytimeline_100001003.json",
+      "hash": "667fee0ca1068546bfad4338954a0eb4f82d3771d5cfb8715fd51f9ad5e80f93",
+      "size": 7560
+    },
+    {
+      "path": "assets/story/data/10/0002/storytimeline_100002001.json",
+      "hash": "632f128e980f72bd0d62876b1164838f1c67b7f39e677ef481a2e304d1f93bb1",
+      "size": 8613
+    },
+    {
+      "path": "assets/story/data/10/0002/storytimeline_100002002.json",
+      "hash": "96a06eb44165149a3ba3384cba62dcfbdd5aa63286ba58368cf332e3e9bf02a4",
+      "size": 8162
+    },
+    {
+      "path": "assets/story/data/10/0002/storytimeline_100002003.json",
+      "hash": "bd70c2d509bf93dc2d540a8e7c34701be05ba0b718d59e337cc33e2715eaa781",
+      "size": 8502
+    },
+    {
+      "path": "assets/story/data/10/0003/storytimeline_100003001.json",
+      "hash": "c550312be39ffa1bfe4ab6d239bc8eb2d18b8836c646fe5f8728926720b1330d",
+      "size": 7744
+    },
+    {
+      "path": "assets/story/data/10/0003/storytimeline_100003002.json",
+      "hash": "7a776c3d4e98586d407d7414eaa127a99a72947805b5e6e11f016b510dd7290a",
+      "size": 8950
+    },
+    {
+      "path": "assets/story/data/10/0003/storytimeline_100003003.json",
+      "hash": "d24cda5feed80876ed2c86c98f9ae0c1cadfa0249172162897d939bf47153438",
+      "size": 7915
+    },
+    {
+      "path": "assets/story/data/10/0004/storytimeline_100004001.json",
+      "hash": "ad4ce8ad902f45d72bb6c5630020b040be83869b52f5a50cd98d4cf33de59536",
+      "size": 2504
+    },
+    {
+      "path": "assets/story/data/10/0004/storytimeline_100004002.json",
+      "hash": "6f8e7f56d19f89f3cf2b245ab8de6a1c78e7f3358fca1442b8454b48d207dbf0",
+      "size": 2261
+    },
+    {
+      "path": "assets/story/data/11/1004/storytimeline_111004001.json",
+      "hash": "d3c0312f7e5f270a57ae426ed5788bcae139af50596878871e13cf0767aa04f3",
+      "size": 258
+    },
+    {
+      "path": "assets/story/data/11/1004/storytimeline_111004002.json",
+      "hash": "50b96306ef88a4ca268fe5159b1984c4700463bcea0e39b9a9ac25c3d601fc0c",
+      "size": 240
+    },
+    {
+      "path": "assets/story/data/11/1011/storytimeline_111011001.json",
+      "hash": "0d1303ec8d5b5c391aac2c524478630b937aca6d72ec92b4364351b16d9b4162",
+      "size": 241
+    },
+    {
+      "path": "assets/story/data/11/1011/storytimeline_111011002.json",
+      "hash": "3e5349a90a33f86370a0c5359867f57676308c4cb858f57c0a82b7a3e35e3c32",
+      "size": 245
+    },
+    {
+      "path": "assets/story/data/11/1018/storytimeline_111018001.json",
+      "hash": "d03f10f06d8695e017c080deb22d9682fb1894ada5f2f53c9c6f77d59b4278a0",
+      "size": 231
+    },
+    {
+      "path": "assets/story/data/11/1018/storytimeline_111018002.json",
+      "hash": "1fb289076908e589ae0034c2402016dde55cd7b1020ec646d21abe45aa101c9b",
+      "size": 239
+    },
+    {
+      "path": "assets/story/data/11/1025/storytimeline_111025001.json",
+      "hash": "46206240cbb881eef22b9c50211aa95e4a2f171dd110f5694649d3279bfdb072",
+      "size": 276
+    },
+    {
+      "path": "assets/story/data/11/1026/storytimeline_111026001.json",
+      "hash": "3dd37d5c26855c3886c5cff72c3d8989ec7999922ee15c0fa7b39925d5e96c4e",
+      "size": 208
+    },
+    {
+      "path": "assets/story/data/11/1026/storytimeline_111026002.json",
+      "hash": "f6a2688fb40ea9347ccbc299114952f1acc095e68444ae773b54dd1add24ac27",
+      "size": 277
+    },
+    {
+      "path": "assets/story/data/11/1032/storytimeline_111032001.json",
+      "hash": "165ec1ace4a1d42a4c368cd60f2586bb2a4e9dcefc7ef1e76167d8c96fd99479",
+      "size": 237
+    },
+    {
+      "path": "assets/story/data/11/1034/storytimeline_111034001.json",
+      "hash": "abc33dadc77c6a1f94e9067311c88ea5ea9dfe96e1cc41d48cd2b849e48cab0e",
+      "size": 192
+    },
+    {
+      "path": "assets/story/data/11/1034/storytimeline_111034002.json",
+      "hash": "ee6bc12127a113c7ede32966fdae2f68dccbe209528aad0b5216b2b57a54a75a",
+      "size": 199
+    },
+    {
+      "path": "assets/story/data/11/1041/storytimeline_111041001.json",
+      "hash": "647ea5f141151b93f103fa7ce02955acb51b92a39ad750ed077d7f40b05b19c7",
+      "size": 294
+    },
+    {
+      "path": "assets/story/data/11/1060/storytimeline_111060001.json",
+      "hash": "c539919bc40f321c6ad14b60849dce0d4969b4e3ff688bad7a04d3a6b91c3263",
+      "size": 254
+    },
+    {
+      "path": "assets/story/data/11/1060/storytimeline_111060002.json",
+      "hash": "929321bcf89acaff8c67ed5d6d3d5bde03304dfcdb5ac8ee5e7e4e245279f368",
+      "size": 239
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251001.json",
+      "hash": "fcb1eabaeb3199073722891ffcd74468810182c4d09f55ce3e5969cb49e0c59d",
+      "size": 370
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251002.json",
+      "hash": "e98eb9c9238d6bed18c5aeb6f7e2c8edef1366486336e990e6ce6874e59d6087",
+      "size": 723
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251003.json",
+      "hash": "e89867a5ccaa3ac387b844d6c624bd2fb64b4da4a3be8b179ec61b222ba91062",
+      "size": 617
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251004.json",
+      "hash": "3e92c1f09b08fcbc9c254e0f7eca6ee4f5ca9aa9cc0ffd2ebb80c7f5f4fa79f2",
+      "size": 550
+    },
+    {
+      "path": "assets/story/data/13/0001/storytimeline_130001001.json",
+      "hash": "49e9a07a91c704382137d4c9fbfda384c16e83c6dc5dce49e587063a2c328a6e",
+      "size": 3970
+    },
+    {
+      "path": "assets/story/data/13/0001/storytimeline_130001002.json",
+      "hash": "5a3c59d30fad2577b1d0de17962d8f2f6299c2df4398f7425244d1e38270f542",
+      "size": 3081
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000001.json",
+      "hash": "042f6133afec52415c4f16e18f820d3da7ea14b2bf3fa0bb500a60a8b4001404",
+      "size": 2537
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000005.json",
+      "hash": "a958f819b15236b452c0a4daac1023e5adc40c003b98d729b0d57798fa0ac7f9",
+      "size": 453
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000008.json",
+      "hash": "48bb16ee229416625aa9ce870688b6fed221d8a3f5079af429f450368ff3b84c",
+      "size": 361
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000009.json",
+      "hash": "fd316d99ce50aecab29a437166e0fec657a2d49717a3764e176788084d243803",
+      "size": 404
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000010.json",
+      "hash": "3476b0ccdc39671f870f24250bda8d92c81acdb470a76287a64dcfeb564fce05",
+      "size": 407
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000011.json",
+      "hash": "db724e78a44b4c6eb98e9286852535e29f44d2d8eaf952c7d85e3ed0a7bc67bf",
+      "size": 435
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000012.json",
+      "hash": "f8f8fccde96cc0ee2789f318e39753364ee6b92bde04784a519d9d3fd29be25f",
+      "size": 424
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000031.json",
+      "hash": "214950ba23142289efed6733ca937157dee94f334542f495fe73ba3b21e5f94e",
+      "size": 579
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000032.json",
+      "hash": "ebd76663a8da23000602132a3d0896e1a3762cec727b84d759f86f9f3a0637b8",
+      "size": 485
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000033.json",
+      "hash": "8e167e67cc774692b103eabbf394a1f0fb7aa226c9cb830bd5f449b7bbee3a3a",
+      "size": 562
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000034.json",
+      "hash": "8671929109c0d1b373bd338f36e92f22f289c837829b790991f347b0758997f2",
+      "size": 898
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000035.json",
+      "hash": "c545149fef66c53234b4ef2ad918043926f7df22337b72ccbaee705c5d1c262b",
+      "size": 625
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000036.json",
+      "hash": "8b7fed87a2f80911a977aca29bd00e1f7aa1051dbbf0e33b9351444326de5ce0",
+      "size": 3617
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000037.json",
+      "hash": "4897f6e1489c4e060dd1a9062f8adfc41712008596b2a609936f66e8077ba52a",
+      "size": 235
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000038.json",
+      "hash": "1267c2049b2f78c6d7cd4107e75e5d139a184e4b6496de2a4139ccad5bcc6e4c",
+      "size": 210
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000039.json",
+      "hash": "987e6aae5057236e89418b0b00c534e61655b3a1cc8cf2192f3cff1d2f7dee7a",
+      "size": 257
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000040.json",
+      "hash": "d705052fb23103507a7961770c9bed1844acedbd1af2292fbe14ccc7fb0cfca0",
+      "size": 232
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000041.json",
+      "hash": "27b8293614a8e7ab6a91f7fe0070935775b5989b8219c6916a4f712362d65eb9",
+      "size": 3182
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000042.json",
+      "hash": "21d40477d5271905529cbf2ce0d436913026b2bb670adaf6b297e1328df085f2",
+      "size": 312
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000043.json",
+      "hash": "d36ca49ca15228a2ade4a1fe4c50aa7d6b2e2f8ee5eaa1635ceddd384c3ac817",
+      "size": 931
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000044.json",
+      "hash": "f1d30836b6440846c2d0b92f5ae593b09db051a3919269474a5110f2f5e49fb8",
+      "size": 896
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000045.json",
+      "hash": "e26346a9981942e35af69209a23b31c017c6e00cb51a1078e87f9ee1487964b2",
+      "size": 1085
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000090.json",
+      "hash": "13d7e927bb5050f4bbddc23db6e9dcfeebe5ac4a00fb150861e97957b4ac6eff",
+      "size": 314
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000091.json",
+      "hash": "2d921699a382f40a5ce42ed2d4adc37236dee5f2868bc2b34f14ee0b0da54dbb",
+      "size": 8522
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000100.json",
+      "hash": "dedc55b35659fa402157d4fca931aff67af6ccb4958697faab5e1a03a742c016",
+      "size": 3150
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000101.json",
+      "hash": "e3c7e26169c95cde977f8dd01b8028e3dfbdcea801ce8665182ca36bdf273103",
+      "size": 852
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000102.json",
+      "hash": "f7f9aca7f660594b31520886f1b2af7827b546c903652fa7d0c85490244efd74",
+      "size": 606
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000103.json",
+      "hash": "9d6ffbb863b674038bd753940ff06b4680522a9089c55663157571dcd0a70660",
+      "size": 824
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000104.json",
+      "hash": "2e12bad7de63aab892585f65a79a80c388434b47523a178868b4ef3ed0aaa68e",
       "size": 762
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_btn_trainingmenu00.json",
-      "hash": "d3236437b05de4915d58b51a3ed8d781d31b7ae5a1ce15d9db8f9f847bf6fffc",
-      "size": 166
+      "path": "assets/story/data/40/0000/storytimeline_400000105.json",
+      "hash": "5db6faaf33b2938ba2fbda2db3bd9b262d54110128682d13baa1d0a6f5c7e82c",
+      "size": 758
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_buff_get00.json",
-      "hash": "0028461d61d17303720fc81192a02dbbddf92f58a4ea204a12e70965bc98cf7d",
-      "size": 166
+      "path": "assets/story/data/40/0000/storytimeline_400000106.json",
+      "hash": "a0c0e55983fe8a4adb7c1ab057ef2a304cd251ae052bbf930628d3a2b957f4fe",
+      "size": 779
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_enter_masterly00.json",
-      "hash": "6ef6ef2056eb13bf901feb83ccdd01fd8bf17aa36436a1ebea8f240056a852dd",
-      "size": 166
+      "path": "assets/story/data/40/0000/storytimeline_400000107.json",
+      "hash": "07bd929aea13212df63aba649b9e6c9d8b3b005f66024bf3b7bc85327b5c26c7",
+      "size": 1030
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_enter_masterly01.json",
-      "hash": "63fe4bb4f0336be9a26d79b1505e294fe61c274ba74d006b64070d078fa69e7c",
-      "size": 166
+      "path": "assets/story/data/40/0000/storytimeline_400000108.json",
+      "hash": "d98bde679d8dde0ada946aa1a9614dbba6fdefef7963a93de9b0e9b2d913c418",
+      "size": 921
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_enter_masterly02.json",
-      "hash": "170afc0195680f718bf3033fd2a71a66d009b2dc7492ae6c026891908ca85cf6",
-      "size": 166
+      "path": "assets/story/data/40/0000/storytimeline_400000109.json",
+      "hash": "6aec697f0a37dbf675a8245001bc4f35ee0f1eabb0caf264a0693a5202958cb9",
+      "size": 819
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_event_legendappear00.json",
-      "hash": "fa1739b48ec40d5f0557bfa719b8bf7b79a93b776865155b7b715065c211f2ca",
-      "size": 166
+      "path": "assets/story/data/40/0000/storytimeline_400000110.json",
+      "hash": "01c4377664d57806146ed03f4f8e391d9cb202254541306214d39077fdffe521",
+      "size": 1357
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_eventbonus_upmotivation00.json",
-      "hash": "9a3c69a33800742a4fe873dfbc3c5e74d951854ebf629f7e329c769d6909104c",
-      "size": 166
+      "path": "assets/story/data/40/0000/storytimeline_400000400.json",
+      "hash": "9df60fcbbf29c5998dd52afa211df11749aac061870c0b00343568db8c24f8cf",
+      "size": 643
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_extrarace_result00.json",
-      "hash": "85b8fe16d4b3e5ba1b2fd5785861dba72383588f23d7e9aafb10d8086956ba6f",
-      "size": 166
+      "path": "assets/story/data/40/0001/storytimeline_400001002.json",
+      "hash": "3c3efac7de466ed827fa1161dc6c0a71a39094d06f7b2b834eb9dd88d5435689",
+      "size": 10453
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_extrarace_result00_01.json",
-      "hash": "9e195aff97174685b8593940d80d28341cda706d324498f203bddfdfa91de2d1",
-      "size": 166
+      "path": "assets/story/data/40/0004/storytimeline_400004249.json",
+      "hash": "e913891600b50a2024ed1b4eba4abd75f2c4e40f2637180d7e1b6abe22c600c1",
+      "size": 2606
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_extrarace_result00_02.json",
-      "hash": "c596dab11b90fb7af877ec6a73d01ed5b31414ea4110b97102a82faef7d5bbef",
-      "size": 166
+      "path": "assets/story/data/50/1007/storytimeline_501007100.json",
+      "hash": "0a84d6fe4eceef95d4864eb56197367d713ca75bd4107fbfb2c950ae9cb84ba7",
+      "size": 4847
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_header_turncounter00.json",
-      "hash": "c3cee204bc9f2fedbfcdcbd39aa008744a8c2666e20a107a65ca2871c8ccbfc7",
-      "size": 2158
+      "path": "assets/story/data/50/1007/storytimeline_501007101.json",
+      "hash": "8636724ab4e8ca64ed672571df0960e91ab76b2530521095021ed95e0283204e",
+      "size": 4149
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_icon_motivation00.json",
-      "hash": "abc9b6f135f88201dd4ba95b23de73d697ffbf610ba91c318c9fa538632505f3",
-      "size": 166
+      "path": "assets/story/data/50/1007/storytimeline_501007102.json",
+      "hash": "1952600a2bdf03be8b3aa3a98ff271d857b158b4c3dc7de07bd6a7c1012d907b",
+      "size": 4555
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_masterly_frame00.json",
-      "hash": "93e8efc60c10c2fd8ae8f236b731249e23a34fa4b687db6867e5a20dfa5df1fa",
-      "size": 166
+      "path": "assets/story/data/50/1007/storytimeline_501007200.json",
+      "hash": "d6c200228f72df5729044e120b71a4838ee8c2a87c980bdb48b7239a0c3198d3",
+      "size": 1924
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_masterly_frame01.json",
-      "hash": "22373c0d9cebbb0fd8b98ae56bdbf1bb3034412ae7526bcdf52f91f2e8683d70",
-      "size": 166
+      "path": "assets/story/data/50/1007/storytimeline_501007201.json",
+      "hash": "d25bb2d3ed54c3a431e3a6de3625f98e22841f3f0f7f750224e82a2960a80851",
+      "size": 897
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_masterly_get00.json",
-      "hash": "6b418c4a2d9773840393a834ec60b2fd18593e266bb9563f2c4f7f3bd50e0e0e",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041100.json",
+      "hash": "356769c5579293bf571d45f414287f714fb07905122036e0d777bae686e3b465",
+      "size": 11057
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_next_target00.json",
-      "hash": "b4078d5d60607f89b4faa480162a6c685e4ff54ea4323a034a1c70bd1d4e8aac",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041101.json",
+      "hash": "c7f6739259774b3fd66f758a8570f62f14227d2769e59a5f37c12043438a9c1b",
+      "size": 7418
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_remind_turn00.json",
-      "hash": "c155600e0dbb42cb2268f7d29e7418ec5679cdc25f1704d7c6ad92f2fe574b53",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041102.json",
+      "hash": "537cfb18bb8b4717f2e1b00ce1e9be7e9575b46243616ee918541943a321d8d7",
+      "size": 6040
     },
     {
-      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_txt_buff_available00.json",
-      "hash": "e15a7402a1cc7f4352aba3de3b838ad164ea88d73cf691ba868a3d2e83ce382a",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041103.json",
+      "hash": "3c2b231f1b0c98d37845ff58d255160b73b5484d479466580ca3a6a65a5961a2",
+      "size": 3181
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_btn_trainingmenu00.json",
-      "hash": "be5c7ad1c9cbc8b5073538ebb9d1b3b78b58c49d607902f3f41fa9001cc8396f",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041104.json",
+      "hash": "e3944402667bd5189a2f9c47a1c0ab9270644bce762bf3f6117a4e07643e3a6f",
+      "size": 8207
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_event_join00.json",
-      "hash": "067100dcd56e4873231793c88f72c4b623dd576fe43c9c96935649d9153d1138",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041105.json",
+      "hash": "943ef32edc9f5f2ca7b5ce60af7b086f8bf768e01832b3922315469ed02e2d27",
+      "size": 1008
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_event_live_expectations00.json",
-      "hash": "f2857de7924d0fe34cd15fc11e71f64a73bfa18e1d62fc5c921ece83c2aac1e2",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041107.json",
+      "hash": "f4bf9799bb4cde1c221490d3e0ae3ff507316c6fead25a1c8f32cbad3f71676e",
+      "size": 7787
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_event_trainingbonus00.json",
-      "hash": "0fc9b18d0ee99ab9e8571cf5fccc61e41984ff7c78ff27ef301614b003363ec4",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041108.json",
+      "hash": "fb3e8596e65b8aadd7f2cd06e47f17b7f602fb7e226a816de4f2964283a0ec5f",
+      "size": 8620
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_header_turncounter00.json",
-      "hash": "8806ba3669740a04e499367f07e62b8022a331471f2046b75be6f638d648cdba",
-      "size": 2157
+      "path": "assets/story/data/50/1041/storytimeline_501041109.json",
+      "hash": "32b389fbbc0d0c2a3064d190a598f2cb07a53ae4bae11ad20240c9165dde09f9",
+      "size": 11348
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_remind_turn00.json",
-      "hash": "abe8ae808be0f41417355601cbe494b7fca1edeaccf088b376f6889913bdb42d",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041110.json",
+      "hash": "eeb59accff7fca5743a1048302db40736ea6e5a1fbeac212f4e0b2721a9dcbb0",
+      "size": 2981
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_txt_get_livetech00.json",
-      "hash": "e05e55a6977de924da341ef8701519145ab312c197db0ae7ae3ebcd4a5ae16b0",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041111.json",
+      "hash": "fc39720c3e1ed50aa02ca70042f3b107835be85b8ec280f1e50203e8d3adedcf",
+      "size": 6305
     },
     {
-      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_txt_get_music00.json",
-      "hash": "908d6f5491172a6f5b07358939085b7b01f64726ab7b2b91a571d770066b0f81",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041112.json",
+      "hash": "2d16f98791fe97f53c236bfcd2f5da0855c98d605e4731a564ced167ba09663c",
+      "size": 7391
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_btn_overdrive00.json",
-      "hash": "59755ae3f15cc8932ba444178c6a9746c99fdccc508b34474fa1d89beecb279d",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041113.json",
+      "hash": "a05b84d86f9a1028b14591c00cd980aafcb1010662419f5a398edf6e2f41992b",
+      "size": 8779
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_btn_trainingmenu00.json",
-      "hash": "18e5079a40eabf183bb73209f384608e8f76189958548aa07acc58dd78dd8cd8",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041114.json",
+      "hash": "61c99a0e324b50214b76e385d363135a23685d039293f2ce765371a1ae23501f",
+      "size": 6428
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_event_join00.json",
-      "hash": "855ef73b19e94c761cb153e0e19a316fdb469e28edfdf0c33cd3f6b65d5eea3b",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041115.json",
+      "hash": "42f286820514b3093f4b05e794111e5d5c1dcc1db577dbc8f9204266ac7dbc55",
+      "size": 8762
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_event_uptrainingeffect00.json",
-      "hash": "8e6de8d756cb57c6937888822dc5a9ce3dfcceb7342a331179f2e9cb41c0aa6f",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041116.json",
+      "hash": "ea42329a9f26f0182d67058922a43649b65a46870d1785dbca54324c653442cc",
+      "size": 4063
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_header_hpgauge00.json",
-      "hash": "052046edcac4eae5d6d9085d58af7054ea17ed96b14ebb070d679811c4a28524",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041117.json",
+      "hash": "6309049259261aad73ebaa3d32bd102a88ba012387df75c73ba310d5c7eee676",
+      "size": 8114
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_header_turncounter00.json",
-      "hash": "2208356a8420ce8f5dd3e0d24cff8ad1cd22292e896c5995c8d364b69c80740e",
-      "size": 2160
+      "path": "assets/story/data/50/1041/storytimeline_501041200.json",
+      "hash": "fac263504bcafa4938e42a6500165a51ddc4a462fa9d6d6a93a1307f48900168",
+      "size": 1396
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_overdrive_recovery00.json",
-      "hash": "40e5ad08a06a6ea6e03e833275c48c93333029cc2ecdbda25e6572a6e60a7e37",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041201.json",
+      "hash": "4961da83dfecb2d6236f02c0a44b3771ecfea87ac71560a8b425debcc77e1c5b",
+      "size": 1657
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_overdrive_text00.json",
-      "hash": "18b8f9b044eb055bba5033a2a2343e89df0f685b4714548dac836f7e0a29bcc2",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041202.json",
+      "hash": "75761227e67575b2015c238669f6f1b20b0f3bad81dfdb038aab15f960bc16d0",
+      "size": 1759
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_remind_turn00.json",
-      "hash": "4020f2c40c7ecdb7d1dd34370423f3878d0f28a5488e21d588de0b4a0b74b449",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041203.json",
+      "hash": "8bbf4e665a556e12eb893a57f2d44b216078c6a667e456adfd785374190da4f6",
+      "size": 862
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_research_lv_maxup00.json",
-      "hash": "181a946eb40c3763458f084f3d951790819353ae5499d69b2b24f723aaee736c",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041204.json",
+      "hash": "979776cd5b16892d112dc0cdddfc8d56974fe2315e0988bda7cbb57317dd6807",
+      "size": 4261
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_research_progress00.json",
-      "hash": "8047b4ec7a45b9f54b3abae61d5fb711459357bc761ca20400334346fbc87a3e",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041205.json",
+      "hash": "8d8beffe4056d32d3aad2ff46ab2fb21149b233a544642e9b8a69d1e12f74ec2",
+      "size": 2624
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_research_progress_text00.json",
-      "hash": "6d87693c0584757a7b8cd8fac714f95d322e620312a5f61ed3c5353fc7b90ed0",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041206.json",
+      "hash": "c70a07b62094442baad1b00adcf94d47df67d7c0c103e4c1080e5a5433553ab2",
+      "size": 1014
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_sp_overdrive_activation00.json",
-      "hash": "666fc4420aae6fe8bc76b734f415595423b6e2500d156a63f22cd41124bacfd9",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041207.json",
+      "hash": "1cebb6ec6ee9404860902102674d1ddaf4d9f615bf82673ecd9dc7f585c3d16a",
+      "size": 1199
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_sp_overdrive_btn00.json",
-      "hash": "2260c0a29c6f21be1b59c03b184e014475034f00fe9faa62f4909fa6a83c7e20",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041208.json",
+      "hash": "5fa89932cdc1589d3c2cd592bf02df6b5f39a0cdc1c1a1fc6179bf1cb869ee21",
+      "size": 1382
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_sp_overdrive_continuation00.json",
-      "hash": "96527827ed2b2f6ef96b44a937497cad9587884ba7b38c8524c97e6539e292c7",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041209.json",
+      "hash": "403b170fa1726aed3762cdbc788d4ef03b50bc7655f6f8f1876875c971da870d",
+      "size": 3293
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_target_research_level00.json",
-      "hash": "2a471f313ef970d9d2135b83b91102f24934e5cce6bdf0b0f6a4b23151b6228f",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041210.json",
+      "hash": "29a940d24b8232098c8960fd7e3d69893a18b41941b1ce9d1e8f1fac71396367",
+      "size": 2164
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_trainingmenu_base00.json",
-      "hash": "53364caac4d4ece2d13b7c8085988a1523033fb557a96d1a8a417dddc54741f9",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041300.json",
+      "hash": "31feaab42e255bc4294c26f12eb790d824f9de579610ef066bf3fb4cbf060887",
+      "size": 1692
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_tuning_text00.json",
-      "hash": "6e03b02175dd6a16227d5f446729f43609d08829b8b6794295b289b3ca9b1b79",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041301.json",
+      "hash": "47a41ceeb02c1eaf74bec5b2b5a51100ea1c91f824e1e7e8e7a755cbf817c505",
+      "size": 2681
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_tuning_transition00.json",
-      "hash": "dbcab8dfcf3a3fece087c102fb1baef4a9b2a23b6bac7f9db35802c0720629c9",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041302.json",
+      "hash": "4863fb922d6e5f042c6afdd7655f2ff790710ba7c4b4ebc04e1b705a8eed854c",
+      "size": 14280
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_txt_upgraderesult00.json",
-      "hash": "800d677740a9c5a4bedcdbcacc794785f66cf6146c7af67e34b0bf413e262a6e",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041303.json",
+      "hash": "6db47943598817cd67b55b1af84436092eef81987c90386ca0fbab82ea0a7331",
+      "size": 3964
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_upgradeexam_btn00.json",
-      "hash": "f08c4c56975ef8a1d1d24a7eb2f040d2bf2c754d0a2a0219b8144c536d45d517",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041304.json",
+      "hash": "99b1060a8f9b1c5d7c7c347d6fc143cf4a5a679cf80c6b95339c09ed9afa29be",
+      "size": 2407
     },
     {
-      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_upgradeexam_start00.json",
-      "hash": "d3c8c65343f4c6dcace7d6a314b60cdb6340ee0bc38acee6d3b0297a80105712",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041305.json",
+      "hash": "275ceb93ce34c1b35f2ce65f257cc68eb066320f4abeccbc4b7b5597bd182383",
+      "size": 3968
     },
     {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_break_resultpoint_record00.json",
-      "hash": "49a455c225506b916d4a983dc3f7eb19f788f630af6732c75469f2d07d269160",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041306.json",
+      "hash": "ee631d22052464695caf380f564d05eadf5fc6c6f7aa4b47d13421646b8bd820",
+      "size": 5607
     },
     {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_btn_factor_succession00.json",
-      "hash": "2f56cc9a945d83927b1fe1276df3ddfb2c3d129589bd996c45de03fa1256e22d",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041513.json",
+      "hash": "e73ddb4b03073ad63887b09204219ae25a25e831b03093c76efc3266cf3fbce6",
+      "size": 8786
     },
     {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_btn_trainingmenu00.json",
-      "hash": "5ca125c03e1d16f9536c56f356ae0f8c6dc2b1b84d1e99d234aa81dc6affb61d",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041514.json",
+      "hash": "ce5b58c8185b8eef4a29cbe9dd03066fa23d406faa94d8039976a23167be5dfb",
+      "size": 9518
     },
     {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_btn_trainingmenu01.json",
-      "hash": "623c924ba07db210673fa4f91e7507f9714bfac80f25711e21511cc998a759ec",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041515.json",
+      "hash": "a64b2eb253c85f6cf4a9aa51be548fffca08fd23500e2ef0c546ca86c164ba03",
+      "size": 9466
     },
     {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_activecondition00.json",
-      "hash": "8f8514d59cf4d3edc6aee4fced62b172b406d6ec99e7a3bb67b71ceb689ad126",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041516.json",
+      "hash": "51932decff53ce48e33e2a1ad5e65cfc8b53414420c5e69250a3788ac30a9df7",
+      "size": 4450
     },
     {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_apptraining00.json",
-      "hash": "d9d2a614c7d8e345a0441215806e8673efc48e7da3e5fb8976e841b0be9cb088",
-      "size": 166
+      "path": "assets/story/data/50/1041/storytimeline_501041517.json",
+      "hash": "1597e0eed49e2b8e00f1d0d9d5adf36a1ff402e0cb37e8775671a0d3f852c51d",
+      "size": 1410
     },
     {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_dncondition00.json",
-      "hash": "02f9458954193ab3768d8584f3439739a6d58c457595b712ad1f6ca30e272415",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_dnskill00.json",
-      "hash": "eab73be9fac6a97c72cfbfc4c3e0619cb877ae3b3b81bcb89e9902aa2a6f9285",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_racebonus00.json",
-      "hash": "7265daeb3cc4e17549bc6efdffda097d9356735c10e97912f8b7c6737142e8d7",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_resolve_dnskill00.json",
-      "hash": "bdcea7ac41a10973fca1a082bf7442deb5acf4dcc753fe72fed6f4643cac5aeb",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_resolvecondition00.json",
-      "hash": "9488c1e51108efd6aa6ece950b261b89355662a7a2a683495de7390f6ca8b863",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_succession00.json",
-      "hash": "0826a0491ef93770d48baa6173429e15f04b1ef69a2b63d51f4f77523fd6bbb7",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_target00.json",
-      "hash": "bffd7d0e5aeac535fcdedd4638c2fa056f94cfbaabe9a58c9fbaa8a93fb7051a",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_upcondition00.json",
-      "hash": "5726076133a6ba1a40c651a9c797124fc92aa663182833846f3f5a5857990759",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_upevent00.json",
-      "hash": "7c6fedb1b8a8f309ef11c28486bd5268e7fd11bfab28b3f93493765f37cab612",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_uphint00.json",
-      "hash": "79862540f6e1b9c977976303a361c5c26d9797b0379c316890ca584679ead2d7",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_upskilllv00.json",
-      "hash": "849e912643401c5a1b10c4760f44b79071084a7d95d5de1e65c9c90b24368a1b",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_extrarace_result00.json",
-      "hash": "0153fac8593fb2831d346c946914f7fa4996535c0a6bfd46ecadfe541da01ea9",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_header_hpgauge00.json",
-      "hash": "53bb896434e169c65334ea25b34989de3ca40a23ebff61b42099cc2da32eca8b",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_header_turncounter00.json",
-      "hash": "dcb20f80c267d7c8e17791cd85b0c809ab10e0a091ec3ac2f6286294d03bc15b",
-      "size": 762
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_hint00.json",
-      "hash": "9e67734670bf6f13cd7adf15432b7755c4ff79e4e3b28236244372109c7b34ee",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_icon_motivation00.json",
-      "hash": "a626ef49167c1625b6e682931d7ed1bdad7d2bf92cded21c7ad074a06c718304",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_next_target00.json",
-      "hash": "0c0fa953cd19f8fee4958dbcaadfcd3565700f0686fdf3412c288861a30c24be",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_result_chararank00.json",
-      "hash": "7972800b5d0af60ae4a8a1cf53a37c29d87cb2410d2cc99c6ac1e79b95bf5a28",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_result_scenariorecord00.json",
-      "hash": "936637f2106b93b6fb20cb045dbd5aac036751dadff8f05d187fbe422f6fbae7",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_sectionstart01.json",
-      "hash": "6461cc4fd7f420a21fe16cd7a5a7c75ab7158ad64ce0902f8fec95a928f5611b",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_single_target_achieve00.json",
-      "hash": "b19b27215dfc870d36ba29b1573e7b6c37ce9ca95239fb1c1ed7fc76b3093f99",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_skillupgrade_skillname00.json",
-      "hash": "55355813bb08816ac33451ca522c2a627111c25703c9610231a50886c77609a5",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_start_succession00.json",
-      "hash": "d5e069952512bd95b1185f9f557141bdfd406e4d2f75e48edc21f472558555d6",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_start_tagtraining00.json",
-      "hash": "3dea44838995d33e769084d22321b176be329e36866d9778029a794cf681d2d7",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_target_decision00.json",
-      "hash": "d984b46402457bc683b696774e8deb7762934a8b4d176e2cc9f746e9901d8b7d",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_title_getfactor00.json",
-      "hash": "9951c03cb6d04a6424798c6f28c4665cde1db48b2e5800f71d7bb25540cf186f",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_title_getreward00.json",
-      "hash": "8f6711b50251df757b6a6e4649abfd9fe4c3ce50a7b9b3cf4ba15ea18dc9eedf",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_auto_training00.json",
-      "hash": "bb19de5c9d04b49ce9505b72669681e9d517aa364fed37d3fc2133d6cb44d4c8",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_factor_succession00.json",
-      "hash": "666bd68f371303f98fba8b008a2dda73ed9e511adb6955b47a8f9f8e17fdd29e",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_tagtrainingresult00.json",
-      "hash": "ff9620f4268e3e8613c321b06abcca17b6e56d0db9b7661baf0010e2b109c4a0",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_trainingresult00.json",
-      "hash": "697a616e34090c48a8e2a47bb0b9c8255e50fe9475f123d95bc3fd2715f204cb",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_badge_shimatraining00.json",
-      "hash": "fdf598924321852b4e8be9b76ffff5a9e3b915e22ef119f8d43e4b84f025e7b4",
-      "size": 410
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_btn_evaluate_decide00.json",
-      "hash": "cce95c4f3b230918879d57c041072c3140526a8f2c3d3883dd4862d5f9813cdc",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_btn_trainingmenu01.json",
-      "hash": "778359ca4b2de50ac29d491f240fab34a109a81f058cf1c6e7d4a1dc85cc1df3",
-      "size": 408
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_btn_trainingmenu_shima00.json",
-      "hash": "aa731cc4a7da8b99fd4459d7dbbbe69778d584c196fb472c5e8e5c7eeedcf36a",
-      "size": 589
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_construction_progress00.json",
-      "hash": "79645353e9a053e8d07e9233c0a287f4cf3b1d6da83b98eb1b0c46bc047151f3",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_construction_progress_text00.json",
-      "hash": "f644d793587f896a5052a55c26e366dc2e1a1939117d0fede0babafd6b87f69e",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_evaluate_start00.json",
-      "hash": "0c0ab0cb8c57f6bd7755a877aa232786ef196d08a4a5882b3225f34f10e9411e",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_evaluate_start01.json",
-      "hash": "2141f5bc3ea8b06b7d021e0c6b273a953676c7d8620062c67edc3882893831ee",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_event_join00.json",
-      "hash": "958d7f30a60f7f123ca4da33d7652fff1a6a065c16c610ca499e2cb48df7d7e4",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_gauge_shimatraining00.json",
-      "hash": "0bcaad8a319b531044673fa938fa21477cfbb1625305d5d3ff61e2a088c68792",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_header_turncounter00.json",
-      "hash": "f52a72f8e37835312da6b96ff2936ba0733ea6d18d1d360859337c482a8d31b0",
-      "size": 1325
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_complete00.json",
-      "hash": "9379df548f2b142078375484db5e1d41d364aab7eca0d4a4caecd2d70e3da712",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_complete01.json",
-      "hash": "c1e5cb2f10493a2c82970c82f373e2ea6930ce43d1d4a8a7cae614eafcc13316",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_hint00.json",
-      "hash": "fba3671be7bb7414d18d3e33d04fcfcbbfcfb705499d5f20a78212a325138c1d",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_transition_logo00.json",
-      "hash": "2ae42db5833e969534af2aba938ca5f6feeb76930bbadd4c5624bd3975606961",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_transition_logo01.json",
-      "hash": "2c611e6662fa8e2ef63b92168190297bc72ff7b009f14e2abf0513b153177143",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_notice_window00.json",
-      "hash": "3ee9bce05988261e2c50e693bec44c08677cc9b5a8adeb1819262f4f38823f53",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_planning_island00.json",
-      "hash": "8b57be613dc1bc10757d5b710d74fa1e814338affcd1ae1079bd2fbb692c40be",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_remind_turn00.json",
-      "hash": "f32bb27c48848c27411a9b424e01b0ac145906a0c3ee41148353e43741f3c30c",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_shimatraining_acquire00.json",
-      "hash": "f8ac0220ab6b804a90ebaa5e62c0c140106753da7cccd2e61845444ba6c97eec",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_shimatraining_period00.json",
-      "hash": "4e46f46270ea3937f02276a844ae5696037fd0939ea1fca99587671fbf595a5c",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_shimatraining_split00.json",
-      "hash": "067fa7260b02726c7478a3cc9d92d3130a71bdf321f423d35f16ff90ab82b6b3",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_start_tagtraining00.json",
-      "hash": "831db5309cf545c17235c2a272e8a9fea4bebe5fa1be75d03aa2bdb4348e1cc5",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_training_facility_upgrade00.json",
-      "hash": "e5dd2905954cd706739ba1c1275432c907bfbb90241e6a96de211aa9e7ac9f31",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_trainingmenu_base00.json",
-      "hash": "b64e946a98472225436594c502955f6f07e89f770c22f333e14a174fa1b91b19",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_txt_evaluateresult00.json",
-      "hash": "645008f556fb08a6d2017a8f678e15cd906b00d2d70c5ef2c7cc900810dc15ae",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_txt_shimatraining00.json",
-      "hash": "52a06503492383eada91b0f1230a5d3219f9fbe1fd68d2be0f6ce739a8be68c3",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_txt_tagtrainingresult00.json",
-      "hash": "5e41e6e6826ed7d1aa29cadf481418ee2ce13fc803e485135927f34af323452a",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_btn_competition_decide00.json",
-      "hash": "345f5a6b0d7fffa3399cfc6536d8ee7773e71ce3a2d609e2592bdd10a16a3746",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_btn_trainingmenu00.json",
-      "hash": "5cf9fe957d1c525d7cfe6312cb7aaeadeb520da97654ea0155f4eef618c82d8e",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_competition_gauge00.json",
-      "hash": "a3696648e84e13a583ee9e386135bdb34495bfbeece1dbdcee5ca9fe04c1de90",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_competition_telop00.json",
-      "hash": "9731cb6986d7be122a58acdaecb26fd80cf3ba3eaf946ea4e6aacf6ad8a86ee2",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_event_advice00.json",
-      "hash": "176ead60b7ea5f4781450a485a2983b2cd50b79ab103ef868f7d7ac8eeea60ee",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_event_stance_rankup00.json",
-      "hash": "2c383f4913bbeac0e5ee4c14a779756604ec86b178a80f1681d58a4add6d2f30",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_header_turncounter00.json",
-      "hash": "3ad847f9a0d68880cf44e91aa00f093d53cb05297eee245facd9a1c9192f25b9",
-      "size": 2161
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_remind_turn00.json",
-      "hash": "356cce7e954f5c6f31c1dc5d4ae6bc16bd04b7aa486b6a58de7c9d816346df3a",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_showdown_result00.json",
-      "hash": "890abd5f74ea1a4235b1e73aaa522441487ebfda65277e2682387edbd0513151",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_trainingmenu_base00.json",
-      "hash": "5ef5d0ffc203612258fbcc12841c4c44abf40fc847dc3ebce81fb8b35e29330b",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_competitionend00.json",
-      "hash": "70afc3ea218b6603c1bd8d1272470d2c087d97e9501c1f593b17650fcdafda54",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_heatup00.json",
-      "hash": "c273c93c0d40a8ec9d41b35f0bd4e357950e00c9b876f7664fe8bdac5fd30d04",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_tagtrainingresult00.json",
-      "hash": "f990bb9ccc0b91712aa9e5db9686dd44ec0e0deb8d1a25f4469c96a508e40986",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_trainingresult00.json",
-      "hash": "ff51ee6cb5213b24a951812b78c8d536bd3d7f29fd511a0c7bd3792637095ef2",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/teamrace/pf_fl_singlemode_teamrace_btn_trainingmenu00.json",
-      "hash": "7d4fd5e6491f61da4d31b5b7f08cf0582f2f1851830901e4c716df4172664e00",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/teamrace/pf_fl_singlemode_teamrace_header_turncounter00.json",
-      "hash": "f4f43f5ea1a546b88fd258b6c38f25ce3a4d6b94bb4dd929ebfbe6934fb14832",
-      "size": 2159
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_acquire_spirit00.json",
-      "hash": "3386f13c2a76c46b6cca58adcdc5bc963670e430fcc371683bae43c41264b2c4",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_btn_trainingmenu00.json",
-      "hash": "016e8ca7841e829daa1370bd5308fc7ee84b682a0cd7b56a6b048876803c57a0",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_enabletagtraining00.json",
-      "hash": "109efdbe063bbf0abb012c4abce6d6ee1dd9a44aa5143909524b1c951c29e9dc",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_upeventrate00.json",
-      "hash": "1e923aa9da9a4bd61ef885ab8a67212510149ee770c462e62be010a7ffeba202",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_upknowledgelv00.json",
-      "hash": "a934768f130a994a429f72b63644fed78d1f539468fadc321170223f6ea3b892",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_upskillhinteventeffect00.json",
-      "hash": "9a68a76d58b70150df878480cd82f9d1b6edd72566fd687e83605b56667390a7",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_uptrainingeffect00.json",
-      "hash": "483ff81a73fe473f762b22dfb43b4fe84c27e0a1cfdd4b6f9afa63a06c066db6",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_venusappear00.json",
-      "hash": "4e95fe9d7e065220ffe429a711c44d3123e4ace19d1c51b544adee07cffb876c",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_fragmentlist00.json",
-      "hash": "da9ddb3f214f93565d1df59fe12ce55cfa9dc714a6591c2a434c65b3b32e41f8",
-      "size": 410
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_get_spirit00.json",
-      "hash": "de9f2c6397ff28d3e859706582d85c44dbcc5f12453546f761d90a1c5bc1e919",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_get_venus_spirit00.json",
-      "hash": "87cb67c112e9107df5f1f4c959521cef989d72e8754cb49b96a930ff7370567b",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_header_turncounter00.json",
-      "hash": "f372bf12d775c8cd336cafe6c06f977e29391e0b5f6516af454bcbedb803f926",
-      "size": 3165
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_remind_turn00.json",
-      "hash": "3dd83bf4dea1bd4fb25498218e0013193bd13ec5793b4d4af345e122272f1d9c",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_spirittree00.json",
-      "hash": "6a4074de6817b0e1cd98a48b51261bacc7fb532ea73ff168b991b8f2edef1e33",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_txt_tagtrainingresult00.json",
-      "hash": "14fd5e74e43c76e9964fca881b0b82de533f8374d81a62b16fb45c9d1a505a61",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_txt_trainingresult00.json",
-      "hash": "7da9f22c47da19d62bd6095d50ef5026ff9816ae7dbb6bb2f93facd1ffcca0aa",
-      "size": 166
-    },
-    {
-      "path": "assets/uianimation/flash/teamstadium/pf_fl_team_icon_winconfirm00.json",
-      "hash": "2f39c774ca4ad6ed17e7d3fa33da204e47cbc4a1e8b43306bc38a70f036d6247",
-      "size": 166
-    },
-    {
-      "path": "character_system_text_dict.json",
-      "hash": "70cfb90964ac589076aadaa3fe6411947a181737671e676e7643da1591001ed3",
-      "size": 220278
-    },
-    {
-      "path": "config.json",
-      "hash": "e8b2f428d411118eac97732783f91c9df50bc3e569ba33716cb7076b514d7d65",
-      "size": 1582
-    },
-    {
-      "path": "font",
-      "hash": "701c57fd5edba8d774d2003df4568114df3be3985f4d3e56048621d8f294f6f1",
-      "size": 2180361
-    },
-    {
-      "path": "font_android",
-      "hash": "c591c48989195582688a6ab8872a15d5eddd07a182fd33c4ebf230ac2bee008a",
-      "size": 2179227
-    },
-    {
-      "path": "hashed_dict.json",
-      "hash": "2f6f90252e6251adb733f53b84fe19e86304703b3bbd79333b90e32ec9666f7c",
-      "size": 9843
-    },
-    {
-      "path": "localize_dict.json",
-      "hash": "459f3502bd0a08c10304acaefff7d55f88e32aa1142edd4c27d7fc576aefbb68",
-      "size": 271017
-    },
-    {
-      "path": "race_jikkyo_comment_dict.json",
-      "hash": "acf47eab3872600f204f41f2a898c75a033fe334312ce19c91d858fbdeaa7c76",
+      "path": "assets/story/data/50/1041/storytimeline_501041518.json",
+      "hash": "90af6bdfb95efd6d89049308c014dd425229597062092dcc81c1b043553640f9",
       "size": 1255
     },
     {
+      "path": "assets/story/data/50/1041/storytimeline_501041520.json",
+      "hash": "020a3404ec7b06cedbd966c6be8539b47347534b4b6deb4fc4c21d3e0a5eeba8",
+      "size": 10794
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041521.json",
+      "hash": "e5012cc0f126f70bc67218662bcc06603644992e83f4a488c916bb9c24f573f8",
+      "size": 1005
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041522.json",
+      "hash": "1969f3a1e32340ab7a1dee070eb95be3894db6a063b3fd1884348c01605a5597",
+      "size": 1409
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041523.json",
+      "hash": "deec05f75ce08021c5a473895a2a50eafc7d446f8ac17f9ebf559cf099a8583e",
+      "size": 3742
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041524.json",
+      "hash": "98c22411d7feb7831bb8444cad9003eb40ee794a1184cae278ecb4f37715d7ae",
+      "size": 5874
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041525.json",
+      "hash": "6a54e60519b918c5ca6dd02c745c6b9e5cc98f93723742cd67ba43c650bd8ad6",
+      "size": 7573
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041600.json",
+      "hash": "de81e240f1ba0f7acc232e83aeacfb6a5b804792f8388cac3919fc2c0f734b4d",
+      "size": 962
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041601.json",
+      "hash": "57faa9ad8b02b6b78ad39d3dbcad55a79a0e2ac616b01d72c497b95dc10ec759",
+      "size": 837
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041700.json",
+      "hash": "f54e906aff6ee5dcae527dd6a26c491f01845ff8c8e13917ae1838998684f9e9",
+      "size": 1255
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041701.json",
+      "hash": "149f398bc6cf515467c9aa6d60d3592f22e22ca031a0cb79504b715b00569b11",
+      "size": 959
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041702.json",
+      "hash": "bf632c42eecf7277923f9dd3ff2d856097b540e9676308c35471dbdf44c0a190",
+      "size": 8400
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041703.json",
+      "hash": "3b5d19724f396a4c905770a9f4fce079ebced9174b1396ba76274e25fcfb347e",
+      "size": 8558
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041704.json",
+      "hash": "51046768a02f492fd0e093018fcdfd0c38bc36a9cc267616f64496e343ca5bb8",
+      "size": 14494
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041705.json",
+      "hash": "9058d5e56e04d3748ba956201418d35281c424730ff2717916c7f352620f9099",
+      "size": 8143
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041706.json",
+      "hash": "c15dd61479eec11a7226dc4e2969541d46bb7ef06f248b5837810b5cbcc2be4a",
+      "size": 7285
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041707.json",
+      "hash": "c1cfb0658d23232fad4387ce49ae915a0c4424afb957bc85f22da09a1ad083d5",
+      "size": 4597
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041708.json",
+      "hash": "efacc93a4e18f5f3e7e58529f5995e32b92cc1234147df437713e91e0cac3ea0",
+      "size": 2191
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041709.json",
+      "hash": "29234ad20296f5876d9a3843d26ba43bf6583d398c6d61105d8a571724ff6dd3",
+      "size": 2278
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041710.json",
+      "hash": "0ee6784bd63797175cfde9f525dcdefbdf917bd437a66488de036b722193a761",
+      "size": 2347
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041711.json",
+      "hash": "a4a88af2b32c922669a6203134bcac0b2571d833b5ea34910e2c210f4ca20bdd",
+      "size": 3038
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041712.json",
+      "hash": "91ac91f237a473b7a2679b44cdbaedfc96265e262aa03add8cd6d11946642467",
+      "size": 1811
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041713.json",
+      "hash": "0357bb5e5058d374f7db6666990e1a762a6195ca537858f613040fccd008d9e1",
+      "size": 3430
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041714.json",
+      "hash": "7521702ffa3f7a8fea912dd231ebfe763a899f79c86a022c02546522db45138e",
+      "size": 5331
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041715.json",
+      "hash": "2f500dff4fcc47af30df6ea3de6438f8ecb968273adb9f16ee94560e43b24746",
+      "size": 2259
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041716.json",
+      "hash": "d43195029083bea0287fe748f0a7478a99be1bafe13077a9f1c6df07c734bb16",
+      "size": 2528
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041717.json",
+      "hash": "8a3fbd7ca843ddb5c882728d5528fa32d320eccf83308ad6ed818a75cdb8a749",
+      "size": 3601
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041718.json",
+      "hash": "69598c0ad4529ab86e08492e55bcdf2a3dbb9ce4a60006791a68c1bcfc2566ca",
+      "size": 781
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041719.json",
+      "hash": "744252550ac8ac7870a32d35ca4e5348b65771fd74abec29e2f560f82ae9ce7c",
+      "size": 1155
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041720.json",
+      "hash": "b3bf27deff620c80a26825f1fa5b200dc0d6ba70c5a7afaed763c81418591cdd",
+      "size": 18564
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041722.json",
+      "hash": "fea5f258e8991b9d43f55c8ecddd51e41f2d71049a1840da2e8834628d5afee8",
+      "size": 1581
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041726.json",
+      "hash": "04ccace69009adc9bf4a4713d49329bf99ef22cada8b5781fab3470f0d6a7f67",
+      "size": 1839
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041727.json",
+      "hash": "2e9d4d1f232b10b48bc3c38c9e988ecf8fbc9aa770ce2aabd3a9b1eacced50f9",
+      "size": 891
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041728.json",
+      "hash": "a8bfd54ed0181e0b996bd0b0f7cf25033b57d2a79cd465ce63f7a23b4a632723",
+      "size": 650
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041729.json",
+      "hash": "c4bb0f6dfd8be7572631ec92bb8662a4ba698f396fa9008521f12fa1d4a5d627",
+      "size": 815
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041730.json",
+      "hash": "2e9d4d1f232b10b48bc3c38c9e988ecf8fbc9aa770ce2aabd3a9b1eacced50f9",
+      "size": 891
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041731.json",
+      "hash": "a8bfd54ed0181e0b996bd0b0f7cf25033b57d2a79cd465ce63f7a23b4a632723",
+      "size": 650
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041732.json",
+      "hash": "b1ee3991397590c5040f6140e1b32270589d2d5f09cfa2f68c88ae17edf3a799",
+      "size": 561
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041733.json",
+      "hash": "163e78ac11b6b350d0a7d6bf45d415e7294b6da277c347e6e9792922d5e980a5",
+      "size": 421
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041900.json",
+      "hash": "ed1017e0d55a770c986156c5e8941bb166ae501a0884fad4c4537cfba070566a",
+      "size": 1091
+    },
+    {
+      "path": "assets/story/data/50/1052/storytimeline_501052100.json",
+      "hash": "c0bcdbf86a6b1266e2f4246d886f0ea0662d7ed7b15732cf7e9959f4d02d79a2",
+      "size": 5873
+    },
+    {
+      "path": "assets/story/data/50/1052/storytimeline_501052103.json",
+      "hash": "5dce1de963dd7124e634081cea1ef663636e364e5c56e35aff3ece31b3d09bb1",
+      "size": 745
+    },
+    {
+      "path": "assets/story/data/50/1052/storytimeline_501052200.json",
+      "hash": "ef4c23391174a73bca6bdcb06842eff59dbf3e24e05c9106cf032de8df6eec0e",
+      "size": 1638
+    },
+    {
+      "path": "assets/story/data/80/1008/storytimeline_801008001.json",
+      "hash": "5a6652662faee8eb05974bd0f6dd4c3b7b8def8094b0b2ca69a5401753bb2be9",
+      "size": 2813
+    },
+    {
+      "path": "assets/story/data/80/1008/storytimeline_801008002.json",
+      "hash": "42ce2f24737865a55b1b5cfba816c6ad9946a6787be677c76fe7d176281cc03b",
+      "size": 1997
+    },
+    {
+      "path": "assets/story/data/80/1008/storytimeline_801008003.json",
+      "hash": "a664b9ef572a758b3e4e4cb81db181d8c3427d18e5e991e4ab71f535ca94130d",
+      "size": 123
+    },
+    {
+      "path": "assets/story/data/82/0039/storytimeline_820039001.json",
+      "hash": "a95a1303d359625f9c825e18764b15b999bfca6617f5a59b9a0a63b46dc0622b",
+      "size": 7323
+    },
+    {
+      "path": "assets/story/data/82/0039/storytimeline_820039002.json",
+      "hash": "7987d59dc55d18466706300108f5eb8882cb10813eda24e668495dd17edbad77",
+      "size": 3649
+    },
+    {
+      "path": "assets/story/data/83/0005/storytimeline_830005001.json",
+      "hash": "2740ceec21e3fbe2611caa2617a797a92fe655f5f3039fd0e1d053f2adf1e69a",
+      "size": 2871
+    },
+    {
+      "path": "assets/story/data/83/0005/storytimeline_830005002.json",
+      "hash": "0f52dd2fcb538238218b6773b024c9a77a297e3cb8b47c6373ac04b32577b9cc",
+      "size": 3348
+    },
+    {
+      "path": "assets/story/data/83/0005/storytimeline_830005003.json",
+      "hash": "a47cbcbc3b873840f632f53e33e23eaf432c908b8d7bcf7936b339c3794a1748",
+      "size": 4065
+    },
+    {
+      "path": "character_system_text_dict.json",
+      "hash": "8ef24795673180793866cbcf1e885469e6b0f3ba25777d2758dcbf6a7d3cf8f2",
+      "size": 214016
+    },
+    {
+      "path": "config.json",
+      "hash": "6aec910cbb6b88746c9c2fcfabc94dca51a4f58b9ab27f5b23946cfc18fdd946",
+      "size": 578
+    },
+    {
+      "path": "hashed_dict.json",
+      "hash": "9c23ab86e9956cf88b4c1b2afb03ff22dfbc594a323f8f01ded7fe3060cc7406",
+      "size": 5290
+    },
+    {
+      "path": "localize_dict.json",
+      "hash": "216508cb625a378b858f1e8b8f1c74652dd67b1472edbc7208fdb185be207126",
+      "size": 35678
+    },
+    {
+      "path": "race_jikkyo_comment_dict.json",
+      "hash": "4cba2476cceab9b48cf43a8ff918e7734c85f5e6ea968d603c61ff02505ba731",
+      "size": 24266
+    },
+    {
       "path": "race_jikkyo_message_dict.json",
-      "hash": "ad10f35d3714b99ee839a17b0d4a2e6f176b3162ecdbbca346bd22eeb8063ec7",
-      "size": 193549
+      "hash": "b3abee4a2fe9c63c5d05829d49781335640be45e5b71c65a6e3cd516d74b7b5f",
+      "size": 84987
     },
     {
       "path": "text_data_dict.json",
-      "hash": "13e2176cd87c0b23f2134346e426beb5076eb38900e965d57ca543a28829e0b4",
-      "size": 3352219
+      "hash": "8295436912e7b48ee1f8638d87d616cbaaa5391023cadf3da66703a68f2b89f0",
+      "size": 1879909
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -4,109 +4,1879 @@
   "zip_dir": "tl-en-dev/localized_data",
   "files": [
     {
-      "path": "assets/an_texture_sets/as_uMeshParam_fl_footer_btn00/tx_uTex_fl_footer_btn00_0.png",
-      "hash": "62477e9e6fb691e4c2a05eb9aae1bccee10d1415c7bf22e35a9e70ca2859e529",
-      "size": 392006
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_announce_supportcard00/tx_uTex_fl_announce_supportcard00_0.diff.png",
+      "hash": "9a859a136c5410e3e078242a441441c2f3b7669cff6f5a6e9e90a674cef9ad36",
+      "size": 450413
     },
     {
-      "path": "assets/atlas/home/home.png",
-      "hash": "9640ad81b7534b00e96582ee19d923894b85af1b6b22c07d4c2fef77591dee35",
-      "size": 957506
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_champions_notice_round00/tx_uTex_fl_champions_notice_round00_0.diff.png",
+      "hash": "3c42e0909391953a64424795024425412978e70cbd1dbe9117fb3bee4b6f72f3",
+      "size": 603375
     },
     {
-      "path": "assets/atlas/single/single.png",
-      "hash": "8e41c104fb2e5d61a09c0f64212d3dc6aa18e0c5e574887918a3aac334298798",
-      "size": 782052
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_champions_result_finalranking00/tx_uTex_fl_champions_result_finalranking00_0.diff.png",
+      "hash": "12ebf2998f1df623453b2a126c8ed7328f8814a0bec9c2d4c4743ac2fa2ab566",
+      "size": 71622
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_chara_txt_hint_lvup00/tx_uTex_fl_chara_txt_hint_lvup00_0.diff.png",
+      "hash": "782ea007c89eadea410d2d37c6fb56ce0ef4a7628be6d609f743a158133885e7",
+      "size": 79780
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_cmn_badge00/tx_uTex_fl_cmn_badge00_0.diff.png",
+      "hash": "7b5c3ed19ed88296f9a76821391b08af0e333bf7316488d5bb12c5860f5b8d89",
+      "size": 1499
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_cmn_txt_event_reward00/tx_uTex_fl_cmn_txt_event_reward00_0.diff.png",
+      "hash": "824b21b08afc0b9b6ad1156a5a277a078449b05dee2aa609ccc2dc2958efa72c",
+      "size": 110144
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_contactcard_photolibrary_icon00/tx_uTex_fl_contactcard_photolibrary_icon00_0.diff.png",
+      "hash": "25c8c2c224a4e03910b225a090d050ea6348cdb0f123a421789faff41023011a",
+      "size": 8385
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_factorresearch_gauge00/tx_uTex_fl_factorresearch_gauge00_0.diff.png",
+      "hash": "75cab709efd94e8cf717105afb962f05d5db8c976a2ebbb5570d1856373eb0d9",
+      "size": 133216
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_factorresearch_reward_txt_title00/tx_uTex_fl_factorresearch_reward_txt_title00_0.diff.png",
+      "hash": "36b90a7bbbcffc912f5d50a2151867746909d5fb52572f487a1a5c579fd56f09",
+      "size": 75551
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_footer_btn00/tx_uTex_fl_footer_btn00_0.diff.png",
+      "hash": "6150ca8754e70c6bf3ed5261cc8db24969b1ce78e41528c1a0a7a8b9c3aea738",
+      "size": 62041
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_footer_landscape_btn00/tx_uTex_fl_footer_landscape_btn00_0.diff.png",
+      "hash": "79568e0c164737afcd76326f289573309f9a259abdbac04c12bd202770fb079d",
+      "size": 43049
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_gacha_chara_piece00/tx_uTex_fl_gacha_chara_piece00_0.diff.png",
+      "hash": "140d146c7ba383f5f52269ce67d12c50bc4fda2bac9fd124b9018f33c06882b3",
+      "size": 6767
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_btn_get_heroskill00/tx_uTex_fl_heroes_btn_get_heroskill00_0.diff.png",
+      "hash": "c4717083c55ddd35cc7d8816cd8508bced93759ed9757980be7f03fa3a688e1b",
+      "size": 69041
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_get_heroskill00/tx_uTex_fl_heroes_get_heroskill00_0.diff.png",
+      "hash": "ec4326573bfd24167961a20b10e87a6a5e482dfeb35683e19282df3c17822034",
+      "size": 76586
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_matching_comp00/tx_uTex_fl_heroes_matching_comp00_0.diff.png",
+      "hash": "ac313eb513b0f2d1f94271b65ed327d21a3ce72da31fa870e1f0c9f0833c0138",
+      "size": 380439
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_raceresult_gaugemax00/tx_uTex_fl_heroes_raceresult_gaugemax00_0.diff.png",
+      "hash": "56bf06395e605b7412cf315b65bbbd6768515ae2be2d12bcb3978f8f14949227",
+      "size": 360981
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_raceresult_raceend_pt00/tx_uTex_fl_heroes_raceresult_raceend_pt00_0.diff.png",
+      "hash": "7e9cf7854d587880ce96f8d7b3bc0a5956318745a77962ba9d5330826288a512",
+      "size": 74623
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_heroes_txt_racereward00/tx_uTex_fl_heroes_txt_racereward00_0.diff.png",
+      "hash": "34c10b6a21f7c9788f0a8087a685c98b864595cf69c3d4e7b10e8dae2c8b3307",
+      "size": 39106
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_login_normal_title00/tx_uTex_fl_login_normal_title00_0.diff.png",
+      "hash": "4e8f5b2279b669da6257f810ddc553e000d7fdde65844290a845d14ec8379759",
+      "size": 25234
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_mng_credit00/tx_uTex_fl_mng_credit00_0.diff.png",
+      "hash": "4ac28e91644fa2f9a6ffe3e0943ae209f98dab817732f4c9308139a036d6c9bc",
+      "size": 39230
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_mng_dialog_get00/tx_uTex_fl_mng_dialog_get00_0.diff.png",
+      "hash": "eb9bb0d02bd2e252a3c680def707168a9c7ce4bb3fa103d153ae73b9de33be4e",
+      "size": 20028
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_race_result_rank00/tx_uTex_fl_race_result_rank00_0.diff.png",
+      "hash": "2fa9e508b28be62c93b2dab5381146d127dab94150b38f616281114572a34bc9",
+      "size": 492276
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_race_rt_04_00/tx_uTex_fl_race_rt_04_00_0.diff.png",
+      "hash": "5f017159fef5199a20d1506d063bf2e119f1131105d3603435ab131add3b6dbd",
+      "size": 27464
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_race_rt_06_00/tx_uTex_fl_race_rt_06_00_0.diff.png",
+      "hash": "fcd1d8aeb1ebb0424f4f993a39b735f24641d0e60c2e15dd81251780e9de7d03",
+      "size": 36470
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_ratingrace_result_rank00/tx_uTex_fl_ratingrace_result_rank00_0.diff.png",
+      "hash": "15f77618b652f12dc4d71b304cb3a638d1789641e6e32e86d0c0ace53e07660e",
+      "size": 397686
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_abroad_expedition00/tx_uTex_fl_singlemode_arc_abroad_expedition00_0.diff.png",
+      "hash": "9d7bd634c2f5d895ff074d7d529411d4164abea0b84f6c6ce6f66c8fbb069b13",
+      "size": 391104
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_btn_trainingmenu_ssmatch00/tx_uTex_fl_singlemode_arc_btn_trainingmenu_ssmatch00_0.diff.png",
+      "hash": "363b106bbe5c1bfb510f075c4e3e56e3fc9e38b7478d0c1c5086093d1a975426",
+      "size": 38065
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_event_racebonus00/tx_uTex_fl_singlemode_arc_event_racebonus00_0.diff.png",
+      "hash": "091c11ad1f64acc0f5d35bbb7aac1ffa18fc8c7b03ed77ffb066958456fce3d7",
+      "size": 69623
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_event_stargauge_up00/tx_uTex_fl_singlemode_arc_event_stargauge_up00_0.diff.png",
+      "hash": "b184007834ff016c2cb2299440edca22621adecd74db62d2ab4b246a58ca8c8e",
+      "size": 47485
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_extrarace_result00/tx_uTex_fl_singlemode_arc_extrarace_result00_0.diff.png",
+      "hash": "2411263ca7fc4f8af9e60b7a22b9e13a56baa54e2066061a92958fc9052ae71f",
+      "size": 736269
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_get_response00/tx_uTex_fl_singlemode_arc_get_response00_0.diff.png",
+      "hash": "09a4bc8b05a5bcf95859aea1a779850c500d9f71a0d6579645043691a5669dca",
+      "size": 77675
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_header_turncounter00/tx_uTex_fl_singlemode_arc_header_turncounter00_0.diff.png",
+      "hash": "59bf46c771261f50c135850d45061c03c8981b0ac8c15e9cbcc5d74657697a05",
+      "size": 8822
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_next_target00/tx_uTex_fl_singlemode_arc_next_target00_0.diff.png",
+      "hash": "f0cbae74a3b0d715479889dad25aac1ff010bea62131e8d2be98d2709e9fa322",
+      "size": 98923
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_remind_turn00/tx_uTex_fl_singlemode_arc_remind_turn00_0.diff.png",
+      "hash": "81d4fe8d5bba6d7690d71388fcbb64391ebd23fc821f06aeea4511834b07cea9",
+      "size": 71745
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_speech_bubble00/tx_uTex_fl_singlemode_arc_speech_bubble00_0.diff.png",
+      "hash": "a1bd560cab7438d764d12cfcad9fc0977cbccf22469e5db3364583fc2129fd7f",
+      "size": 49993
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_arc_txt_lvup_response00/tx_uTex_fl_singlemode_arc_txt_lvup_response00_0.diff.png",
+      "hash": "4aaa9fd44476be56f5df08a9f1928299aa1b474ff27c85f6255991ec1f491639",
+      "size": 90565
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_break_resultpoint_record00/tx_uTex_fl_singlemode_break_resultpoint_record00_0.diff.png",
+      "hash": "ae3cbfadecab54d3432fe0fa53555acc4193636b1a2bb46e80124632120f32a2",
+      "size": 129314
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_btn_factor_succession00/tx_uTex_fl_singlemode_btn_factor_succession00_0.diff.png",
+      "hash": "b799c32a0442dcb3bc8541ab92c57e122cd1e2f5288277912913a9dc2bd1731c",
+      "size": 72174
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_btn_trainingmenu00/tx_uTex_fl_singlemode_btn_trainingmenu00_0.diff.png",
+      "hash": "86032b9953786f6cfb855ea5d9021f13e53e71646fbeb7464433ebe881a1c783",
+      "size": 6343
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_btn_trainingmenu01/tx_uTex_fl_singlemode_btn_trainingmenu01_0.diff.png",
+      "hash": "728c99e1772ce65753f875dcf90e4b7b68964e424144f50af2d34512f4884630",
+      "size": 6941
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_badge_garden_reinforcement00/tx_uTex_fl_singlemode_cook_badge_garden_reinforcement00_0.diff.png",
+      "hash": "9c7efaefd8a7c73eafb9f1735deedbb47cbfda279b03ebec48843c616b933090",
+      "size": 2596
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_btn_recommend_dish00/tx_uTex_fl_singlemode_cook_btn_recommend_dish00_0.diff.png",
+      "hash": "ebffd8df07ab7e39733cec5e54111d743b8bd24238ed6450ed765d418a2b19ad",
+      "size": 43378
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_btn_trainingmenu00/tx_uTex_fl_singlemode_cook_btn_trainingmenu00_0.diff.png",
+      "hash": "23c061f4720f5fa3517f396495928e99fde650e2cc9f34cfcae693a991af42bb",
+      "size": 7584
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_care_harvestup00/tx_uTex_fl_singlemode_cook_care_harvestup00_0.diff.png",
+      "hash": "eb03ffb7a49ee9e06fc642ed4c624d0f27ac496b59f03d7a1476d30970cdc25c",
+      "size": 65076
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_care_title00/tx_uTex_fl_singlemode_cook_care_title00_0.diff.png",
+      "hash": "93e7568800fd73d554b026a3ff88bf95e034e60830c743fd1f76e12e0cc7508a",
+      "size": 129986
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_btn_kaien00/tx_uTex_fl_singlemode_cook_event_btn_kaien00_0.diff.png",
+      "hash": "f4d9911d853f643ebd9051d99ec7e62482f4bded699f493017a49ab364dce1ae",
+      "size": 144086
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_dish_add00/tx_uTex_fl_singlemode_cook_event_dish_add00_0.diff.png",
+      "hash": "5f588f7210fae7773a788c1914897d86788a0204813bb4e3cb04ce2e77a5f984",
+      "size": 56590
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_dish_efficacy_up00/tx_uTex_fl_singlemode_cook_event_dish_efficacy_up00_0.diff.png",
+      "hash": "f0b8cc3006031ad5d46036fbf1a4ccef4f233c67f3efd493cb4d6be15a1b94c6",
+      "size": 78432
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_join00/tx_uTex_fl_singlemode_cook_event_join00_0.diff.png",
+      "hash": "4ef9c0dd31e5d4de6e1204d44529040e01440b76901f7ca4ef71a18f8020f75c",
+      "size": 87132
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_uptrainingeffect00/tx_uTex_fl_singlemode_cook_event_uptrainingeffect00_0.diff.png",
+      "hash": "50f94e25f758ac39e0f331fad7edb76bdfebfdab38a8eed24f83f31a71af404c",
+      "size": 71553
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_event_vegetables_lv_maxup00/tx_uTex_fl_singlemode_cook_event_vegetables_lv_maxup00_0.diff.png",
+      "hash": "876eea69d9033d9653d67c7bbff2e93fb3fc582fd736b69d270d5dcbafb6b4ca",
+      "size": 82547
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_get_vegetables00/tx_uTex_fl_singlemode_cook_get_vegetables00_0.diff.png",
+      "hash": "93cebfd8d75f66fef2026fdcd8749df29127504e158e2c3015db4afef731deed",
+      "size": 55212
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_header_turncounter00/tx_uTex_fl_singlemode_cook_header_turncounter00_0.diff.png",
+      "hash": "30aa59df423c5f7fffbcf563a95f4da946ea2b1477bb9fbf0104acaf6882027c",
+      "size": 12131
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_premonition00/tx_uTex_fl_singlemode_cook_premonition00_0.diff.png",
+      "hash": "caffab025719f2ebf64dd2cffb14a4b57474041761b1a83525e7c97f89da83ed",
+      "size": 34065
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_ptup00/tx_uTex_fl_singlemode_cook_ptup00_0.diff.png",
+      "hash": "ca32e307fb270b9a15c91cdf6ea728a7dcccdb9c0b8e673774148ea73e99ec2e",
+      "size": 71959
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_remind_turn00/tx_uTex_fl_singlemode_cook_remind_turn00_0.diff.png",
+      "hash": "1f95c39c90989983b2b2e569a32ddd96042c93a1698d3defc4059e9584cb95f1",
+      "size": 35396
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_training_multiple00/tx_uTex_fl_singlemode_cook_training_multiple00_0.diff.png",
+      "hash": "d046fff5d1e69f8e9c855237fdfe51169c38b451fd9a4346c9910466a5d247f0",
+      "size": 90106
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_txt_harvest00/tx_uTex_fl_singlemode_cook_txt_harvest00_0.diff.png",
+      "hash": "d3e93154305187f8a70d1bf908bbd239b08da4265549254243659ac5b9967990",
+      "size": 90418
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_txt_manzoku00/tx_uTex_fl_singlemode_cook_txt_manzoku00_0.diff.png",
+      "hash": "d9a4063f34319b6ab17f5e4c53d4fe9267b99e4d99aa3e2380ea9e0f2e366049",
+      "size": 187614
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_cook_txt_success00/tx_uTex_fl_singlemode_cook_txt_success00_0.diff.png",
+      "hash": "2d1bc27c43566de28cd049ce8669309261240193dda092eb3f6413f4e2453438",
+      "size": 84181
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_activecondition00/tx_uTex_fl_singlemode_eventbonus_activecondition00_0.diff.png",
+      "hash": "1c04cba14b6677267e4689fc526f8e22342b59e16dbd5a35e2510f7d8a9b1a93",
+      "size": 57734
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_apptraining00/tx_uTex_fl_singlemode_eventbonus_apptraining00_0.diff.png",
+      "hash": "cbf171467ad7790e3cbe2ccf206d00942d9a7d18f13a674d57c753c63fc45cc3",
+      "size": 56087
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_dncondition00/tx_uTex_fl_singlemode_eventbonus_dncondition00_0.diff.png",
+      "hash": "fb20a54dfa04a77d76b4ac6b2b3f449a74a071627cec07e823d7ba8ed0bb5768",
+      "size": 140277
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_dnskill00/tx_uTex_fl_singlemode_eventbonus_dnskill00_0.diff.png",
+      "hash": "5e6c6f40f7b1ab245219da9478b196f5b8e82fc9839fbeb483e64d0a9a6e19ae",
+      "size": 133649
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_racebonus00/tx_uTex_fl_singlemode_eventbonus_racebonus00_0.diff.png",
+      "hash": "766991f1336f8aa149a9491e575225ef696ab5a03068108ba19bc5c0a68bf6cf",
+      "size": 88619
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_resolve_dnskill00/tx_uTex_fl_singlemode_eventbonus_resolve_dnskill00_0.diff.png",
+      "hash": "ff36c633d2168c5eb5819edf649352be298cbccec6ac587f323c10a258ab6eab",
+      "size": 64692
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_resolvecondition00/tx_uTex_fl_singlemode_eventbonus_resolvecondition00_0.diff.png",
+      "hash": "ce39146449e4bb8ac1cc6233e227a3cddf18c5cf872a251f44852c652900a928",
+      "size": 62188
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_succession00/tx_uTex_fl_singlemode_eventbonus_succession00_0.diff.png",
+      "hash": "b7f20dcbd4ced2ac00d488c72c939625991e603a60e0b9a41736a73bd39a6f80",
+      "size": 67292
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_target00/tx_uTex_fl_singlemode_eventbonus_target00_0.diff.png",
+      "hash": "4da0372b1e667666eb589947d60b8cccb3437326ecdd37cc01cc4faf6a41a5a4",
+      "size": 107934
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_upcondition00/tx_uTex_fl_singlemode_eventbonus_upcondition00_0.diff.png",
+      "hash": "a157cc476f38822e0d7d62591d715d2f929c1ebbbe2a2e4423d58c9ff8a78611",
+      "size": 134301
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_upevent00/tx_uTex_fl_singlemode_eventbonus_upevent00_0.diff.png",
+      "hash": "6837083ea3a89438bc232abc176f70ba9e7e67447efa5cc0074c4a0c0c39bd03",
+      "size": 63012
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_uphint00/tx_uTex_fl_singlemode_eventbonus_uphint00_0.diff.png",
+      "hash": "6c70b7d4ea7d69bb8f1242c146bb05824c57d0ea0f3a01526003ebfa67925c3f",
+      "size": 127418
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_eventbonus_upskilllv00/tx_uTex_fl_singlemode_eventbonus_upskilllv00_0.diff.png",
+      "hash": "2ac604fd400777dabae3ed4b9c65f9943e2cf9b2fa0e6acc8bc59a55164fe6df",
+      "size": 134641
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_extrarace_result00/tx_uTex_fl_singlemode_extrarace_result00_0.diff.png",
+      "hash": "d519a00d31a337772b62abf81a0787ccc7d4bd6c00a8485dfc952822b986e9af",
+      "size": 236762
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_free_header_turncounter00/tx_uTex_fl_singlemode_free_header_turncounter00_0.diff.png",
+      "hash": "3b3387744cdf8d27aaae310e7cad0d8ff34e9dd5f367bbcc8b7932a435f21a3b",
+      "size": 2954
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_header_hpgauge00/tx_uTex_fl_singlemode_header_hpgauge00_0.diff.png",
+      "hash": "909a16e7f1a66a4293961563cf0cf5c7580c3a162ae7958dcdcc5fc23b17c2a2",
+      "size": 6489
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_header_turncounter00/tx_uTex_fl_singlemode_header_turncounter00_0.diff.png",
+      "hash": "f7625a08cdca2fac64c884fa95512b93413b9de0a1a779d81cf7fe1dfe38b451",
+      "size": 2585
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_hint00/tx_uTex_fl_singlemode_hint00_0.diff.png",
+      "hash": "789f0e4c3d115bbebc8af1e3c4687ae00bbf69f137ede902b543e3ffd188d3c2",
+      "size": 2630
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_icon_motivation00/tx_uTex_fl_singlemode_icon_motivation00_0.diff.png",
+      "hash": "01552e7cd1e54044df24abb211f190a34631836564d5fcadca0fc4d03f62b95d",
+      "size": 36437
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_btn_trainingmenu00/tx_uTex_fl_singlemode_legend_btn_trainingmenu00_0.diff.png",
+      "hash": "5176e39d76294a90761a7c3cfaecd9721c129c17b995016ceef06085a168f930",
+      "size": 7766
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_buff_get00/tx_uTex_fl_singlemode_legend_buff_get00_0.diff.png",
+      "hash": "2fcfd933eca4f11be431e743cf37cdcf8a36296f6d5405499a83dd49d74048a5",
+      "size": 50782
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_enter_masterly00/tx_uTex_fl_singlemode_legend_enter_masterly00_0.diff.png",
+      "hash": "ce1f19f5bb67bc910aebe9c7366814aa704d7825e5a7fce2ead359c5e089be11",
+      "size": 126546
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_enter_masterly01/tx_uTex_fl_singlemode_legend_enter_masterly01_0.diff.png",
+      "hash": "6017d1013bc89fdfc68ae73fd2133a6832f67b633c2a937a5bc08a8431b3744d",
+      "size": 125789
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_enter_masterly02/tx_uTex_fl_singlemode_legend_enter_masterly02_0.diff.png",
+      "hash": "f07970dc57bedd3d83e2c08f194475a67300c6b4da7992c1a63d1d36e8f4b05c",
+      "size": 150154
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_event_legendappear00/tx_uTex_fl_singlemode_legend_event_legendappear00_0.diff.png",
+      "hash": "4729ed944889126c6bc0e4d386b73a3e20d5938b031bd71ec7f0995eca1eb8b4",
+      "size": 158543
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_eventbonus_upmotivation00/tx_uTex_fl_singlemode_legend_eventbonus_upmotivation00_0.diff.png",
+      "hash": "9480ee3dcdce3863bf7acc93dd7edc676e42de4e1e6def69d7874153471c83ee",
+      "size": 9310
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_extrarace_result00/tx_uTex_fl_singlemode_legend_extrarace_result00_0.diff.png",
+      "hash": "404a89caead0700d28081239331e555d5e8a9d5f729d7e9d962e695782d67bda",
+      "size": 115840
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_extrarace_result00_01/tx_uTex_fl_singlemode_legend_extrarace_result00_01_0.diff.png",
+      "hash": "bf8a8f62db14b408bf4dce6ec456e1b6518e6033a95dcb7310ef1ff804d03de7",
+      "size": 115984
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_extrarace_result00_02/tx_uTex_fl_singlemode_legend_extrarace_result00_02_0.diff.png",
+      "hash": "bed9e681372a694de5dbd64759fafe1b5846d020d038c184ff95b9f6d243c332",
+      "size": 115034
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_header_turncounter00/tx_uTex_fl_singlemode_legend_header_turncounter00_0.diff.png",
+      "hash": "b035645ec77a095d022399f45ce826211abe20b195750eacde65103808837b86",
+      "size": 7442
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_icon_motivation00/tx_uTex_fl_singlemode_legend_icon_motivation00_0.diff.png",
+      "hash": "6a7cf17aab350143ed463a9d7141ac00bda2a14fba367c961e8053f426047d6e",
+      "size": 145007
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_masterly_frame00/tx_uTex_fl_singlemode_legend_masterly_frame00_0.diff.png",
+      "hash": "faefd044afc5bd368a1dfd1852c8da98ed2179e358ee93145c1e67246a0a6167",
+      "size": 28439
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_masterly_frame01/tx_uTex_fl_singlemode_legend_masterly_frame01_0.diff.png",
+      "hash": "b010333da94270e48c6dc361174bba9ce205a85d46df8ebf7abdfd06e9454bf8",
+      "size": 41055
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_masterly_get00/tx_uTex_fl_singlemode_legend_masterly_get00_0.diff.png",
+      "hash": "501b0ade5e35402a8711792e7541c48a5da702de6230197cf0d7e0a78e5839f9",
+      "size": 395112
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_next_target00/tx_uTex_fl_singlemode_legend_next_target00_0.diff.png",
+      "hash": "725ab55fe561da8802d43a3a240a5dac0bbd0368a9324fac43925c705973cd38",
+      "size": 101623
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_remind_turn00/tx_uTex_fl_singlemode_legend_remind_turn00_0.diff.png",
+      "hash": "f7401e1abc43202377ae63e2b036c322f67541fe53f6deea8dbb65035767ee74",
+      "size": 31781
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_legend_txt_buff_available00/tx_uTex_fl_singlemode_legend_txt_buff_available00_0.diff.png",
+      "hash": "95ce7b8ecc54bb9fd2cf9cfbb1fb289a1c1a507380ff5e136cbc075957353b3e",
+      "size": 61153
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_btn_trainingmenu00/tx_uTex_fl_singlemode_live_btn_trainingmenu00_0.diff.png",
+      "hash": "9d41927ea655caff9daff54557b212441b6cf4a779b2b4a918e7ba6aa302ccb5",
+      "size": 6303
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_event_join00/tx_uTex_fl_singlemode_live_event_join00_0.diff.png",
+      "hash": "3b967f3445dba761486314fb08d14cd8866052e20b4bc3472aed617dd7ed259b",
+      "size": 59413
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_event_live_expectations00/tx_uTex_fl_singlemode_live_event_live_expectations00_0.diff.png",
+      "hash": "1775671575ce47774a607cdc3ceadefe49087c2926cb58323e87112f379e5ef7",
+      "size": 323701
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_event_trainingbonus00/tx_uTex_fl_singlemode_live_event_trainingbonus00_0.diff.png",
+      "hash": "0979bc6a1f9a629bcda1fa03aa7a5fa39fbab8ab44990d00c6bdf085a5212f3e",
+      "size": 69163
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_header_turncounter00/tx_uTex_fl_singlemode_live_header_turncounter00_0.diff.png",
+      "hash": "b049518422705700abcb3b1aeed5502ec560832bafc191852c47923bdf1cf1df",
+      "size": 8746
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_remind_turn00/tx_uTex_fl_singlemode_live_remind_turn00_0.diff.png",
+      "hash": "c673180b14347050c0b5241bc47ef22208baa5d8b011823c89becbe40b15daf8",
+      "size": 63583
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_txt_get_livetech00/tx_uTex_fl_singlemode_live_txt_get_livetech00_0.diff.png",
+      "hash": "2ba54c10e5d013e6b41282ced1c5e6b4b2117774d2edcc9108c87eabfc8e1b37",
+      "size": 307142
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_live_txt_get_music00/tx_uTex_fl_singlemode_live_txt_get_music00_0.diff.png",
+      "hash": "22c8cbf2ea18fe4d4169208f7481c572d3c01e42834f0955ea39e0c7bf68c7e2",
+      "size": 81269
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_btn_overdrive00/tx_uTex_fl_singlemode_mecha_btn_overdrive00_0.diff.png",
+      "hash": "cf3fdf849f85d1b69a1b139d2dbe790fe46fb5a65ee1984b90ea8324ad5bd096",
+      "size": 61140
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_btn_trainingmenu00/tx_uTex_fl_singlemode_mecha_btn_trainingmenu00_0.diff.png",
+      "hash": "577b6a361308e529bf24dc3970dd3291bbea5261dcdd1d6d7e701e0ab3f5596b",
+      "size": 7934
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_event_join00/tx_uTex_fl_singlemode_mecha_event_join00_0.diff.png",
+      "hash": "64048eda95a3e2f9ff8cdd7cf3ba867636541c88a628b5cb2f7736a918036c80",
+      "size": 84587
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_event_uptrainingeffect00/tx_uTex_fl_singlemode_mecha_event_uptrainingeffect00_0.diff.png",
+      "hash": "c4f982641880719858271fc9a40cb88b86d59ff6f560609c1855f30f2abf3294",
+      "size": 110255
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_header_hpgauge00/tx_uTex_fl_singlemode_mecha_header_hpgauge00_0.diff.png",
+      "hash": "972e0c36a102bba6fc391fa7d506b82eeb128214ec01e227eae4498eb37e4090",
+      "size": 11260
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_header_turncounter00/tx_uTex_fl_singlemode_mecha_header_turncounter00_0.diff.png",
+      "hash": "2ffb6444b2e7846fc957cd29475615e955bb930efbc1e6eafec050fe1b7cc687",
+      "size": 8820
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_overdrive_recovery00/tx_uTex_fl_singlemode_mecha_overdrive_recovery00_0.diff.png",
+      "hash": "60517f2f5a6910902d3cb5421dddbff44f0983fc1c1d0b4a579afec8937145fe",
+      "size": 227369
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_overdrive_text00/tx_uTex_fl_singlemode_mecha_overdrive_text00_0.diff.png",
+      "hash": "4e43fd2fce7313c6d045700024d1b1cc1ba06452b5c8d1db4ed1dc88489162b7",
+      "size": 867422
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_remind_turn00/tx_uTex_fl_singlemode_mecha_remind_turn00_0.diff.png",
+      "hash": "cf839daa6cf398bc4ffbca5ae41a0feda38363530d24869346e78cc5b66d3da2",
+      "size": 34370
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_research_lv_maxup00/tx_uTex_fl_singlemode_mecha_research_lv_maxup00_0.diff.png",
+      "hash": "436c4eb7696bfef35cc650988e661270fc3a36317078ed3aacd50812e26e9cec",
+      "size": 94698
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_research_progress00/tx_uTex_fl_singlemode_mecha_research_progress00_0.diff.png",
+      "hash": "6f00556b377b8bdc7076b6f3d57d232ee9c989b5df7f479f1a3b305c31e1e90c",
+      "size": 81661
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_research_progress_text00/tx_uTex_fl_singlemode_mecha_research_progress_text00_0.diff.png",
+      "hash": "d764ed9d151e5ae2f356b0ffc36528176d366b8f268c6d5df874d31b2d80102a",
+      "size": 255070
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_sp_overdrive_activation00/tx_uTex_fl_singlemode_mecha_sp_overdrive_activation00_0.diff.png",
+      "hash": "0482743bbbd0ffbced3df17d497288427ff6b9829c79283a32746914ae5fdbf6",
+      "size": 500687
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_sp_overdrive_btn00/tx_uTex_fl_singlemode_mecha_sp_overdrive_btn00_0.diff.png",
+      "hash": "cff550e14d1823f167aff26de76212e7e852174b3ad76a7d9182229032b6b127",
+      "size": 344130
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_sp_overdrive_continuation00/tx_uTex_fl_singlemode_mecha_sp_overdrive_continuation00_0.diff.png",
+      "hash": "e272f86033ade82ec6bac0a67ab8207ae86de69479ed0e82ab975a6689977710",
+      "size": 53690
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_target_research_level00/tx_uTex_fl_singlemode_mecha_target_research_level00_0.diff.png",
+      "hash": "2c9d82dc871c90ed861a3f99ccdebb9cdf1edd24b22f5fc31bd5e28540113d1a",
+      "size": 28511
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_trainingmenu_base00/tx_uTex_fl_singlemode_mecha_trainingmenu_base00_0.diff.png",
+      "hash": "597708d677ccd024728834ac91fd43bacbdefe34cc98030d9d8285c8b8f0fca5",
+      "size": 15393
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_tuning_text00/tx_uTex_fl_singlemode_mecha_tuning_text00_0.diff.png",
+      "hash": "f4e3b18e3e53602b5850c00e8e7934c1667a4dd7625dc17f87d8fae1a0542f44",
+      "size": 577260
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_tuning_transition00/tx_uTex_fl_singlemode_mecha_tuning_transition00_0.diff.png",
+      "hash": "bea3f57d5c667718383318c387c55d89386218550f3c74472755eeed1a5e8319",
+      "size": 212319
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_txt_upgraderesult00/tx_uTex_fl_singlemode_mecha_txt_upgraderesult00_0.diff.png",
+      "hash": "7734f00a0eb26429e5f27f6f906d4b2d215a12beb50ab5302094ed2a4182bbba",
+      "size": 419707
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_upgradeexam_btn00/tx_uTex_fl_singlemode_mecha_upgradeexam_btn00_0.diff.png",
+      "hash": "fe86d934a7b886f953c5e786eb209e26b0d8485ce27177c76aab9cdd38ddf8ad",
+      "size": 76652
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_mecha_upgradeexam_start00/tx_uTex_fl_singlemode_mecha_upgradeexam_start00_0.diff.png",
+      "hash": "ebbfd7ab512626dfd4d6e91f536b52cd76a7866234fd366465bc1ade71aa7ca8",
+      "size": 71175
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_next_target00/tx_uTex_fl_singlemode_next_target00_0.diff.png",
+      "hash": "fef55939d571ed3176f2d1c536a2a1f50078a7dba015562808f0ac085ecfcb9a",
+      "size": 94746
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_btn_evaluate_decide00/tx_uTex_fl_singlemode_pioneer_btn_evaluate_decide00_0.diff.png",
+      "hash": "b967ad99ce21eb8009f97790d849e1fb868dc6d5c6442d1ad03d9c1bc1a8c888",
+      "size": 75752
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_btn_trainingmenu01/tx_uTex_fl_singlemode_pioneer_btn_trainingmenu01_0.diff.png",
+      "hash": "2a8930e1de102e95afd943ea1d6417e2e2ba828243542a2671e8998e6468f763",
+      "size": 10575
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_btn_trainingmenu_shima00/tx_uTex_fl_singlemode_pioneer_btn_trainingmenu_shima00_0.diff.png",
+      "hash": "16d6add486996fb9aae0bdd5b071c8ad8d6d5795c44b4f5077d4db78a2946345",
+      "size": 16772
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_construction_progress00/tx_uTex_fl_singlemode_pioneer_construction_progress00_0.diff.png",
+      "hash": "2e79b1853d6548c43587ea9f0085a28eabc9faa207d5d42018db1312935698fb",
+      "size": 98202
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_construction_progress_text00/tx_uTex_fl_singlemode_pioneer_construction_progress_text00_0.diff.png",
+      "hash": "ff72fc7b7da48097a10d15b5260611d47586e6965642303d63bb3af608cd27b1",
+      "size": 194495
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_evaluate_start00/tx_uTex_fl_singlemode_pioneer_evaluate_start00_0.diff.png",
+      "hash": "fd6d93f6e799eba760bb69cbbb4c452167fb9df8fc9d2a57d682983eb9e31e6c",
+      "size": 103613
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_evaluate_start01/tx_uTex_fl_singlemode_pioneer_evaluate_start01_0.diff.png",
+      "hash": "1390c7538bb19855326c6eeef843608e4a476930d5991464cfcf1da089df7c5f",
+      "size": 70898
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_event_join00/tx_uTex_fl_singlemode_pioneer_event_join00_0.diff.png",
+      "hash": "f781a32fba451d3af4b87646bb699234b3cb65538e08e5839f438d3de74a5bec",
+      "size": 98924
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_gauge_shimatraining00/tx_uTex_fl_singlemode_pioneer_gauge_shimatraining00_0.diff.png",
+      "hash": "bea05b9f57267759f135abd81f696066aa206f2d2a6083a8efd54911701e06b2",
+      "size": 6184
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_complete00/tx_uTex_fl_singlemode_pioneer_island_complete00_0.diff.png",
+      "hash": "2acee396a0cc0d3b65d2c6f641d4d43323364a06187c27b5c9fa752f38cc8061",
+      "size": 165694
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_complete01/tx_uTex_fl_singlemode_pioneer_island_complete01_0.diff.png",
+      "hash": "1d06418b2543944563daa51ba7c90326cb430ec169d0b6fc6eafd532b721df54",
+      "size": 220394
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_hint00/tx_uTex_fl_singlemode_pioneer_island_hint00_0.diff.png",
+      "hash": "5c71198593d8a9748ce1aefd01115b90a28c22a88207abce35fe992fe3f145c1",
+      "size": 2995
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_transition_logo00/tx_uTex_fl_singlemode_pioneer_island_transition_logo00_0.diff.png",
+      "hash": "5609e5bd1ea376e31b6c8297e884426ad8164256b32443294783dba06d94a421",
+      "size": 89771
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_island_transition_logo01/tx_uTex_fl_singlemode_pioneer_island_transition_logo01_0.diff.png",
+      "hash": "ea62eebb240826152c2319eca199125e9c741895a9d424e67265314ebe7a361a",
+      "size": 96554
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_notice_window00/tx_uTex_fl_singlemode_pioneer_notice_window00_0.diff.png",
+      "hash": "d6618e1d867b8fd0b8650d148f6862ffee4674807c664da0994c5e5b13c180f8",
+      "size": 118207
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_planning_island00/tx_uTex_fl_singlemode_pioneer_planning_island00_0.diff.png",
+      "hash": "16f72fbaa464cfe236022d18a5ebf2bf7f09818746201465f8a505e9621fa7b4",
+      "size": 24982
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_remind_turn00/tx_uTex_fl_singlemode_pioneer_remind_turn00_0.diff.png",
+      "hash": "d748bafae6b93ed73338f4afd840846e4d49e4f79c8f00981943496266627817",
+      "size": 24570
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_shimatraining_acquire00/tx_uTex_fl_singlemode_pioneer_shimatraining_acquire00_0.diff.png",
+      "hash": "c51925d5ad803f7251455ff450d0051dec27237d82ba0c38d04e8b0848c12b4e",
+      "size": 51517
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_shimatraining_period00/tx_uTex_fl_singlemode_pioneer_shimatraining_period00_0.diff.png",
+      "hash": "c80544813892e33ecd95a660aa755509c2f6b92865658ad0d3c0e8e7f8cf176a",
+      "size": 60185
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_shimatraining_split00/tx_uTex_fl_singlemode_pioneer_shimatraining_split00_0.diff.png",
+      "hash": "4d83a70bdb3c52322115daa5ed92152548a6b397acdeb77a312e0d19768c2111",
+      "size": 102049
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_start_tagtraining00/tx_uTex_fl_singlemode_pioneer_start_tagtraining00_0.diff.png",
+      "hash": "2f3cf3d477a663a0aac52af886dd0303ec6daa9e949f9f9ea37350e22e08f475",
+      "size": 126506
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_training_facility_upgrade00/tx_uTex_fl_singlemode_pioneer_training_facility_upgrade00_0.diff.png",
+      "hash": "a8d89ba6c5ac08d8789e23495e2203f0b1d2f0cd601c35428a84c2de3a145615",
+      "size": 57768
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_trainingmenu_base00/tx_uTex_fl_singlemode_pioneer_trainingmenu_base00_0.diff.png",
+      "hash": "dc9dcc2ccd7e0af312d4e32262cc0d5c28edb369c1bb447916e597560660174e",
+      "size": 46821
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_txt_evaluateresult00/tx_uTex_fl_singlemode_pioneer_txt_evaluateresult00_0.diff.png",
+      "hash": "5318c8f6243636fc21502f59ed82c25b800d5405b596f7f4c2e587f37c6da920",
+      "size": 709729
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_txt_shimatraining00/tx_uTex_fl_singlemode_pioneer_txt_shimatraining00_0.diff.png",
+      "hash": "78c103944209477362aa44ce937c244092b03346b8b1c3c1823970f5cabfb2ef",
+      "size": 64397
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_pioneer_txt_tagtrainingresult00/tx_uTex_fl_singlemode_pioneer_txt_tagtrainingresult00_0.diff.png",
+      "hash": "34c7e599cee390dd5da26d0c608e5c59d27a42b32c6abccf8e33e63ef537b1c6",
+      "size": 325729
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_result_chararank00/tx_uTex_fl_singlemode_result_chararank00_0.diff.png",
+      "hash": "51b577209ab256a969d88e98a3d38163b29a62d917e82ba7c707004d0bcccccc",
+      "size": 19425
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_result_scenariorecord00/tx_uTex_fl_singlemode_result_scenariorecord00_0.diff.png",
+      "hash": "62629c34cac8770a438f2c8980fbeb16faf5dde524ed6de2928a8ed64f80ab58",
+      "size": 289609
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sectionstart01/tx_uTex_fl_singlemode_sectionstart01_0.diff.png",
+      "hash": "faa31e9ca7165414ba2fb61f02a6bbef2bd049d3c6eee6571771d397dc9399f8",
+      "size": 53744
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_single_target_achieve00/tx_uTex_fl_singlemode_single_target_achieve00_0.diff.png",
+      "hash": "5017a84ef911c828b431acb8dc8744f65914f2860dd5c0b8f3e6cc40880043c6",
+      "size": 75467
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_skillupgrade_skillname00/tx_uTex_fl_singlemode_skillupgrade_skillname00_0.diff.png",
+      "hash": "bc18517c528415d9d58a6aa7ab7b0db328e143b21fc66d64e19ed1e7012023d5",
+      "size": 208459
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_btn_competition_decide00/tx_uTex_fl_singlemode_sport_btn_competition_decide00_0.diff.png",
+      "hash": "cf931c223c51a41af1d6c6b885bbad59ad1c28b5ca9e739b0fa0a7450b378fb6",
+      "size": 81183
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_btn_trainingmenu00/tx_uTex_fl_singlemode_sport_btn_trainingmenu00_0.diff.png",
+      "hash": "9f82411517ad5dfa0a148833e5f360af759f1be0ead64d25456309258f4e6ba3",
+      "size": 10855
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_competition_gauge00/tx_uTex_fl_singlemode_sport_competition_gauge00_0.diff.png",
+      "hash": "fc4f3cf25809a8fd19e54c32c37b8603e9daba1e7581f187a258728c13fd22f4",
+      "size": 92973
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_competition_telop00/tx_uTex_fl_singlemode_sport_competition_telop00_0.diff.png",
+      "hash": "311c5f78cfc05aaddee21eada63a4b534a2c3a1e40d495fafaf29beb6c5e20cc",
+      "size": 10829
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_event_advice00/tx_uTex_fl_singlemode_sport_event_advice00_0.diff.png",
+      "hash": "ba631325fb9d5fc8e16f4acae960c3d47273d33cf64d07436b657201a639538a",
+      "size": 49662
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_event_stance_rankup00/tx_uTex_fl_singlemode_sport_event_stance_rankup00_0.diff.png",
+      "hash": "cfc4e18b4c0c718c4c61abb8502ab0a1e794e0eec29256eccd171729e67a9249",
+      "size": 62167
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_header_turncounter00/tx_uTex_fl_singlemode_sport_header_turncounter00_0.diff.png",
+      "hash": "9e7322cd81d44b0a7a6f08f924566dcb3fab314e5c3f4f901957f7b9a39773a6",
+      "size": 10184
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_remind_turn00/tx_uTex_fl_singlemode_sport_remind_turn00_0.diff.png",
+      "hash": "6c9df71503ea623b9fa3a9574deb234c2358dda3b554e4cd4c100577dc53f974",
+      "size": 58579
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_showdown_result00/tx_uTex_fl_singlemode_sport_showdown_result00_0.diff.png",
+      "hash": "9ecacd97a619fe6f5d9d47f4fdd5e664d25faf583a6ec178a5a015d7489d989a",
+      "size": 177654
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_trainingmenu_base00/tx_uTex_fl_singlemode_sport_trainingmenu_base00_0.diff.png",
+      "hash": "a45097bf9e53e8b8ba4b0bfface4b5a81e04d93224689020a5bda116be2a9cdf",
+      "size": 15690
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_competitionend00/tx_uTex_fl_singlemode_sport_txt_competitionend00_0.diff.png",
+      "hash": "3c875732077c41e146e5f066976d4c333be2161b689b2e557b02f93cf3eb81d6",
+      "size": 61099
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_heatup00/tx_uTex_fl_singlemode_sport_txt_heatup00_0.diff.png",
+      "hash": "799bd2e14916b45b53d4ed064dde93d4c1ed51750c612229faeac437beb0f8ac",
+      "size": 37496
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_tagtrainingresult00/tx_uTex_fl_singlemode_sport_txt_tagtrainingresult00_0.diff.png",
+      "hash": "08be52384adf917150d94af362d7717f8ce9df4ba26228a7daf8d684b32283da",
+      "size": 215640
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_sport_txt_trainingresult00/tx_uTex_fl_singlemode_sport_txt_trainingresult00_0.diff.png",
+      "hash": "bd9d3599a33350a7a49fc236dd3537c10aee85c6bf8326d717c6d024a791cdbd",
+      "size": 182748
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_start_succession00/tx_uTex_fl_singlemode_start_succession00_0.diff.png",
+      "hash": "0bf87054fdeb8dd4615a037b2a99e71ec3a82a7bf1c47912e23932d4e81401e5",
+      "size": 69688
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_start_tagtraining00/tx_uTex_fl_singlemode_start_tagtraining00_0.diff.png",
+      "hash": "c6d68b041e417f5db1ce85719184a7ef3247718834e3db4df1e00207f90737a8",
+      "size": 99789
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_target_decision00/tx_uTex_fl_singlemode_target_decision00_0.diff.png",
+      "hash": "596469e902f3e063a02a501625600c9208e13791b51d74da63723ec682504de7",
+      "size": 45444
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_teamrace_btn_trainingmenu00/tx_uTex_fl_singlemode_teamrace_btn_trainingmenu00_0.diff.png",
+      "hash": "2af8b0e21fabe982b30d2cf8670977851ceb5ab04fe30edc53087935db5d5838",
+      "size": 6418
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_teamrace_header_turncounter00/tx_uTex_fl_singlemode_teamrace_header_turncounter00_0.diff.png",
+      "hash": "b6a8cbd2c6f4c71ab97e1f07c192225a847fa2ea67218e54614176e3171c3dc0",
+      "size": 8837
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_title_getfactor00/tx_uTex_fl_singlemode_title_getfactor00_0.diff.png",
+      "hash": "03ebc06fedbc9eaea38fd102133e027f2b9e0ed0ed65d2e7039a94b53a872f84",
+      "size": 80436
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_title_getreward00/tx_uTex_fl_singlemode_title_getreward00_0.diff.png",
+      "hash": "15e49802eb915c9634071fb7f0694e6c4d4a951d7e759dcdfe4d0c68f2845cf3",
+      "size": 67574
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_auto_training00/tx_uTex_fl_singlemode_txt_auto_training00_0.diff.png",
+      "hash": "394de1d314eabe97f0d675eaa68753965d5d3cff4e2e115e69d405e44c93bf33",
+      "size": 17819
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_factor_succession00/tx_uTex_fl_singlemode_txt_factor_succession00_0.diff.png",
+      "hash": "0a56990c45f9eae5a52b66104a4c74667b7a1535a06bce750352eda9826b5b7e",
+      "size": 91713
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_tagtrainingresult00/tx_uTex_fl_singlemode_txt_tagtrainingresult00_0.diff.png",
+      "hash": "b7766191b5b29e59928256eb01a6061747be7ee57fb2ef7fd96de2587c3d1eec",
+      "size": 225445
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_txt_trainingresult00/tx_uTex_fl_singlemode_txt_trainingresult00_0.diff.png",
+      "hash": "b3046e2c92425bc6a44f644f11fbadb4d8536ff47da17fad3fdb42e71c01762f",
+      "size": 118546
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_acquire_spirit00/tx_uTex_fl_singlemode_venus_acquire_spirit00_0.diff.png",
+      "hash": "5a5c32d54807495c1bb0205664e75d9670f3fb453f9ed4c82816cd81054218b3",
+      "size": 351909
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_btn_trainingmenu00/tx_uTex_fl_singlemode_venus_btn_trainingmenu00_0.diff.png",
+      "hash": "86032b9953786f6cfb855ea5d9021f13e53e71646fbeb7464433ebe881a1c783",
+      "size": 6343
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_enabletagtraining00/tx_uTex_fl_singlemode_venus_event_enabletagtraining00_0.diff.png",
+      "hash": "1feaeec3aca752008fc00a58c00c30d3cc36a7279e033cc3390f6b02341252a9",
+      "size": 78180
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_upeventrate00/tx_uTex_fl_singlemode_venus_event_upeventrate00_0.diff.png",
+      "hash": "5d1cca8c816554c929a0bf99f86d2c2171e208d8a95ec269783db253cc4b4a93",
+      "size": 85907
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_upknowledgelv00/tx_uTex_fl_singlemode_venus_event_upknowledgelv00_0.diff.png",
+      "hash": "83c590a2307cebd2582f1b821851c9cd5dfc46f74ecfeee576dfbac16bac3c7e",
+      "size": 39013
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_upskillhinteventeffect00/tx_uTex_fl_singlemode_venus_event_upskillhinteventeffect00_0.diff.png",
+      "hash": "7dcb62976405ae58a388b69179f4067810e14da3ba9631b92e99a233320bd358",
+      "size": 60363
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_uptrainingeffect00/tx_uTex_fl_singlemode_venus_event_uptrainingeffect00_0.diff.png",
+      "hash": "3198a3515fd5e58555ddb887c4730922ce4f0a1704a0625dcae3014dc6d2bdec",
+      "size": 74824
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_event_venusappear00/tx_uTex_fl_singlemode_venus_event_venusappear00_0.diff.png",
+      "hash": "3fe53b9804ca2de39fc43e87b77974b6daaac0c417b1486b6ed5e341a9ed02cc",
+      "size": 157888
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_get_spirit00/tx_uTex_fl_singlemode_venus_get_spirit00_0.diff.png",
+      "hash": "6f446588c5c7f701b5d7b605bfa8f043b9f606e44574ada4ae9edcda41d79b37",
+      "size": 73925
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_get_venus_spirit00/tx_uTex_fl_singlemode_venus_get_venus_spirit00_0.diff.png",
+      "hash": "38f08e4f3c83e97fc613ef9e9d3183fa710e06258112b0dcdc64561e3a956970",
+      "size": 221672
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_header_turncounter00/tx_uTex_fl_singlemode_venus_header_turncounter00_0.diff.png",
+      "hash": "8a43ffaedd8fc23bc1ce8090819b258d743dee59c587a45da4c94e2090918f47",
+      "size": 7843
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_remind_turn00/tx_uTex_fl_singlemode_venus_remind_turn00_0.diff.png",
+      "hash": "853e3a7f41065c1343cd6d55ba320ecb387226e4f79e729962cb79dc2f6c55d7",
+      "size": 28868
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_spirittree00/tx_uTex_fl_singlemode_venus_spirittree00_0.diff.png",
+      "hash": "5838271c22c53ebb72dc82516c1ad537efb27515c8f70ad4bd8de07d84d19fa2",
+      "size": 36980
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_txt_tagtrainingresult00/tx_uTex_fl_singlemode_venus_txt_tagtrainingresult00_0.diff.png",
+      "hash": "65bbdaf672def4e14d88d8a721c06c3fdf019121761a9fef97d03f8fc4b83130",
+      "size": 241779
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_singlemode_venus_txt_trainingresult00/tx_uTex_fl_singlemode_venus_txt_trainingresult00_0.diff.png",
+      "hash": "ab48ddd191317c042619b12755c037a6a246bfe461d9d85083e15eb11678f3a8",
+      "size": 101550
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_team_icon_winconfirm00/tx_uTex_fl_team_icon_winconfirm00_0.diff.png",
+      "hash": "df2653b2957139376271d32d19abf8e2b131d1bdc925a3d92e5ae2ff3efc3456",
+      "size": 17489
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_team_txt_winning_reward00/tx_uTex_fl_team_txt_winning_reward00_0.diff.png",
+      "hash": "18686a3bb4b77bb45bd537bffb565dd8e6baaf17b55ef29c1bdecac2f6b2b2dd",
+      "size": 134533
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_trainingreport_reward00/tx_uTex_fl_trainingreport_reward00_0.png",
+      "hash": "efc464756bcd3e3caca7b3f1480124d1ffaa98f214cf1c373ed6999f202024ad",
+      "size": 101832
+    },
+    {
+      "path": "assets/an_texture_sets/as_uMeshParam_fl_transfer_txt_negotiation00/tx_uTex_fl_transfer_txt_negotiation00_0.diff.png",
+      "hash": "dea566a4b63ac316e1727fa9ddf588a5161ab9d6da2475dd5a8660ca9a28ec55",
+      "size": 100782
+    },
+    {
+      "path": "assets/atlas/campaign/campaign.diff.png",
+      "hash": "d14a087abaf2dbe4741fa0f5ebc3ad48ef9fc3edbcf1249e3775caf370c95e18",
+      "size": 107733
+    },
+    {
+      "path": "assets/atlas/campaign/campaign.json",
+      "hash": "b7b97f3a8002eda0a5c597ac8c1fe47987be3d89c65c17151dcf9af12cd0855f",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/challengematch/challengematch.diff.png",
+      "hash": "c3ce185aad28a50bc6e01ca53edc28cef0292796970917ba2a05af260677c059",
+      "size": 182265
+    },
+    {
+      "path": "assets/atlas/challengematch/challengematch.json",
+      "hash": "ec68afef58d7eb66958d784f00213a20aa2b7342b1449a0cdc6595331e15d294",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/championsmeeting/championsmeeting.diff.png",
+      "hash": "120759ec6305bb95c912d6cb7e29cfc3dcade15ce6d161d2ed10949050985625",
+      "size": 1325416
+    },
+    {
+      "path": "assets/atlas/championsmeeting/championsmeeting.json",
+      "hash": "35f22a63abe0524fed5d21cbff42c32c774759a00f4655e4eed57f45123a322b",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/common/common.diff.png",
+      "hash": "90dc7df0efd7328c708a5087eee3a75521721f6f171c31b15d572d55945853ed",
+      "size": 418883
+    },
+    {
+      "path": "assets/atlas/common/common.json",
+      "hash": "5dbee5a0bb1e9652abe613bd9433442bc6aae185958c36c3e3a1ea3d785bfc76",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/factorresearch/factorresearch.diff.png",
+      "hash": "6a700ff1cf61a7824b1f21eda2bcef3489f39d328b8bf81738222634cd8fff2d",
+      "size": 47640
+    },
+    {
+      "path": "assets/atlas/factorresearch/factorresearch.json",
+      "hash": "6ca0b2d4a814f631afc5d621d24d93c8e13dd22ee584a73235926b1e12c85ce3",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/gacha/gacha.diff.png",
+      "hash": "316ff269f8a82544df13f13da8dff3e16e9bef6c2c5aefce85b8c746ddcfe477",
+      "size": 530647
+    },
+    {
+      "path": "assets/atlas/gacha/gacha.json",
+      "hash": "54a7e8321366257d15091d2718aecaef457a8eebe6fcaa32911f08cb81146904",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/heroes/heroes.diff.png",
+      "hash": "028348e544a11ebed253d7738270c6710e351f898d11ec88acf668319331f63f",
+      "size": 696284
+    },
+    {
+      "path": "assets/atlas/heroes/heroes.json",
+      "hash": "2719df38733c986eaa030942340167100c52c16094fdacd458b97da233b1bb86",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/home/home.diff.png",
+      "hash": "714a510c1c0399d55f1c1dc18dfcdb222fb2ab4425570e4fe4e398bccb088f9f",
+      "size": 141323
+    },
+    {
+      "path": "assets/atlas/home/home.json",
+      "hash": "32d8305bcb6e55fe9ec4640b941c93654ddb2099f09951ba1806dad4481cf5bd",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/mission/mission.diff.png",
+      "hash": "36fb0386f3f56725bfc59994f846fc8720e08e9be7a3a028fdeea6f5d35a44ea",
+      "size": 12672
+    },
+    {
+      "path": "assets/atlas/mission/mission.json",
+      "hash": "4da1e5aa54099ca8194f8f73a339869a24d453b1b5476ca9040c2947f2c74f48",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/photostudio/photostudio.diff.png",
+      "hash": "7e7b0ec37c62e52d0aec6c34bb9ab0dae45eed0ba0fcddfa3842cdfabee314ec",
+      "size": 7521
+    },
+    {
+      "path": "assets/atlas/photostudio/photostudio.json",
+      "hash": "bb0e702d18e3a0aeb6694ed122b5746e4dcebfe3d7f1b1094f45206824703403",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/practicerace/practicerace.diff.png",
+      "hash": "95eb03d85c8f1d39627b4a202fa1a0a4e8fbc0b7f2791756b4695a5723dbd948",
+      "size": 33416
+    },
+    {
+      "path": "assets/atlas/practicerace/practicerace.json",
+      "hash": "bfcd1f8589cde8cbef297ce41f34a009e07c4098058fa8180aee63a24670c7a2",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/race/race.diff.png",
+      "hash": "505008314ddfc36f03173f5458382e85400dd03ec17d94455e8562e454339870",
+      "size": 374921
+    },
+    {
+      "path": "assets/atlas/race/race.json",
+      "hash": "ddff08b743744230f9b19e38336832ada6afbdee0a7edc3d39ac3bbae65d5039",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/racecommon/racecommon.diff.png",
+      "hash": "ba7831d3ed2e6449c1ab0751ecfdecdc22875c999c48bb9088dc7ef2d5efd66a",
+      "size": 77088
+    },
+    {
+      "path": "assets/atlas/racecommon/racecommon.json",
+      "hash": "7f18ecf6ca4c3e6d46fdcb0d394526db622872630bb4e9ea53f796ee91f8297d",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/raceorder/raceorder.json",
+      "hash": "1c9a57cff67b0a7fb1fcb2f596601b54f786567f3d304a341d0560922547891f",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/raceorder/raceorder.png",
+      "hash": "930ac3f776e6a9b7b0b55526bcef53d2e4a0085a6fb94b6a7f3776ba501ebf8a",
+      "size": 649347
+    },
+    {
+      "path": "assets/atlas/roommatch/roommatch.diff.png",
+      "hash": "7a4439168e7678636dbbd5c3528ac0def3f39380075bde2edf8668ea5497e26e",
+      "size": 74885
+    },
+    {
+      "path": "assets/atlas/roommatch/roommatch.json",
+      "hash": "04ce0fb2e9190d335ab63739598beae90552919a4e21207c535f6ed02306455b",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/schedulebook/schedulebook.diff.png",
+      "hash": "c86d44176f3b1dfc241b7b6e76986d04a967ff9cf829a0bbdf49ca5621cef60c",
+      "size": 16700
+    },
+    {
+      "path": "assets/atlas/schedulebook/schedulebook.json",
+      "hash": "dc22d9a58a21dbcbdfbca2533a5014b3aa0dae5036798dd8fb2444f84c5d9678",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/single/single.diff.png",
+      "hash": "1167fe790e7da6af03c43510f5c378c3435f82e432c77284715677d6418cc158",
+      "size": 152194
+    },
+    {
+      "path": "assets/atlas/single/single.json",
+      "hash": "b6702d06015a0e9b52f15e3e8ab3dd468646c2216ee55d9b74a3502d719a6eb9",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenarioarc/singlemodescenarioarc.diff.png",
+      "hash": "dcca72aa950fa7d0879476348d180572eca05ab07a1a736230ff60ad83650ce1",
+      "size": 227861
+    },
+    {
+      "path": "assets/atlas/singlemodescenarioarc/singlemodescenarioarc.json",
+      "hash": "ca0818e2a2b7337bc8d47b5fbda9de25da759f458183da52126aa56e4cf4b75f",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariocook/singlemodescenariocook.diff.png",
+      "hash": "2cab1da13661442dbcca628d8103471fb2cd352bd0638f3e258c0b6217c273d2",
+      "size": 334681
+    },
+    {
+      "path": "assets/atlas/singlemodescenariocook/singlemodescenariocook.json",
+      "hash": "c9863c493c03c4665a0dea37ab4e3bd1765fc1ce812efcbad219197fe64d5f23",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariofree/singlemodescenariofree.diff.png",
+      "hash": "fa974d73d7aa2c052931e9490a6a65edf3935bdf77fc43f6b809c1bb76bd7e4a",
+      "size": 404901
+    },
+    {
+      "path": "assets/atlas/singlemodescenariofree/singlemodescenariofree.json",
+      "hash": "70bdd7f015966f28850173aad48a331780fab993f4ce4f554874160052eedc37",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariolegend/singlemodescenariolegend.diff.png",
+      "hash": "aa01704a2b459441942521a9b05ae86508de7d7454fdd3340dbdb73aee6a52b8",
+      "size": 56892
+    },
+    {
+      "path": "assets/atlas/singlemodescenariolegend/singlemodescenariolegend.json",
+      "hash": "0a16bba8e48cdde765f368277620887a1b7d8fe45ea069304e36e2dae51c4e16",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariolive/singlemodescenariolive.diff.png",
+      "hash": "9c049ad7cbe020fa040354af8816872a8f2060ec287abddaf2e6f0040bf78c03",
+      "size": 324007
+    },
+    {
+      "path": "assets/atlas/singlemodescenariolive/singlemodescenariolive.json",
+      "hash": "9c845bbcc4379542826aa405315c4ff22f0500b6260eb1dcb6ad37c06783b358",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariomecha/singlemodescenariomecha.diff.png",
+      "hash": "17556c52aaf17292df3f4a5c1a9392b3174bdd7a7a772c3d2048e4be23921f3b",
+      "size": 110937
+    },
+    {
+      "path": "assets/atlas/singlemodescenariomecha/singlemodescenariomecha.json",
+      "hash": "60de387c674b44eb4f60951c297c19e5023e29275e5749f463b27c205fde2ae2",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariopioneer/singlemodescenariopioneer.diff.png",
+      "hash": "1cbbdf9a59d12a52655287e861e2569babf0aeefc540031493bfbedf43627b8f",
+      "size": 398743
+    },
+    {
+      "path": "assets/atlas/singlemodescenariopioneer/singlemodescenariopioneer.json",
+      "hash": "bfaeaf69bd4fa5c57c740f68e1dc0e2391cc94a002a210861ee63ec8965516de",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariopioneerfacilityicon/singlemodescenariopioneerfacilityicon.diff.png",
+      "hash": "ab77b72cc68446baf9d9b6e8052985f900e8621879945968559c783a9bb8e123",
+      "size": 18444
+    },
+    {
+      "path": "assets/atlas/singlemodescenariopioneerfacilityicon/singlemodescenariopioneerfacilityicon.json",
+      "hash": "c7c9d6e047aeab4a488ea9d2ce995c4211e3089cbcdd5166a6fcbf82350127bb",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariosport/singlemodescenariosport.diff.png",
+      "hash": "152f44cbfba4a5bd9c8cdcd78aec18b5d58f258f841b8cc31ace0ae177fad368",
+      "size": 129828
+    },
+    {
+      "path": "assets/atlas/singlemodescenariosport/singlemodescenariosport.json",
+      "hash": "bfd1ce9c3b190184d97be3ce5432018c3cc02ec6b4018ace3176ae32b44e4f05",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenarioteamrace/singlemodescenarioteamrace.diff.png",
+      "hash": "db28502f4e3496bd943e404b00150c02682146d664116b3b9bbf58e98da28f7a",
+      "size": 309428
+    },
+    {
+      "path": "assets/atlas/singlemodescenarioteamrace/singlemodescenarioteamrace.json",
+      "hash": "8d89a587faa0df908fce068ac26725c45fbbc9ab598be85a192ee02933523d15",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlemodescenariovenus/singlemodescenariovenus.diff.png",
+      "hash": "e60a0438b7499ec2b46f6ff2dc09f4b2122903abd85d2f4f158443424f56be94",
+      "size": 152064
+    },
+    {
+      "path": "assets/atlas/singlemodescenariovenus/singlemodescenariovenus.json",
+      "hash": "15f90dc30de025a93000e887e2116587836a2f32a4ed13e6de26fae0dc7dbc21",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singleresult/singleresult.diff.png",
+      "hash": "a752a1b60204e2ad3e5dab297fd09f3638ca35b107c838b6d1efe72f13b77998",
+      "size": 98618
+    },
+    {
+      "path": "assets/atlas/singleresult/singleresult.json",
+      "hash": "b9e8ab06e6c60ae028df57b6f6805462a61a33005629d5169fd118d7e28dbbb0",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/singlestart/singlestart.diff.png",
+      "hash": "dbcabf1a510b73bf277809138941e79c5b16193183b3cd06b5f38a47010b0af8",
+      "size": 75501
+    },
+    {
+      "path": "assets/atlas/singlestart/singlestart.json",
+      "hash": "749af68822cb9bf6f48ec20b4f6e4aa8aa9b8c2679c8f637448ced36f54db340",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/storyevent/storyevent.diff.png",
+      "hash": "103dbb76bb86db5a7dbdeb289f0d3d65b49913509f6b39159a3eb07bf6f978e1",
+      "size": 235915
+    },
+    {
+      "path": "assets/atlas/storyevent/storyevent.json",
+      "hash": "495e79a30603c7cb0f3ec98851bb1b97282d022defccb464a306006664a82705",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/teambuilding/teambuilding.diff.png",
+      "hash": "11539f116502f9f8792b0529bc759a58cd0c46f2ebf8e74ed69aa2f451ac264c",
+      "size": 446989
+    },
+    {
+      "path": "assets/atlas/teambuilding/teambuilding.json",
+      "hash": "d0bbc8cae34537ff9319533d8a6a361acf86c2364d4c9168dac94f718fc8290a",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/teamstadium/teamstadium.diff.png",
+      "hash": "0cef50684171432b6d214e9ced1d3757469ef037cfb426332d6e5a27764e637d",
+      "size": 712062
+    },
+    {
+      "path": "assets/atlas/teamstadium/teamstadium.json",
+      "hash": "36f4b65c0182d6cad6c7bc3dbef17ba696e977f8f24d3942aa6fc14baa09c2b1",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/trainingreport/trainingreport.diff.png",
+      "hash": "b824e9b669d544b15fcabcf1dba42db7b00f3bd47c921f8fe826198274ca962f",
+      "size": 98758
+    },
+    {
+      "path": "assets/atlas/trainingreport/trainingreport.json",
+      "hash": "0154b50f59a3bdcb13e4de40aba734d7e116e73931df048515b2d71ae8476a07",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/transferevent/transferevent.diff.png",
+      "hash": "c50875b4a64ebea892ca6b77c43ced99b212a25ac7ae1e15e9f01369f1dd105e",
+      "size": 119937
+    },
+    {
+      "path": "assets/atlas/transferevent/transferevent.json",
+      "hash": "1e681af6288764f9a0df3022e7b5fc64643e41ce4823664f7c0d0a1cd9bda3b2",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/umamusume/umamusume.diff.png",
+      "hash": "5095e5e45bdd7da62b606ff25f48e5bc5b1cf0384a588c09d5296ae83f2d3937",
+      "size": 12000
+    },
+    {
+      "path": "assets/atlas/umamusume/umamusume.json",
+      "hash": "a079d1aae2ae198af513911299b72ac04a87cd0983d9ec7b4e260eeea5f127f2",
+      "size": 166
+    },
+    {
+      "path": "assets/atlas/walking/walking.diff.png",
+      "hash": "bae6b4b8655e5ecbd6fbc19e9f9db6758554d08c74e0c7880764d501d877c982",
+      "size": 25622
+    },
+    {
+      "path": "assets/atlas/walking/walking.json",
+      "hash": "a35aaf8626b4fc4fe9efd360d8a073a69ae24e7db0ba67d4afd4cd160d00c9e8",
+      "size": 166
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1004001.json",
-      "hash": "2f1a26a894d6a048031febf372f98acf738bf9472904ad2e9e8717c43b8b1e06",
-      "size": 551
+      "hash": "2df2a508ef60203ced9efb8cdecd96761269f87a170d963fe3d3beef2a5b7b8c",
+      "size": 579
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1004002.json",
-      "hash": "1207d600058ce8cc7e30067077223e13399e101ef9e82a591aaa548af1bb6edb",
-      "size": 574
+      "hash": "ebed2cefb1a90554c0f41f19c46ca601be51a274604f7928c59e6e252d5ef752",
+      "size": 599
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1004003.json",
-      "hash": "f0acdf2b0895e53a1d07dcad95e0297060c43d219f4add39e753d93a1396504d",
-      "size": 669
+      "hash": "7ea0b413a3767ed78575da6209e643c7710b51c154c7f3cc329d81114eeadf5f",
+      "size": 700
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1007001.json",
-      "hash": "37d3a7ea35bde7a2572ff48f306366d25046df07b3988e5ba0d87597803f6fce",
-      "size": 678
+      "hash": "3633b947d4487322eb15458476d09dea2ccf891fbb8bd10ad0aaa782bc8dd6c1",
+      "size": 708
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1007002.json",
-      "hash": "d9ba51304b8745b18cb2e24f1a5fe614748eea59cd474fcf764a614291fb42c6",
-      "size": 782
+      "hash": "668e52d2dd29a7cad9c30c9db0fef884697499f763e7942edb21b27c57528b82",
+      "size": 813
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1010001.json",
+      "hash": "9f4044ada0f35f21b0ec9e95df8f19872219171fd2671fe8832278da547e6385",
+      "size": 798
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1010002.json",
+      "hash": "dc97901dd725d746f6fe83a11ace4d25979160c4a3b80ccbac239c99c3cf6dd6",
+      "size": 759
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1010003.json",
+      "hash": "a6707ffc06eddb6ca064312dc4f6d5efcbf90f935b80d566d6d90840dc614106",
+      "size": 823
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1013001.json",
+      "hash": "f062a278e8b542dbd844d1d2e00a3d4af267d1b26c48f73e7ed9b2af7dd90163",
+      "size": 707
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1013002.json",
+      "hash": "2d0ab02cb05d55d3b812a498ea79de3cca146971d58cb7cc0204ef793dd07698",
+      "size": 770
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1013003.json",
+      "hash": "7af806374848002b31612ec52f359d640be5796731dd9e799bfb653de8cd5cdd",
+      "size": 625
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1026001.json",
-      "hash": "8f353c6605e12371908751ac87c69916a2f4ae961ed2d30e2c5fdc9efdb19249",
-      "size": 690
+      "hash": "97edcdf36254871bf3d9255efc4329892f0ee255c7d84e755dce5b4edf4f2954",
+      "size": 719
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1038001.json",
-      "hash": "0d78b5afd3c5fc298bf78f59aef1c5a9bd1179a1cea8897c448c01b3fb1e2ad6",
-      "size": 913
+      "hash": "d48fbfb95dc71c9de70c2446b8fc7a60468996b8d569d6d32b65552fdf4b3d23",
+      "size": 947
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1038002.json",
-      "hash": "ac61284c150a9946b62072ed087c1f1ca403c176ced1bd622668e3421af6d950",
-      "size": 614
+      "hash": "2618e85106d5b25ed73c53e0c14edec4a5b4481f079a9be5b18a63f16b9a343e",
+      "size": 642
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1038003.json",
-      "hash": "0f5a04d7ddabe1088d0b682305e3c3f4bb62f93846af6200527c0a9866aac7f7",
-      "size": 602
+      "hash": "b9f257cac1162e488490330467e0aead95e1effbf6250a39a17034a15af37556",
+      "size": 633
     },
     {
       "path": "assets/home/data/00000/01/hometimeline_00000_01_1043003.json",
-      "hash": "aa662454bed4aa0c46552c1c95c567de517524b46725f62e9983cee47cac4d58",
-      "size": 730
+      "hash": "b589835c706e2c73ae137ef98880e360d0fe9439eb6a9fccd4fc70429cc34b76",
+      "size": 763
     },
     {
-      "path": "assets/home/data/00000/01/hometimeline_00000_01_1068002.json",
-      "hash": "3c6d8f74b1993155c3e7e3a76a4a8b083d1943709345a2ce7ed290538368f7ec",
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1055001.json",
+      "hash": "9b8eb3f8d2756cbead35e496fab040298f43fa9a6007e2e5ea0d90a8a773def1",
       "size": 748
     },
     {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1055002.json",
+      "hash": "00f0f16dc03dd843ea095cd391b72a3b6ba9fadde73fc87781c7017707602c6b",
+      "size": 886
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1055003.json",
+      "hash": "1ff4c7750f7469297339ee9d55c7266cd83aca4993ba0d86b2f25b60989a95ff",
+      "size": 570
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1057001.json",
+      "hash": "1c33823e4a04bc445986b45b29602a04bd4f7e69a4bbb6474e7da993205e6ae9",
+      "size": 742
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1057002.json",
+      "hash": "02a100904b32048608b09dda7dc378009068bc7d31601e62fb97f61e778e9b6b",
+      "size": 696
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1057003.json",
+      "hash": "91daa4d3f929899455e70c4622431b2e54d064b401b6c037e6565fbd74c7b1ba",
+      "size": 717
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1058001.json",
+      "hash": "44ee04b00aedb5a23885515a3eaf8d174fab2dce42e131659076585ae94450c6",
+      "size": 605
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1058002.json",
+      "hash": "06c86294ca3cf35676d6d108bbd8a9dc2231693f7169c378b552bbb318d7c3bc",
+      "size": 720
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1058003.json",
+      "hash": "932f85c36fee7933380eacce7ce9435b4352f4fd3d6e3b6241eacb74a62c4e89",
+      "size": 599
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1066001.json",
+      "hash": "0c144403bbe04b1cf8bd7b4b8028f416e87de30ab62d59e0e549724bd9822630",
+      "size": 603
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1066002.json",
+      "hash": "cd0440be2298be6c4e9831456bc658a2d973b6c66a2eadfb163c69a93e768f04",
+      "size": 541
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1066003.json",
+      "hash": "231c39586bf5ce4acfb860418f63171c1da0ba5d638ab8604a2b740590974c20",
+      "size": 654
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1068002.json",
+      "hash": "17a8216770fe60ef211f2f870fb0dc32792a6669baddc3db36e7d48d7488042f",
+      "size": 780
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1070001.json",
+      "hash": "9dc843f3dd45dc10a66b2bd32e6c1397b8d57a2900550692bb48508a289f52ca",
+      "size": 786
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1070002.json",
+      "hash": "abe36c22fa15f91a45632f00b90f47aa1203307ff0455c9744f9e1a14c3b49e0",
+      "size": 552
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1070003.json",
+      "hash": "5ea87226bbecd857d75affa0545b82b7081c88a4967ee97405535a35e36852c9",
+      "size": 700
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1076001.json",
+      "hash": "b613e390ff6808c290f4f474048d374793b59de8a125ab42cfb596c0b480cefc",
+      "size": 742
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1076002.json",
+      "hash": "5b5494ea79e732542bb40800c6e73720fdf14a19e1bcbdb2b5a7ded7801d98db",
+      "size": 829
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1076003.json",
+      "hash": "411f0ca8af5eb3f13d658dd9c2c7c42944c10eb409da5ad16302b9ff22217a6d",
+      "size": 817
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1077001.json",
+      "hash": "eefceb07fc1f53dd5302cd2ac069696912f3b4d7035c03cdb0609e88305400b4",
+      "size": 710
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1077002.json",
+      "hash": "ee51a77eb19076716568c9204ca8e653cb17370b5faec28a7e9451ca7bd7c5a4",
+      "size": 759
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1077003.json",
+      "hash": "6cf4a58e8d08b279158d6f8cc28f89b54ab8ad3aae3c2cb2d4a9a9b80a3977f3",
+      "size": 655
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1080001.json",
+      "hash": "f3fbd01a11339abeb5b1b6f63b314e17a80d4df42d1889ff65f44cc432f7766d",
+      "size": 692
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1080002.json",
+      "hash": "d61f79dbfc112a88d733c850c3599c258a99286fa709112796fe5cb046722ea7",
+      "size": 642
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1080003.json",
+      "hash": "8fd7be722374179e7233c101d035135b5a2abebf9025cc6f6dd67ac9fbe51ad6",
+      "size": 681
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1083001.json",
+      "hash": "7b70dd864274a5a0a97d3e5da066f7d1c8e79dae7b99c9e708032cf4f48cf4b8",
+      "size": 743
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1083002.json",
+      "hash": "6c5891f9a3e0cde9c9a3ccc9ad36482584ea5f17f02548792ca4ea230112941b",
+      "size": 758
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1083003.json",
+      "hash": "ff25a76b742bdbbd0b9903bb7e2576114746b1ef0e592f3094c0f8945ab397df",
+      "size": 814
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1084001.json",
+      "hash": "25f5947690b01d5ef743de2c86726657e7b79c017aa45fb200903c5d9ae0f805",
+      "size": 950
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1084002.json",
+      "hash": "2b2b97339f15bea61bfdd09e05f3174bb1e2440ba818c186a99a3e82b7d9b231",
+      "size": 798
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1084003.json",
+      "hash": "a3d73ad410cfe0f5432119dd225271e28e0c781626e08bdf85b0e3645cfbf92e",
+      "size": 743
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1085001.json",
+      "hash": "2d4e530fbe0f7868932a2619f7eed389bb2260f6007483648e2707fd7143956f",
+      "size": 630
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1085002.json",
+      "hash": "b974c7d55df277844b60b2796a011b839438a72d835444164ea2b840b82901b2",
+      "size": 830
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1085003.json",
+      "hash": "2b30614b4671daada2c3d18c83d45fd03ff2bd7ac4995001512fc6dfbfc93091",
+      "size": 494
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1086001.json",
+      "hash": "a381e7d522fdd97111812a4e49f7623ec74f22c8b42776a9e349f8484ef9f82e",
+      "size": 573
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1086002.json",
+      "hash": "f1004e3f215a42968122d4364616b9aea46fb979202fa182e69db76942712cd6",
+      "size": 647
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1086003.json",
+      "hash": "522915b4558d090c8a86d2d5a49b95f11df04ae1c9fd891fe09a9911472d25b2",
+      "size": 589
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1093001.json",
+      "hash": "1dcbc34c6024adc18bd65c66a0672a896ee2202ce350b5042158c0c307e529a4",
+      "size": 780
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1093002.json",
+      "hash": "d50fb1c07e9b2ce901c02c9173f5bed38df82318ee6f62cb4ea58408c6b1ea21",
+      "size": 628
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1093003.json",
+      "hash": "72acbc17afbad9916ace045e34f695930cf870db28a28b4cdddbfa2d1f803d9e",
+      "size": 700
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1106001.json",
+      "hash": "94297c2b00e4f45e0cf0070c4d88513e754f9979ce38aabb530e450410aa86a0",
+      "size": 670
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1106002.json",
+      "hash": "c1cd9c0ef62577284cd38d41a7b7a1b0e0921c56f87d2bf93085bc8a2a7480e5",
+      "size": 737
+    },
+    {
+      "path": "assets/home/data/00000/01/hometimeline_00000_01_1106003.json",
+      "hash": "f109b028d1238553a5a2eb3d578831fafe3c746dec352ee1d53be198043b596a",
+      "size": 698
+    },
+    {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1004001.json",
-      "hash": "bd72df6646f63792ba4c4ffc4fd25a849dec68e8866ed408e5b2b42eec3502ae",
-      "size": 1453
+      "hash": "0fd8429769b3c0270767690505371838bc8679c065102ab52b521211ab2f88c0",
+      "size": 1496
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1004002.json",
-      "hash": "70d39c5622d4fb6680cc5946c305f613f5ac321967b42ecbf8351a61c8fd46f9",
-      "size": 1399
+      "hash": "b59bd581918ed771951103b5f21b7bb0f9780d0618f52cb125ff5d3532e7aeb2",
+      "size": 1436
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1012002.json",
-      "hash": "53c81e45d6898f3e32d08311753ffff606d392b39b4b0dfa939bf00686d41de1",
-      "size": 1345
+      "hash": "60f603018166029cbeb27e39cd14df27cf3be4881112df1db831e8cb8f8dc458",
+      "size": 1379
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1038001.json",
-      "hash": "fbacc9c004a6fd2b15ec53797a7464bca2c757dc7f52500869a10d49f422bc5a",
-      "size": 1267
+      "hash": "0ca61cbde4dc1748a991bbf5a11cc3ca05ed435241663b4f26d999cf95e2a64e",
+      "size": 1297
     },
     {
       "path": "assets/home/data/00000/02/hometimeline_00000_02_1038002.json",
-      "hash": "ef78a904ce9aeebd1cdcab1c78b04104e602f84441df8532021d67503128ea47",
-      "size": 1389
+      "hash": "a744ea6a29757023f3e80e0246f2c732bc93d7e17f8af17019e63224252ef924",
+      "size": 1426
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1055001.json",
+      "hash": "ad770af46270d0abed90b75ff8bf8c988d290875f3f4a164993bf2656fb23295",
+      "size": 1886
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1055002.json",
+      "hash": "3b163b13c4e17736f7712423e06179949d94fa28542a984da4209843a916db65",
+      "size": 1272
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1057001.json",
+      "hash": "35d99d9b3a38a5ab410c71ec9597d7822b235b5643916eebd0bba2b88cfeb8b0",
+      "size": 1827
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1057002.json",
+      "hash": "bf4658ff4109521577942c811028b89e771ef354538336416fb7315c1261ac16",
+      "size": 1431
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1066001.json",
+      "hash": "d0994e1a690b48db21172ad0d78bc2770481f0f856653f329e74e5ad6c389bcd",
+      "size": 1940
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1066002.json",
+      "hash": "d0fa11663fa59301080409fbc87a50cfb3b006c60bfa0bce0788f5105f12e6e8",
+      "size": 1736
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1070001.json",
+      "hash": "d613c981afaf6381b1df7e09476b0f5408cbcec7ea03455b3a1d6bdf06fa3c28",
+      "size": 2170
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1070002.json",
+      "hash": "a415ddc438996b14aaa2be3d8c296e4a9aede99d5327b99b5f16c2535590a05c",
+      "size": 1900
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1076001.json",
+      "hash": "872e6c6dff6ea1438e56e2451ffcd087e96ee454bd211eaf40cd2cae1e0fcc54",
+      "size": 1967
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1076002.json",
+      "hash": "f22ae3f9a72f7f3b5dfd6bc666250e6d34324e1e9007cf3b94a058aafb6f777b",
+      "size": 1735
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1077001.json",
+      "hash": "e6c96544ed2912b191ad699875f99e42147202489d9c1494d155d5b034e9ad08",
+      "size": 1595
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1077002.json",
+      "hash": "60c791174fb0981f7e5b7ae157b459de3e7d8630eb378a131885d295503dd02b",
+      "size": 1508
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1080001.json",
+      "hash": "0ce0d8dc098abf910361620bf1a95225e4b85e6e033a1457e443d57758dcbc71",
+      "size": 1680
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1080002.json",
+      "hash": "b77a24b532a2d868d8e0654f6151c6fb406657aa260e21d403cd91116e2ee759",
+      "size": 1738
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1083001.json",
+      "hash": "e75afa0e50aeb508dbce8891b631a8c2f718286b90777367e0abc8021d3021eb",
+      "size": 1954
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1083002.json",
+      "hash": "fd79aa938a55cba8c86ff2a01a302fbdf2e001402a1a93dbcd509e95e27e3ab0",
+      "size": 1816
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1084001.json",
+      "hash": "94c6ba441fa2828828170c837587a991119e4cb00ed3165af973724c0575612a",
+      "size": 1849
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1084002.json",
+      "hash": "77256af49188161992171830021bafc88add0cf22be96ab14ce933e4bd3b4ca3",
+      "size": 1773
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1085001.json",
+      "hash": "912f54b0ce659e8ab9b7263c6a8cd92db30c553b6024e5e735f5666de0a15c69",
+      "size": 1502
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1085002.json",
+      "hash": "b8dc8e8edb4170e16758c69ad5d0c24a3d074fac47b8225bf21ed414c8519812",
+      "size": 1824
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1086001.json",
+      "hash": "e41977bbb193c70acf1ecf24fc484efe6c3b5c17b9de40c29e8928f186daa0b1",
+      "size": 1962
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1093001.json",
+      "hash": "5828d7d56ab397b8d13b6e311f2db335f59eb58ee09e9154cc1c7bc2c36a9c52",
+      "size": 1615
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1093002.json",
+      "hash": "24908c7f6d110876b09bedc80478216644254c89beb476bf8a8f7971712f8463",
+      "size": 1945
+    },
+    {
+      "path": "assets/home/data/00000/02/hometimeline_00000_02_1106002.json",
+      "hash": "1f66100ec6877189c5ac27b8942846917631e4deec87b6fe8f905a84f23dec33",
+      "size": 1906
+    },
+    {
+      "path": "assets/home/data/00001/02/hometimeline_00001_02_1026001.json",
+      "hash": "d2e13c59f4c5714184bbcaf14f5f53f3d9d342c942b1b51fea5cec5c02a07a63",
+      "size": 1737
+    },
+    {
+      "path": "assets/home/data/00001/02/hometimeline_00001_02_1026002.json",
+      "hash": "6db5625b832c786eb2cbb1b34fa31421b93ff41ac1e6b8eb7b21ef1d6deacc47",
+      "size": 1751
     },
     {
       "path": "assets/home/data/00001/02/hometimeline_00001_02_1032001.json",
-      "hash": "315db38d8b026ffa136e5207c0f5532d1d6e169bdeb5e50a4a02fa1ae09addde",
-      "size": 1873
+      "hash": "99670a4c2ebab94a95e438c473471cf60723c0de2f23d11afdc8176ed13025f7",
+      "size": 1916
     },
     {
       "path": "assets/home/data/00001/02/hometimeline_00001_02_1032002.json",
-      "hash": "685397555ece6d098705177a751c2d64bfd433201c18e5ee051bbf11ced7aaa4",
-      "size": 1838
+      "hash": "951e04a17fa6f8ff428558cffba1861f90ec674f057c727cd5c15d36f1485875",
+      "size": 1885
+    },
+    {
+      "path": "assets/home/data/00001/02/hometimeline_00001_02_1061001.json",
+      "hash": "bc49090a670401c8bf37a1bce98568b9a1584d7e2fd09459d0ccfea4286bb352",
+      "size": 1691
+    },
+    {
+      "path": "assets/home/data/00001/02/hometimeline_00001_02_1061002.json",
+      "hash": "d5859f05c44c666812614c323b935b18fa6751fd6634e540f239b28c72d98763",
+      "size": 1674
+    },
+    {
+      "path": "assets/home/data/00001/02/hometimeline_00001_02_1081001.json",
+      "hash": "496e9bdbc55e79b8a62bc368de5fa6428133576e24b3995208a9bdc6b9332fcd",
+      "size": 1814
+    },
+    {
+      "path": "assets/home/data/00001/03/hometimeline_00001_03_1026001.json",
+      "hash": "1e76dfe07ecb7dd4e4105f808cf591e552e10968c733bfcc77f5e284bee0ccca",
+      "size": 1866
+    },
+    {
+      "path": "assets/home/data/00001/03/hometimeline_00001_03_1061001.json",
+      "hash": "7dddadc12b2be054423b15c09ffc17b41f71e14ed1e01266200c0d1109c96339",
+      "size": 1395
+    },
+    {
+      "path": "assets/home/data/00001/03/hometimeline_00001_03_1081001.json",
+      "hash": "f1f013724b5c3cdb56de2d77cdbdb26753af55640587b7d08524f49f7655f448",
+      "size": 1698
     },
     {
       "path": "assets/lyrics/m1001_lyrics.json",
@@ -122,6 +1892,11 @@
       "path": "assets/lyrics/m1006_lyrics.json",
       "hash": "32e7f43f8caffd3a91d4ad786e6f542d9ad82478b8d790b6420682692d715bdf",
       "size": 1098
+    },
+    {
+      "path": "assets/lyrics/m1008_lyrics.json",
+      "hash": "ec2a7e3457b404b24b5fe803e13968d4fe0f1b3607f9a225e2828f16850f5d32",
+      "size": 1404
     },
     {
       "path": "assets/lyrics/m1009_lyrics.json",
@@ -145,18 +1920,18 @@
     },
     {
       "path": "assets/lyrics/m1029_lyrics.json",
-      "hash": "75c7b793a95b13c10ca31baa581ffa5d0c5c606f8bbed3a3ec0495274f164481",
-      "size": 2624
+      "hash": "2c4fc1cc33b3d4a6b1d2089e1312ae53b0c358e733332a93426f740ed21bb684",
+      "size": 2610
     },
     {
       "path": "assets/lyrics/m1030_lyrics.json",
-      "hash": "1815f4b487deabac2d43beacfcabd4d3944d360fb1aa00578b4f87721bfb06df",
+      "hash": "a3997b0ead0519a34f018b1f4c5f363b9d717864224a6ca2e942f41afcd86401",
       "size": 1259
     },
     {
       "path": "assets/lyrics/m1031_lyrics.json",
-      "hash": "a03d39078a7ec9fb98ed433b7186de2c6ab43db1cadf1781960e902ba2a290ae",
-      "size": 1251
+      "hash": "a69487f8cf46213ed6eeda2a37565e2ef8a89e0f2ba9a99ed3bfa71e5394b92f",
+      "size": 1248
     },
     {
       "path": "assets/lyrics/m1032_lyrics.json",
@@ -169,9 +1944,14 @@
       "size": 1514
     },
     {
+      "path": "assets/lyrics/m1034_lyrics.json",
+      "hash": "7fd97de85ab704c4827c53658e9f67d27ed65ef82a11d7103042014d611f0cbd",
+      "size": 2348
+    },
+    {
       "path": "assets/lyrics/m1036_lyrics.json",
-      "hash": "2d32e48da5643da8170256c345b05583273f457ba430198e0c5b2ad242e88f2a",
-      "size": 1467
+      "hash": "68e7f0823ff03996e180db3934d682b9308ee4c2eed4685a2289ae424e2a2cd6",
+      "size": 1464
     },
     {
       "path": "assets/lyrics/m1037_lyrics.json",
@@ -215,8 +1995,8 @@
     },
     {
       "path": "assets/lyrics/m1081_lyrics.json",
-      "hash": "683220630bf52e6a9f43f0dc3ecea3004c2d3f04052e30efbef12881ef054c76",
-      "size": 1463
+      "hash": "b767386332115ef12286ecf94ad9b4962fba2f5705cd34c06a54a05cee93ad9a",
+      "size": 1459
     },
     {
       "path": "assets/lyrics/m1082_lyrics.json",
@@ -225,4078 +2005,13308 @@
     },
     {
       "path": "assets/lyrics/m1083_lyrics.json",
-      "hash": "e1bd33f5ba96c7f8dfa2801d1b6e8a95b14cd15ae2184e9dfc94096c8046eb82",
-      "size": 3812
+      "hash": "ab3ba73eb82f9e8cf5ded2c26a60993509cf685519b96901d37c507ae115459d",
+      "size": 3776
     },
     {
-      "path": "assets/race/storyrace/text/storyrace_020000001.json",
-      "hash": "eb8ba02aacab46b09ca0e0121082d7de2ac614beb6d346fcdf84f390e72d81a3",
-      "size": 1458
+      "path": "assets/lyrics/m1088_lyrics.json",
+      "hash": "6df43b62c70cb1d385c85bc23008147dc89bbaec2f7d0978dedddffbfe3334f8",
+      "size": 1914
     },
     {
-      "path": "assets/race/storyrace/text/storyrace_020001052.json",
-      "hash": "f3d8895c030cde31c5f1f41e954d9086e759f7c1eda55c1fa2183757dee40f02",
-      "size": 1422
+      "path": "assets/lyrics/m1089_lyrics.json",
+      "hash": "4634ebe98b93b5f7aec127bab095cce17f3033e956cfe85c165769ee4d69d034",
+      "size": 3220
     },
     {
-      "path": "assets/race/storyrace/text/storyrace_020001092.json",
-      "hash": "b82539e634dbc4f298e454039efdac4b9bd6cf49916f595d7b8239f190912851",
-      "size": 1451
+      "path": "assets/lyrics/m1091_lyrics.json",
+      "hash": "fe996cb29ab4beab5aa684381660827cad24e6fa064d323198d468c2af3586c7",
+      "size": 524
     },
     {
-      "path": "assets/race/storyrace/text/storyrace_020001122.json",
-      "hash": "6b3634b2c5a0d5345dbce692b001cb07133e23aa2adcf9b57e21a9300817c01a",
-      "size": 1340
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020002042.json",
-      "hash": "c4244a065128dfc870aa05c938d9e07af9bb6d58a9573e9847c7975f815b6eb2",
-      "size": 1433
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020002062.json",
-      "hash": "3653c8f8a9e0c2e99bb92127caeee41b9dbb797bc1bf6622e04c31b4dc085743",
-      "size": 1649
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020002102.json",
-      "hash": "027e5259e57f7624e459f19024467a887f89f26c6336ae36c32b6894c349a3c6",
-      "size": 1531
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020003062.json",
-      "hash": "c097bf19efb7c0b8863b03d129a444cb4d57259b5e1046b8bb45126a10b46ba4",
-      "size": 1697
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020003092.json",
-      "hash": "8d90f160e644141d9e50f449bb5328765c443b457623e945053838b66849f385",
-      "size": 1981
-    },
-    {
-      "path": "assets/race/storyrace/text/storyrace_020003132.json",
-      "hash": "c23474a1f5ef79a1ef7e22907be9877c2dd614b9568daf8488899889f0118d17",
+      "path": "assets/lyrics/m1154_lyrics.json",
+      "hash": "fedf8ee8f51cd139cde537bf11f45239ed58dc3981a17094a925f030afe111db",
       "size": 2009
     },
     {
+      "path": "assets/lyrics/m9051_lyrics.json",
+      "hash": "4699ae66cdceb5e731cc41a1fc00ec6dbed0f9ebb71695a344a446892552373a",
+      "size": 516
+    },
+    {
+      "path": "assets/movies/mainstory/contents/mainstory_contents_2001.usm",
+      "hash": "10c7ab4057d309cf74e4cca25d7d453709f941147eccd681c8cbd4a004df15d0",
+      "size": 42549007
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020000001.json",
+      "hash": "276d608b3f398332bcc7d4ae66ce0972b8dd73ebf0bd17a8649d1b4c3bc4a39c",
+      "size": 1463
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020001052.json",
+      "hash": "4e46f57ea903ef23d1ab4996742cf00a228aa27d137383c13c2307e872961efb",
+      "size": 1424
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020001092.json",
+      "hash": "ad2be4205553789a66ba4b693986a166a2122711f1d30dc2b9380a72c31770af",
+      "size": 1453
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020001122.json",
+      "hash": "f054964ac52844e71fd81785b8c24419f713abbc51973fb3eea31a7b4f703bd2",
+      "size": 1344
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020002042.json",
+      "hash": "d0c9957b0b5002fffc9a5b22775b0091b24d32cf0076ac8838817a844d1d23c6",
+      "size": 1439
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020002062.json",
+      "hash": "a5d6ce1c58934841babd448b3cb8a87dbd81384827d9b99cce49bc8c66de664e",
+      "size": 1644
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020002102.json",
+      "hash": "986529bb2ebf0ebd0d791952ba4206dc2a472ee70690338acb58c7b1749b28c1",
+      "size": 1532
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020003062.json",
+      "hash": "f2ca065d23ef6202f6d57c8d67e171723f4282aab91c2862a9b9a2cb9494eb7d",
+      "size": 1701
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020003092.json",
+      "hash": "81ebccd8fc50d4b73cb00f9adb873d21904394ad37b7c37169a678c3d7ea0145",
+      "size": 1988
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020003132.json",
+      "hash": "d6e4f05ada845b187950da6a8d4d1ac4c7d9984c94629a1a461f940da2696fbc",
+      "size": 2003
+    },
+    {
       "path": "assets/race/storyrace/text/storyrace_020004011.json",
-      "hash": "24ba6720e93728a8f7e1484882df41673be57e9100741f10cd7b77292ddbdafc",
-      "size": 1252
+      "hash": "b62de7ae233fec521da30328b79772e5bd18cb95902193d828c7aaa1924a03f1",
+      "size": 1258
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020004072.json",
-      "hash": "c22f8bebb4b166f022bdf81b040bc51f987552ee27f11d23d52f8d05622a3ad2",
-      "size": 1808
+      "hash": "570131ca5b12f28adf6e1da936e037a2a41f9447b03f6a50cb57cea9f6020ac5",
+      "size": 1803
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020004132.json",
-      "hash": "8ac0584d2de0e098c85b5cc9d354a93688dcbefe9a75387e08c8289490b409ef",
-      "size": 2521
+      "hash": "376fb39a72dbedb436da06d32438228e13be1ce09282b7719ee14d948ee89a8f",
+      "size": 2514
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005011.json",
-      "hash": "40431d62b2c22a9873f225b97ce5e042de49aa4b3e80044c8737d68cd20ab76a",
-      "size": 733
+      "hash": "178e76ed6e55f41badf17b083a78e760730a97319a5d716676ba9832cd8e3b40",
+      "size": 731
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005072.json",
-      "hash": "a6bc27dc17d3ab5303f1ab77e0d1ede6fbcd5813456ff5bfd935230e7d59b7ea",
-      "size": 2121
+      "hash": "aa63fbceea8f652181d79bee7a5a633a12f821e53f0f2f761f77ca8c7f1128ed",
+      "size": 2125
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005092.json",
-      "hash": "20782b98251cc51fe405de1bf363f398cd5d99fdc69b80f8f75eab815c30850e",
-      "size": 1881
+      "hash": "7771413c5cfe71da888066f905b09fa93a351d4e2f26e412b5b8e60ce77eb1f8",
+      "size": 1885
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005111.json",
-      "hash": "d2f2d8ac00e717c819a3fef7c2849820b6169e9fb6ce325fd4611bcb4ad0772f",
-      "size": 513
+      "hash": "9944477fbca95aec1fd8d879de3e44d66cb96dcbbda68cd22bf5e61c42190201",
+      "size": 511
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020005132.json",
-      "hash": "12b5801138cf734947e5d7ef06999b67bcfbf45540188cb25392515a460d5cf2",
+      "hash": "1e9191222a7a97e528513f6181bd42298d598fff549d0678d7beae4969329778",
       "size": 2149
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006062.json",
-      "hash": "dce7538c29cf9ee47dc47fc185731452d3662945783c4a1965fbcbe5b00a6420",
+      "hash": "00633628f4312d9b2369c99ca5a700c19f0c1c723044b8373aa1d5e3c9cb5c88",
       "size": 2651
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006132.json",
-      "hash": "f83347598ee48b214cb49323e4fa5492066a02a795f57831e578ece30b74a5df",
-      "size": 3248
+      "hash": "aa3b871ffd32689fc5398b64b1906af4933d7592cac990e3a098e7922abe2e6e",
+      "size": 3250
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006162.json",
-      "hash": "758a46576f64f121704e92bb8056a964d797a3be00f688dac5e0899c8ce7c4d9",
-      "size": 2871
+      "hash": "b01f7aef4949d32e008b5f775d8bb28ff6f09cb380537ba0ccaafaca0bda097f",
+      "size": 2879
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006172.json",
-      "hash": "243faa29e64983f2d94eb390aaa174af05503010d05b997d87dcefb15c4b82c0",
-      "size": 3199
+      "hash": "8c94e3134f63b11bd5bf56b2cf2ba66d22d43a891bf1d33f500deb8ecc71f028",
+      "size": 3205
     },
     {
       "path": "assets/race/storyrace/text/storyrace_020006212.json",
-      "hash": "688df859ac65a5f50a5e8a5b8cb730d61039cf33597447d726aecbf9d4c6dbe7",
-      "size": 3659
+      "hash": "eec32e4308b35139b0b6851c3c07737a1c8774668338ab9f7c55f7f58d04cc1a",
+      "size": 3667
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020201013.json",
+      "hash": "e6da810f254dfb3b1049669ba965a6170248c14c444c2a4628c0129304b16ac6",
+      "size": 2155
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020201082.json",
+      "hash": "372c860b700d43d4a5e8849f02e8c126f3205b9a2981352d11e76b1be170e8ea",
+      "size": 2250
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020201132.json",
+      "hash": "f8d112e88ec8bd9dc62001ad5d550ff2467aa5a4f00566ba78bc6605861a43d8",
+      "size": 2527
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020202032.json",
+      "hash": "3ea7628b6a2584eb080899d246fead33e95940c045f7a40c57b1af2ad89e5d36",
+      "size": 2928
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020202062.json",
+      "hash": "ab798fc949c762a6017b23b8044216776414dc6536119498ab6d9dbc2357b3ca",
+      "size": 2198
+    },
+    {
+      "path": "assets/race/storyrace/text/storyrace_020202132.json",
+      "hash": "3762e0021dcf131b82c6f314201c4fc21ffe4b991aa9b6b60aad3c2fd68c1657",
+      "size": 2867
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008001.json",
-      "hash": "8f0275bbf5d12b06140ee2769fab149e2f28ee787608169fb7ef9bb8efb4c899",
-      "size": 201
+      "hash": "d6e0ed912298faec5d114e632623bca0624c4a8d4af934b6b4c94241acb6de13",
+      "size": 226
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008002.json",
-      "hash": "c7c2ae50f06b248ad3f440c0c3e0aa5cf9e11078421b7421b21bae570da6ffaa",
-      "size": 241
+      "hash": "605bc758c5052e31feaa8a5dd767cd3c868a3f75e4092fe8824b62d2af3725d0",
+      "size": 268
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008003.json",
-      "hash": "ae511f26437f4e3b8ed73676015755360265049ae414ffd701ac079baa713e82",
-      "size": 196
+      "hash": "16ea34e6152a21e8633d158d1b2865deefdd4e3dd3c180d8ae36783e4a5877a3",
+      "size": 221
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008004.json",
-      "hash": "7be5f3625b3869651aede6ddefc195d66cb77512c9704c8b2c904bf14b4313f7",
-      "size": 251
+      "hash": "20ecdd1612d8e572312fdff9ced48d11507411a4fabd9a2e06fc379b18796165",
+      "size": 278
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008005.json",
-      "hash": "2841788dc611ba2d4f2b5510de5903a29a69c68343954ba08010d0dec51d9609",
-      "size": 228
+      "hash": "3162043c0d10c38c861e4f7443da8cfb8531e6b5da9bc6211203b1d48ff65777",
+      "size": 251
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008006.json",
-      "hash": "56f763a7cabdc16452b09c198cd700438fc07ef95626c0fc2a4c2779db41869c",
-      "size": 277
+      "hash": "0e53ff117a56c9d23bea3d8c1b3e240ce2e2dddb85154e4f16d329df08da936b",
+      "size": 302
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008008.json",
-      "hash": "00bbdc5663c00b05a98acfb3b5cb234a0f59ca841ce0788c00d0bbb9960b150a",
-      "size": 955
+      "hash": "14c15b2ce6cf2d80c878e80ae0e149539d819ca60a77df8bf20a63c718cf61f2",
+      "size": 989
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008009.json",
-      "hash": "29267d71506cc0e22981a7cb1e42e74775ea9fb0da4c469518093a05dbefacf1",
-      "size": 681
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008010.json",
-      "hash": "dba9248552eee55827d6027654dd9af393296a69fd6e26169f3afd5fe5eea7ab",
+      "hash": "52e7adc293dd38b1fe453f6fc4e353a799ca859513a87185ffa6b44d9ea6efd3",
       "size": 712
     },
     {
+      "path": "assets/story/data/00/0008/storytimeline_000008010.json",
+      "hash": "47c0f38011476bde663502b5fedf24b42a80abd2fd0b0b5bb7edebcd2f01a7b2",
+      "size": 743
+    },
+    {
       "path": "assets/story/data/00/0008/storytimeline_000008011.json",
-      "hash": "a73054df3bf75da1bc236056c0520642b4a4bd838e23f1ba4ae2432ba78c1a75",
-      "size": 678
+      "hash": "d368f7a9c87e329763d254e69c5a44c978987d0123c50dd891cabe1bb35fe4c1",
+      "size": 708
     },
     {
       "path": "assets/story/data/00/0008/storytimeline_000008012.json",
-      "hash": "d1409933d19d80b4a430463867ffe6609d0456d6d280e20eb87043102ce8bc82",
-      "size": 973
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008013.json",
-      "hash": "6fffbd2c5a0403aa8245ca74291aa764dbc8d0a603ce1ccdcb06d9933fa206e4",
-      "size": 816
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008014.json",
-      "hash": "ca1bcda5eb05a9bae46efa854daaeed62502b32564105cf2b382053977f945ba",
-      "size": 703
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008015.json",
-      "hash": "8224de199af438e14e740ec319b2f3e73a0f9e94cf963925c29af9554ffe5526",
-      "size": 695
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008016.json",
-      "hash": "88f0eed6315073a6c4fbd827c361c64a0a1b3697b7d3302491f3122a236d2038",
-      "size": 852
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008017.json",
-      "hash": "4d00dc18a814082071e4824978fa1d2347ffdf4ccecb50fe9bf9eeb6e111e3cb",
-      "size": 890
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008018.json",
-      "hash": "84dd314ec93531dd957993a2d7c60e6299fde9ac69302e3d74994754b7e927f1",
-      "size": 552
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008019.json",
-      "hash": "0d344314ff273bf33a31e91900b92bb473dc9e22e5c7cfab9feb8f179d757130",
-      "size": 668
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008020.json",
-      "hash": "993ba1acd9f0a8423f069506fcaeb568353c28235ac2876756f60bcacf537172",
-      "size": 776
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008021.json",
-      "hash": "956ac22b70d606872d828ec7094bf2a8bdd709444cf10a91313ad039eeb3c560",
-      "size": 780
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008022.json",
-      "hash": "890e46b79f90ae3a3aa62da097124458bcd6f6be6422bdcdd9c02d93614b29c2",
-      "size": 703
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008023.json",
-      "hash": "1006acb13361b9291d601c2b4dcf9d6a2ef3c4de02d99046ec8855722346a783",
-      "size": 719
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008024.json",
-      "hash": "49d84624f632f3efabad7254e835aee9337685beeb543b0c100b48efedc7922c",
-      "size": 936
-    },
-    {
-      "path": "assets/story/data/00/0008/storytimeline_000008025.json",
-      "hash": "3e473566a2ec32a77239794336f2fe43780f92daa12c894b3c0b9fbeb92d6b6d",
-      "size": 681
-    },
-    {
-      "path": "assets/story/data/01/0000/storytimeline_010000001.json",
-      "hash": "010787f9ce82cb5f54f53bc30e4c931fc9ae8b686a6733f91b0906e8d4371989",
-      "size": 1858
-    },
-    {
-      "path": "assets/story/data/01/0000/storytimeline_010000002.json",
-      "hash": "9f2295934ade1349ff7d969e3545438281354cfaee515dbd04cb212c5d24faf0",
-      "size": 1534
-    },
-    {
-      "path": "assets/story/data/01/0000/storytimeline_010000003.json",
-      "hash": "70444cfb1e300bc141c1308ef1e8a652ddc979c459b1c6bb4ea5f2a510068f1c",
-      "size": 2622
-    },
-    {
-      "path": "assets/story/data/01/0000/storytimeline_010000004.json",
-      "hash": "d815e509414827e7d6136482deea2c734ac2b4a3d9a3ee22cb3ed46803717c50",
-      "size": 999
-    },
-    {
-      "path": "assets/story/data/01/0001/storytimeline_010001001.json",
-      "hash": "6bd9aac9e1560be49c3e7e3f715f51ff9dc819c8fc7ec4b199126576d241a1a6",
-      "size": 571
-    },
-    {
-      "path": "assets/story/data/01/0001/storytimeline_010001002.json",
-      "hash": "01d64ae3a6bbfe8e196fea8bb9d277e20e69760c3fa8f98d7fbe364b799d9aa2",
-      "size": 789
-    },
-    {
-      "path": "assets/story/data/01/0001/storytimeline_010001003.json",
-      "hash": "82c4090db2bcec87a4975c8e2448ab2932fefdfb2e2a8e4635edbd760b0818f6",
-      "size": 321
-    },
-    {
-      "path": "assets/story/data/01/0001/storytimeline_010001004.json",
-      "hash": "7665792be647f0c5ef88d1bed7b46c9f49be9e958dfedbc2b82d7194eb501d53",
-      "size": 509
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002001.json",
-      "hash": "2a1cfea04c09f29ece669ace742939724ec464a56f910acce02036b8c6aaa4cf",
-      "size": 194
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002002.json",
-      "hash": "a2b8ae479e0a91babe2b0cc37ddfa10b51df7b30ed2de080fc588061fd56fe96",
-      "size": 1010
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002003.json",
-      "hash": "263f1dc4205bbdcc67272ad55475a2afa62008463d96fa674c7f5b73b79101eb",
-      "size": 532
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002004.json",
-      "hash": "b29ca9999f00f33a9b54094fc1a6059ee139f3f146885afbb507ab39679b0d3f",
-      "size": 340
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002005.json",
-      "hash": "adf3ad2dc3902ec5677f6e3c6da437f94e5d5ed3cf16ac5afaaa9e950992a457",
-      "size": 285
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002006.json",
-      "hash": "af54d401e3e0a7676af04df4a4d3b6cca20a7e46f1c7e7fb9e4c574c1969e3c4",
-      "size": 342
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002007.json",
-      "hash": "bdc09f10f083f6c64fa5d393a2472afcc0a33717759da90234620e9a2715fef3",
-      "size": 398
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002008.json",
-      "hash": "8ea16bf4e7010b3662d290508b359dfe2661eaeadfdceea9825ac073acbd7445",
-      "size": 1356
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002009.json",
-      "hash": "68c1f3a7cbb7336b2fac72d4a8e64fc7469142a6ac21ffde84d42c8afde75cce",
-      "size": 1232
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002010.json",
-      "hash": "6a5d96cdb79c129388d57f7aa59ec9e29a1e3f92b06f2f808d24609bbe89ef79",
-      "size": 411
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002011.json",
-      "hash": "d4d477bf33eecd698d4bcb2beb6e914f25ade8b00ade9c961a0a8b48fdaeb43d",
-      "size": 804
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002012.json",
-      "hash": "cacdf02edc748602477f5090dd77c94d4c9e784a03e4ab74bc2308b2e1e5931e",
-      "size": 692
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002013.json",
-      "hash": "eb9bf407f86b7e152a988f7e7bb7f277b39a9a1fc3c2a3d51fb4de24e0350eda",
-      "size": 593
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002014.json",
-      "hash": "cdd6383b54c30592785edfe17be0aca0348e80105b0781c2cc96fc519d0322e9",
-      "size": 724
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002015.json",
-      "hash": "9103571e4d20b6bce3cb08bfdf1e7e1fa2f39ce3830e8b17dc792e674bca8306",
-      "size": 718
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002016.json",
-      "hash": "d96899a69fb8a86189d4afaf5fb8a8616c42bd1e5d73e9423a34fac8351be779",
-      "size": 701
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002017.json",
-      "hash": "14394d38595791e1ec78c1839d3b4471802ef03c557d9b762e5fc90add04ca08",
-      "size": 979
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002018.json",
-      "hash": "e175116096224b338604a303f3b7fde3e87773e421d46457498be2424dddb6df",
-      "size": 355
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002019.json",
-      "hash": "28a162b7c10f0a179bd7359fce36065cc31f90bd32be38cb6814d8e30b7d3010",
-      "size": 961
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002020.json",
-      "hash": "9fb7dac7e89e08802ead2885fdee94afb59a301f7ecb63a6b28147c5f0618751",
-      "size": 680
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002021.json",
-      "hash": "45aa7b8a65d9eaa486234bd0152bf59c63a07a9d10ec32edc6feabb8e743fccd",
-      "size": 646
-    },
-    {
-      "path": "assets/story/data/01/0002/storytimeline_010002022.json",
-      "hash": "392c756c1cdf606622814d86148d4f2f52b4318bcc4872e887ff84ce277ef11c",
-      "size": 460
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001011.json",
-      "hash": "e1591dc7e79a97126cbe6c6ad84bd3f5ba89d5bfd0599809e6c330dad6f075e3",
-      "size": 7136
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001021.json",
-      "hash": "028e599f17f3de67f7a09fa72ad0913aaf7cd0ec9277d42a5b6a5ffb2af5924f",
-      "size": 8690
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001031.json",
-      "hash": "dbe1cfb3da2045c964442e7f241fbe3c3db6ebe2364239efa8308b0d7a5937ee",
-      "size": 8548
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001041.json",
-      "hash": "3311486515fbcf708f80e234cf2662c16b1401bb1817057e1502ffdd17e383cf",
-      "size": 6955
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001051.json",
-      "hash": "1f9d4886b0802fdef45d61c240ea3d122d2c2d4f0e0341ac8ec5c6d74ed9c130",
-      "size": 5109
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001053.json",
-      "hash": "48cdb3dc23c9dd37674552139c25d898dc43ef78bb851ca2fcae68d3a5bc08ea",
-      "size": 2141
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001061.json",
-      "hash": "3914263e7602f941bdeaed7e89d112e02efbd3a4663df391f6156e1c68f9a972",
-      "size": 8451
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001071.json",
-      "hash": "b3cea60914521ca4a5de52e0aea3e8476a6e04bc5a344e0e25b641340d681b43",
-      "size": 8370
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001081.json",
-      "hash": "ec087ffa9c216c15003752b4e8b6271379c8d3373c90f83821da15cae6cb63db",
-      "size": 7702
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001091.json",
-      "hash": "d16bfdc8747afd50736cdf04d9adc023248e6b9c87a4cfa0f54c1fd2c9951533",
-      "size": 8945
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001101.json",
-      "hash": "d6f7496f72fc1d571ee8f31ad18ab29825a11a32e4e033a9e80578c4fdda66f0",
-      "size": 9607
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001111.json",
-      "hash": "21c5bc33abdded44e4e6dd266693a86d96f8261aa736e8e91a5c60ee9d49a2e0",
-      "size": 9044
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001121.json",
-      "hash": "cdbc405d14dbaeb1d711a7df53993d035b46f2beefd1a6fbe80d551d74c9990e",
-      "size": 9524
-    },
-    {
-      "path": "assets/story/data/02/0001/storytimeline_020001131.json",
-      "hash": "70b01d3a9f95a008ea78c013fb08ae7dfcde13aba7d70c7078553f279a72261b",
-      "size": 7889
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002011.json",
-      "hash": "4b010cff57635060485b9201850d462ce4107bd028093fa3bb170e6e3b3207a3",
-      "size": 7903
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002021.json",
-      "hash": "4d7717fef520752736de777fb52307dd1bb079cbeb72e98a85b8f651c53c69b9",
-      "size": 8312
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002031.json",
-      "hash": "56d8ddf4fe347969f456bd17ed13e7d22583cc8f0115b65eed8979c6cf2ce8ea",
-      "size": 8728
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002041.json",
-      "hash": "73c8128bd48d53ac6742db562c674a07308c699ccca3d372e5ec4daeb26eca83",
-      "size": 6638
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002051.json",
-      "hash": "b76390974529afce43e6878b96a80bf584625400a20433c229e27abb2df3ccb2",
-      "size": 7189
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002061.json",
-      "hash": "379f3c70912a2e6871e4228c6857b47bc1b7653be0a7fd79cda038385c813f5e",
-      "size": 2696
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002063.json",
-      "hash": "225823a73e29c7f6296b8555e0d2d8c10da1493996010c20fcd65c228a0b3e83",
-      "size": 3209
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002071.json",
-      "hash": "0a04df849268c481925256dd10c2d3df23364114c04d4ab27fafffacc2c1bf1f",
-      "size": 8492
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002081.json",
-      "hash": "618aa301c02471e7873a069ea9236fb3d998ed67bdc6c53c6959bdd0164e7e2a",
-      "size": 8396
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002091.json",
-      "hash": "b2df42a0d93cc3bf71d8ade10ff6935e630acc09c93a4bd2cedb8c794dc68e00",
-      "size": 9367
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002101.json",
-      "hash": "711d48709c05f464f35f870a97a9373c207c2d6bb087adef4756a5ef33f664ba",
-      "size": 7933
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002111.json",
-      "hash": "85d32d8e4a678910a6b754c62104813ec423e3da5fa91ca5cf21f7f321e92182",
-      "size": 8031
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002121.json",
-      "hash": "76680bd0489cc6dc49a5c30fad65ce1c64a5bc37b80efabdeadc81db5a2b2d4b",
-      "size": 6441
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002131.json",
-      "hash": "1c23ecdd27edb504484381caa1b89dd83f014d2cef609430922a8f7d7aa30cbb",
-      "size": 8183
-    },
-    {
-      "path": "assets/story/data/02/0002/storytimeline_020002133.json",
-      "hash": "49898bd004dce0e777868d4e82315c87975cc4b3eef6c8e095b103c550e64746",
-      "size": 1891
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003011.json",
-      "hash": "f42205acae5c3c34c8182ed7a2d9136517116c2a87ca3886c23995ca7e6431cf",
-      "size": 12082
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003021.json",
-      "hash": "df720ea6052ed1ba6b56970cd478930f195b87aae3e78c99c4b8286dc4c6efc9",
-      "size": 13140
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003031.json",
-      "hash": "3317836dfbc38e7545bc0e3977c5da15ed1021f82224e14478ceb8938ff07fae",
-      "size": 9071
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003041.json",
-      "hash": "c61081c0e8e77510e61c906bf3b4c4009f09d3ab21c444619429a6b60a5876b9",
-      "size": 9537
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003051.json",
-      "hash": "fc618b7691ac6566baaa125ea25be8c6f91c12fa18d3e47326c7ac7c62b9900a",
-      "size": 9463
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003061.json",
-      "hash": "e15ba92e8e7326e4c3d0789ec5bfc9c676dc2da0f3b045ea1bd74675fd7f2d04",
-      "size": 6871
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003063.json",
-      "hash": "f815a7bb1c17498552895a2e69484175436ab70a4fc48814ad940773145105be",
-      "size": 2045
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003071.json",
-      "hash": "2bcda672a3c2dfdf7f43b2873377e01db62fb1ed6f69549ad129c8a655bf1888",
-      "size": 7798
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003081.json",
-      "hash": "8672bc6441513efc877d252649c4b465e4f6969585f90dc954d8aecc403b6ddd",
-      "size": 10029
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003091.json",
-      "hash": "d377f305cc0106f64637b0a136e52ca729816dda22c74603b4642079415ce6e6",
-      "size": 11374
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003101.json",
-      "hash": "a980de5c7a7b6513f61b9a7f14b4c40ccd90dab6a1eea191711cf518fabb5e14",
-      "size": 6085
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003111.json",
-      "hash": "e6b1d333ff9a3463cfc005f46ec2044af2372b7eefa0bd6485a328a2ceede483",
-      "size": 8725
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003121.json",
-      "hash": "288a0f785d7316d9c89c487656d54c48ec5845ddcd4cdce0e927d4064e321d78",
-      "size": 12247
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003131.json",
-      "hash": "05ab4a984a6894906722b3c8957a2b377ad3cebd35d41506a92135206226265a",
-      "size": 3058
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003133.json",
-      "hash": "7891de8c8286f27deedc82901a600c8f5a1877794f93b7adb7f46bb6b02638c8",
-      "size": 5108
-    },
-    {
-      "path": "assets/story/data/02/0003/storytimeline_020003134.json",
-      "hash": "d1b6dced30fb69b57bd71f7b87f45db6c7a4c38f36faa19ec1ac13ee2a87eb85",
-      "size": 704
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004012.json",
-      "hash": "239cfc783d555f7b723282069c8f193ee53a5c4f9f42f96b0ca71ffb212cb7b8",
-      "size": 7699
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004021.json",
-      "hash": "37e636b4f5427e0d11a96480d73dcf4182a29ac0a98e672e4b3809612271124f",
-      "size": 11524
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004031.json",
-      "hash": "fb2f2cdaa1c02d2140444f6a94b984a290ffc8d8e13117062faeaa618b778cde",
-      "size": 9698
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004041.json",
-      "hash": "4f2409ad297e3fdda58b7c462651c1dc08be40b7f81d09d3a30cc7e8e585fa3e",
-      "size": 8594
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004051.json",
-      "hash": "03ecc1ae0949e87eab7706b9cf94756fca7dd74c46bd5e94f97a7739ed99d513",
-      "size": 8692
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004061.json",
-      "hash": "f9ab121bdcc89d0a674f7fe131aa7f4dfbdaa303578bc495328a24c26052bcdc",
-      "size": 7374
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004071.json",
-      "hash": "8b11f1557b6c55aca6f275fea9d13083daa51463ed3e7daeb9756302987e07d2",
-      "size": 3018
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004073.json",
-      "hash": "299d6bf1702b03970b06bcd2994a937e7a2019f2bc80a33722c7ea0ac7f49a4c",
-      "size": 2475
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004081.json",
-      "hash": "d1a896fe47feb224f6d78a6e4cf99b5b9425aef22ffd19f0a9437768c13daaad",
-      "size": 7895
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004091.json",
-      "hash": "2375f41796f81e90d3add71cc234b4c20c6fa876a9c0f7a13c165a7713d3b644",
-      "size": 8591
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004101.json",
-      "hash": "0406594fcf86b2d89d54ff5032b113f7b362172bfd764c5a2c3618e1938a066a",
-      "size": 6907
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004111.json",
-      "hash": "fca21cd60ec4f5b67472b28e2e528d966eb68d4d328510eaf8f8bcde90496e3f",
-      "size": 12599
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004121.json",
-      "hash": "a1c504a1bd80ced2841a0a1fbf6060fd54c8e0a925d269c2e78d292f467f08ef",
-      "size": 12241
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004131.json",
-      "hash": "cdfb8b212754b684e47d99899b3326e704216786ea34482cb7aa1b413bb10cfe",
-      "size": 5634
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004133.json",
-      "hash": "8ad615f4f67af7b3059b2b820eb24c57cc350386d33dde69c266b8b001450bd0",
-      "size": 1549
-    },
-    {
-      "path": "assets/story/data/02/0004/storytimeline_020004134.json",
-      "hash": "805ea39c59fdde301381bfbb2a570974b90bc2fcc947877f5c11f3ad5f04c4d1",
-      "size": 1649
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005012.json",
-      "hash": "4582ebb9e6b8449e9b41aca8af9e77d4655b7cf96537bf3561a13b3afdf90969",
-      "size": 8838
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005021.json",
-      "hash": "d1dbc58c41a667427ef69ad421ad706181987aaace6e7c6419f983e31b05f700",
-      "size": 6914
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005031.json",
-      "hash": "05b94ae789f4242cb054706c76d754139b092a3ccd168c4411c410d94e61e410",
-      "size": 8926
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005041.json",
-      "hash": "70d7f2b1f945a8784e324658385ab4a451bb4d144f8771f696e0ed6834c2adef",
-      "size": 6841
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005051.json",
-      "hash": "f1c3991b1ead2092b72088270b321bea39155df5fd6892e72813b09ee97fa291",
-      "size": 10406
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005061.json",
-      "hash": "e19c196f37e8ca559a9c03dab1aeb2f7809aba70432c0d1f0bd2d80329f21821",
-      "size": 8678
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005071.json",
-      "hash": "bc38c28c99c66c879cb61002270b17db1ffe3d906a7152f48eef0f0ca2638d7c",
-      "size": 8438
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005073.json",
-      "hash": "1b41d95f0b14b097487d3258f45a3fa7c02fbfc3b00fd83bdac56644cfe17fa6",
-      "size": 3383
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005081.json",
-      "hash": "d89fe46468d564e3071f53dec63a6a140e8a50c502ff8bb4cb00643adca9100a",
-      "size": 8660
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005091.json",
-      "hash": "87faf91b899cd04b2a92c3c89501ea5d361982cbed41d5999236e1590dddab85",
-      "size": 8913
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005093.json",
-      "hash": "e5efd73b106c2e47a82ae0c5f68dbb83773b739ca5a941e6f90a3f970333afe6",
-      "size": 2258
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005101.json",
-      "hash": "b891b5ab9285fa5449d62307a1e4ced562701a9be208a277e76e60412b8c825e",
-      "size": 11378
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005112.json",
-      "hash": "473b955d3ec379a622fafdb31750ee0a9ba45c96ae646a2e3b6f25f94d87aee6",
-      "size": 10037
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005121.json",
-      "hash": "952c4e7efae0f970199b6d584a9ced05ea9199c6adebaac3477a9685cc610b33",
-      "size": 14543
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005131.json",
-      "hash": "32e26b763c238c119cb8d5bfba40b14d63c37aa30693afddf8d8c6f01c10c3c3",
-      "size": 3692
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005133.json",
-      "hash": "c09a594fd7b5d13954fb1792b5dae60b79c591bf63f16f3e57f0dc5c7db1352b",
-      "size": 4965
-    },
-    {
-      "path": "assets/story/data/02/0005/storytimeline_020005134.json",
-      "hash": "75e1618a4f1802def75285d2bead8908da1a3d70622f02f6b44b80dc78006d4a",
-      "size": 1236
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006011.json",
-      "hash": "a32a3daa1f89f5698f17740eea15fd201e57ccdf1059f9e5c3d2f92e1650d671",
-      "size": 13126
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006021.json",
-      "hash": "1f5ed712f3c97a18a4ff89386f914158debbd9bce6e9d5ac4fdb7a2d23e72f8d",
-      "size": 10387
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006031.json",
-      "hash": "47521ee7f01be2ef5da5aee7eb477122648607cfa05c34539d36360823d5527d",
-      "size": 8462
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006041.json",
-      "hash": "e999c724d821d7484329ec4f736ca9d221c3356e2875a2635fb1656229b53999",
-      "size": 12314
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006051.json",
-      "hash": "2bc945addc508477c8f72fed3ca45146629cd17fc3bff1b69d7c4b8bc4d70688",
-      "size": 9239
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006061.json",
-      "hash": "27f8de2b8a30d60a60d3e64b774b1139395e1dedda9c9a24858d92e059e19666",
-      "size": 11274
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006063.json",
-      "hash": "767f2d7049b90f11bb6476313a0adc04619d73bbb19f4cce60a61494e725cb87",
-      "size": 6008
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006071.json",
-      "hash": "f4d363bcf28ac4f2fdefd61f15832954bbb78695c8439405a7c23c4f9e289800",
-      "size": 13736
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006081.json",
-      "hash": "02dc91ce372a8f66e0ecd5e6606082a1601849b07f3ec63b1b4fcb1e4cb1461b",
-      "size": 8266
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006091.json",
-      "hash": "90c60ba78e7f46b6ea5d9ee7836387989b801b58bb2a1fa4e67ef7b86478ed86",
-      "size": 6878
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006101.json",
-      "hash": "43f482ae7f81d0f3a306b9832562ac648fdeb6b683c47fd70171c158ffee52a7",
-      "size": 13985
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006111.json",
-      "hash": "fbc3c129fc7e64e56e83055d1d6571dd9db68cca17fdc3c36dfaede30b25d1d9",
-      "size": 7864
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006121.json",
-      "hash": "f9d84d8c590e1218f4d80d40ca2645d9ed2ef8e08cb4c499f400a6bcfe883d2e",
-      "size": 12492
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006131.json",
-      "hash": "52b8345209b8795f1e68fd265d2662e66bc10deee3cd0a4555ad82b71d9867e9",
-      "size": 6404
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006133.json",
-      "hash": "e19fe620518f64f1617bcf7e371cd0325fa891328c4ed4252283fd4545e663e6",
-      "size": 5399
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006134.json",
-      "hash": "5441d6bf0cb7e638d369665f5ccf91eb8f6a5ca88c103a47a378b4b3b56c0c5d",
-      "size": 702
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006141.json",
-      "hash": "b5b95eb8a0af8c58987e413250d962ba2ecc1a33f887616d8f634bff1cfea194",
-      "size": 8248
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006151.json",
-      "hash": "a3d8384609cb4a738bc9d6fa1248e1d861921663852c7380a2e6d99d6e237098",
-      "size": 12215
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006161.json",
-      "hash": "6478a2f1edfb066ee1563921991743f3e90243a88709258928c212e9996a0421",
-      "size": 12048
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006171.json",
-      "hash": "f8c8cac7f60be01758a3fb57ed616cb77a386f7aed994140e35a8e47a1d8921f",
-      "size": 11362
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006181.json",
-      "hash": "c5ff1eedcbd83643a0c666a13cc33ffea549ed03d250abea9d252feeb7fd9ef9",
-      "size": 9349
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006191.json",
-      "hash": "47cc1310f1b59db460bb68f355f786e8352221a5f13251778abd91b0b7c842df",
-      "size": 20000
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006201.json",
-      "hash": "107a8e7ccc9045ec72db63b1091313cd055c20f5a560fa4a8aa72dd19b6dba4c",
-      "size": 10574
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006211.json",
-      "hash": "10a79ddade7a9070f997ef6cc3b6d8233ff83bfcfe076abc3d02decd460d8f4c",
-      "size": 14698
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006213.json",
-      "hash": "5e9c7789e18b7daa4f18259da7bfb60e8b44b1ce147eef665ed4a569524edf15",
-      "size": 7658
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006221.json",
-      "hash": "c502d961da61efce8e26adaf52465ee0562822317dba4e7a20b8ea572d1f30e8",
-      "size": 9663
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006231.json",
-      "hash": "6fd295b959bae2953b6eaa6e70d2c0e0b9835648c974b18cb5cfca008b649a86",
-      "size": 5177
-    },
-    {
-      "path": "assets/story/data/02/0006/storytimeline_020006232.json",
-      "hash": "79b3747a87911d6891e89ac1786b228ae1f16c87c2247ceda456e9b3408ca415",
-      "size": 4285
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001001.json",
-      "hash": "aa332918509dfbafc65238ecbd6a47803e75cfd5e6be4665b977141e94c15c7b",
-      "size": 9640
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001002.json",
-      "hash": "981bb36eb86b13b2f04b777ddfa08ad39e1e6ac79d9c13cbb8083289831f773b",
-      "size": 9202
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001003.json",
-      "hash": "8f9320440fbb1ee16031d4f644753fc9aceaa7a61a5e8cee9d5ced063129810d",
-      "size": 8827
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001004.json",
-      "hash": "8a1a0de54d8258d26dcfbfc338660f9d341cf6cb1f657f9bac2012059af75c80",
-      "size": 9844
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001005.json",
-      "hash": "7a357da0121216cc9a082e6863357a15751c947c27cb48d79d625adf8538cb2f",
-      "size": 6004
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001006.json",
-      "hash": "58bc065f6129877f10a2e143679edadc9f17374c1d05436211a7d99c2bd289d2",
-      "size": 9434
-    },
-    {
-      "path": "assets/story/data/04/1001/storytimeline_041001007.json",
-      "hash": "a3a093c752ab49fbd774fce74fab1de3f28e800135f77f0cd8cd3ab67e4b83f3",
-      "size": 9188
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002001.json",
-      "hash": "41a22df2589d9b50255242c66fe957ae25f6c956159741c61ac0463cfc91733e",
-      "size": 8189
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002002.json",
-      "hash": "12d861c539c12d7b90bdb4a38d78418f769761111b486bea1dad5c9ca86f8bdc",
-      "size": 6673
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002003.json",
-      "hash": "97f0667d219da35738d5526b7b66fb8312f85c207f6497f9490f4a6a1fd0f7d8",
-      "size": 9234
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002004.json",
-      "hash": "95659454911fde15326a30699a49c9abe2e19fd5ec4035fa5b9bfc0c84606f81",
-      "size": 9153
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002005.json",
-      "hash": "0c1c158682c4c9a79c45d5308db89acb2b7a4e443e3dcfe93eb0c445a7b425d2",
-      "size": 4681
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002006.json",
-      "hash": "53cac9b841909bb904a0f205c74165e688006866734beb8d7e0b5bfd5c96c81c",
-      "size": 7948
-    },
-    {
-      "path": "assets/story/data/04/1002/storytimeline_041002007.json",
-      "hash": "3fbad7964f1c1c8223a53f028e2306aaadfffa1369d5ad9687b59eed860dbce6",
-      "size": 9321
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003001.json",
-      "hash": "72368941183458d98a765bf3ac56a8f18e8654771cc841d689bd21a56d4a9ead",
-      "size": 8069
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003002.json",
-      "hash": "d076a313067aac0ab465bee2bebe4b76629acb1c0499b74ea24d9bc47cea106d",
-      "size": 9416
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003003.json",
-      "hash": "4b43d496e29b1d01d4352d6a823d6042d3e9cb8b08f38a32bc9da3c56732b121",
-      "size": 8278
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003004.json",
-      "hash": "7adcb814a76284638cfce2bc71d5e0710279f772a260f18e189d54167fdcf4f3",
-      "size": 7640
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003005.json",
-      "hash": "216135dcdb1d42819c9f3e3d4bfe14560e0259295568c282a41ad0f4111ff0f0",
-      "size": 6039
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003006.json",
-      "hash": "ed13f903389014ee3acde7b7b098890847052b1ea0f9b0bfa34fd5264cb163ac",
-      "size": 9125
-    },
-    {
-      "path": "assets/story/data/04/1003/storytimeline_041003007.json",
-      "hash": "b9b5b4300c5b904adbcf8607e42b5beffedf8234807a0d96c426563f9be08b58",
-      "size": 9747
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004001.json",
-      "hash": "b4a1b2602c79ab0795cda2cd981e882c80d3eef18886d40fdf56765cda91e2c1",
-      "size": 8412
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004002.json",
-      "hash": "431c02f2daea909f7f44c03f02769a03001ae2d6a956366be06941f5c2c6fef3",
-      "size": 10545
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004003.json",
-      "hash": "7941ada557a208e47def857e8b7fcd6a9b2104e7920bf9c5787a8111c33c14eb",
-      "size": 9711
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004004.json",
-      "hash": "107b91f9cc59906b3f2d893ea08bdd92b482910c9156d7d9c15b41f5a15f4e3d",
-      "size": 10325
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004005.json",
-      "hash": "33f7833b3ab2892c0ca44682ee27f330fad668b49aa98d4012d403959455da54",
-      "size": 6474
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004006.json",
-      "hash": "cccfb3f1466faf263c427fb5361035a237809154f554526b72301aac5ba3a0c5",
-      "size": 9846
-    },
-    {
-      "path": "assets/story/data/04/1004/storytimeline_041004007.json",
-      "hash": "f8fdc48ceaec786b8ff9a958d5bc2951c79aea5643ffb825df458cce14c60384",
-      "size": 11487
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005001.json",
-      "hash": "5b26b3363b1aa85fc1011449876d55f7c491adc81b80899ccea5a24274fea100",
-      "size": 8766
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005002.json",
-      "hash": "5cafefe4a90f922588da05a82f3cdc888cc39155b898692b44554034b3785d71",
-      "size": 9754
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005003.json",
-      "hash": "f31593860feb7d331a945499ee693515b9b2d1e82341b6425b637c04b6226a66",
-      "size": 9144
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005004.json",
-      "hash": "ba9ec48eb58f515fed1f6dc99946605c40a3795ff73dc11498f69c5f1a15aad9",
-      "size": 10556
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005005.json",
-      "hash": "d0663f0243eb17000197b9c58fc7de39c915c06f53ed3de42b9795c683b94ab6",
-      "size": 5167
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005006.json",
-      "hash": "b482985d4066f50d549505dc03c1bc65ab9fc2d6c88a817e98b7aae26491e6c8",
-      "size": 8641
-    },
-    {
-      "path": "assets/story/data/04/1005/storytimeline_041005007.json",
-      "hash": "f528b7387e99ebcfe9472c9c6c3d1828bd2bb8a7148443a719dd140f75f3c498",
-      "size": 8643
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008001.json",
-      "hash": "eb88d804e1f54053434895fc9292170f704bff8fcbc2e86ede01a7a696186fdf",
-      "size": 8616
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008002.json",
-      "hash": "d91e6cc936184feca9bd5ec90c082b3f1fbc492042a2c39b552b8fd689e99b36",
-      "size": 8514
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008003.json",
-      "hash": "8f81020c9e6aa7b093185406e476de359476f5179943533515be0b89058c0932",
-      "size": 6899
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008004.json",
-      "hash": "5766d1cba7dc75a71ef070af3554d292a4362bf37be165060b9f8035c64c6277",
-      "size": 8468
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008005.json",
-      "hash": "3c77e3dff768745246a1e2398c8580a9ddd0e73a7ee7d4eee55e2e7de5721664",
-      "size": 5540
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008006.json",
-      "hash": "8266d94fb68838c54a61f4d55ec0e42ba2f42a9f4b2d7629c35c4cffcfeca7d8",
-      "size": 7719
-    },
-    {
-      "path": "assets/story/data/04/1008/storytimeline_041008007.json",
-      "hash": "57bde3fd8662417f98801be78b16db565f2d402cf10903ab64497e9ebcf989d0",
-      "size": 9257
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009001.json",
-      "hash": "c3085c61f85b620a61524c6baf19b9f0daa00da1344cccebaaeb12d90daf3ea8",
-      "size": 7006
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009002.json",
-      "hash": "5b4c9462dcf74bc7bb119fc6d1ff818bba658f65d3ca5da6c9015578279a72a6",
-      "size": 7483
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009003.json",
-      "hash": "203b5e055d6ac6e227f70ac1bbc40d8d80359c25c4e03f70111e867e64323148",
-      "size": 8720
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009004.json",
-      "hash": "ffe5ef3731829409d709f856419d050a34e9682dba1b5e09897a225e6912d2fb",
-      "size": 7688
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009005.json",
-      "hash": "41bf6ba5489db1721bde96f2a54d1296e4703e81cb419cf2d7e2c4049c33f790",
-      "size": 5994
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009006.json",
-      "hash": "89d12040e6ab1e45bac1f71978b0f8882384fc284627d3d2892d8689d1ecbe9e",
-      "size": 9531
-    },
-    {
-      "path": "assets/story/data/04/1009/storytimeline_041009007.json",
-      "hash": "a29537ab4515b1c8a46af13b0ca7d7591cf10b606c8217edcd1c8df31cfa2793",
-      "size": 9413
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010001.json",
-      "hash": "af70a13d37218a45baea9d0557f49365a3541511b7403a6510c694cfa8972612",
-      "size": 7460
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010002.json",
-      "hash": "ed4034bda1ca7c93b831166b9bfdaa83ab5354c52ca427680c46deb5b24644f0",
-      "size": 8808
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010003.json",
-      "hash": "0cbe8f26090049c74318512296699cf44aa5211367527afc8d4e7d0428419d63",
-      "size": 9179
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010004.json",
-      "hash": "e1e499b30fc2cf1f0e63f1bd017ae5eac7936b5199d2dfb651a74546795819d2",
-      "size": 7226
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010005.json",
-      "hash": "4a7c2b44e52845c78b6198716b6f3303163007fa46b7a73a3fbe7a79f15b8351",
-      "size": 4776
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010006.json",
-      "hash": "34c9721a34ef8d7d639f9dc035640f65c50b2cdc024ae1d7834dc5b947a746aa",
-      "size": 7887
-    },
-    {
-      "path": "assets/story/data/04/1010/storytimeline_041010007.json",
-      "hash": "6a1472dcca91600ec367f33b35959443eb351a7f780f85255bb4d89ed54ecefd",
-      "size": 8663
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011001.json",
-      "hash": "2cc2a8cb4168b92b2ba4bec43823edb65c8aba2f09628e66a90ae855d5f23fd6",
-      "size": 8517
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011002.json",
-      "hash": "8e92bd1c492f98d55a4ee9b425ceb527ea18886e4b5e24a3eb4771f6ae83efce",
-      "size": 8361
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011003.json",
-      "hash": "ba7be5d25238d386a2de015980621c7955e1d773c81f8e3b5c9c924e717ee7f5",
-      "size": 7406
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011004.json",
-      "hash": "be8371e5f6d781e5202cf00b486163015153dab88541b1e21a29886cd3cc2818",
-      "size": 9425
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011005.json",
-      "hash": "c4901559b2dd18082bca37eb64e0e3f6089c16be7ef322067cccd6a4ea67def6",
-      "size": 5447
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011006.json",
-      "hash": "57b4d42e83c32e41c7b12e24648801385ef98af220a9f176c2281f0e185b997a",
-      "size": 8031
-    },
-    {
-      "path": "assets/story/data/04/1011/storytimeline_041011007.json",
-      "hash": "62eadca66a4ee9cab267d7c8ee65bec73db0d0f35f06c85d309b7b9d82e3c0b2",
-      "size": 8167
-    },
-    {
-      "path": "assets/story/data/04/1013/storytimeline_041013001.json",
-      "hash": "8a85b7d3bcfb1672912f6b93bae6e0cfb8176e6b466a2825010a3296b2433637",
-      "size": 6537
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017001.json",
-      "hash": "e06e1c305778492461e5a48a41fb7a4ea68dcf21b47b975e0140336b89f60159",
-      "size": 6197
-    },
-    {
-      "path": "assets/story/data/04/1017/storytimeline_041017002.json",
-      "hash": "70ba8d0a0bb1033f9cbc429256e12b3cf20c4512a7d9d3c91345277a537eb369",
-      "size": 9016
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018001.json",
-      "hash": "09c4b1ccba3849dc5122bc400318addd33fdf5d625abe63674bd5c0b9ab7db2d",
-      "size": 7701
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018002.json",
-      "hash": "3a942f3ceecb67482c60532e8e13454b73113f5842e77b30e02b34dc7bc198c6",
-      "size": 9296
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018003.json",
-      "hash": "6a4efba4ed405eb5331a1d237f8b45b8549eb23b2691ed33a8e975d0d2103dcf",
-      "size": 9179
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018004.json",
-      "hash": "546d65db94f07b865f61e04a55f8eda1b570c8b91142385b5c18a76779f28a34",
-      "size": 10075
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018005.json",
-      "hash": "35d57664217c1b996472ef1091e839d42e22458018490e280e03481e30afa44b",
-      "size": 5684
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018006.json",
-      "hash": "d49d25f7f03407e2b5e3ea6ee909a7ff5cecb6fc4665fb226848976e54d17509",
-      "size": 9120
-    },
-    {
-      "path": "assets/story/data/04/1018/storytimeline_041018007.json",
-      "hash": "171f48c7b0fa45b0fced95487767d28b98a3b57594363dc8dfb803c65f5f231c",
-      "size": 8986
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020001.json",
-      "hash": "2817f94dc5cd8890e756f40445bc64d78dc1b50936c877d42bb3c407a507bf8d",
-      "size": 9261
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020002.json",
-      "hash": "338c57c01eb579d57d55209143c98251b458cf24a02729a87570e8d0b907200c",
-      "size": 9197
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020003.json",
-      "hash": "e033641a18eb1713e25ab3f017371d27bad91021cd1df7e92f9ebc3e5a08288f",
-      "size": 9182
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020004.json",
-      "hash": "f160bb8eae01d9d815c29d39c6672b9eca46ffcc22df827f279885172979353e",
-      "size": 9762
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020005.json",
-      "hash": "6737e0ac0827d5d213e5893cd8d543db94b3e0518e3f035a05eb0bb3494f28e9",
-      "size": 5243
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020006.json",
-      "hash": "1ae4c28077450daa7cbd2bacbce961f11082608f46f944a6669fcc88d29852d1",
-      "size": 6967
-    },
-    {
-      "path": "assets/story/data/04/1020/storytimeline_041020007.json",
-      "hash": "86ba60875283dbed1d29ee4d829744bc7d79febeaae4ecb72aff4480aa57a315",
-      "size": 7942
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021001.json",
-      "hash": "f45dab00ada67dd562ff87573c5bfc27807b2a72a030242a22e7eb20bde3eda9",
-      "size": 10479
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021002.json",
-      "hash": "42e6d050d03849051705ae0472efa67e3b94d3ac12199285ac858d5707e04e17",
-      "size": 8749
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021003.json",
-      "hash": "d7ed3d409253db7f00d86eeadd366147682cda7eda818c74e2275c786f279fd5",
-      "size": 8646
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021004.json",
-      "hash": "a1c5b6d898b4d45f8ecfec38fc03d8987a3a268ae8aff99948588ed0af12724e",
-      "size": 8413
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021005.json",
-      "hash": "721315a8bd2e9a60b427ad8880c118539fab8ae831f9a74832b466c35591232f",
-      "size": 6363
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021006.json",
-      "hash": "a58fe8bd1f85ad4f7ec0da119ccad35333a86ef98bf481822b54c51e5f98bd2b",
-      "size": 10044
-    },
-    {
-      "path": "assets/story/data/04/1021/storytimeline_041021007.json",
-      "hash": "d0e63ba54e385b98c1360fd6a0d50e1140835a71f44d777e7db06ac8f670d75e",
-      "size": 10816
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022001.json",
-      "hash": "64da899bcb9af226c6bb1920896a3b66589779f15c3fc217e3d950a666b49acc",
-      "size": 7194
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022002.json",
-      "hash": "94ef702dd62582385a7930c0b80c38136f20f8331ecd6b5300c9401c1a552d3a",
-      "size": 9837
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022003.json",
-      "hash": "e7587c0befbbdf0330726056ad86c11438754ee0fb72b132f788b2f95fde4cd1",
-      "size": 9458
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022004.json",
-      "hash": "1ef66828933a953358e6703fa6b1a76d90194995a739b50febdd04f726cae0ce",
-      "size": 8314
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022005.json",
-      "hash": "4eb480abc2e329b646f5e0175e0aae0b62a2e45460aae4008aa6d5d8ca05ae61",
-      "size": 5993
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022006.json",
-      "hash": "14745c6ce244d4aad3fd88e2e714916607993ed0b7a36f9776d3fd08969772ac",
-      "size": 10083
-    },
-    {
-      "path": "assets/story/data/04/1022/storytimeline_041022007.json",
-      "hash": "a7242912e5cd87c6b76ec1102c1661c5468b2c48f6d47ea78d44919399515e45",
-      "size": 10046
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025001.json",
-      "hash": "2139b581cd153222fb1ac6312e4e5d4128b0e2fc7c9e30d6ecc080c1f247887b",
-      "size": 7507
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025002.json",
-      "hash": "3b6f658f0b9385b864722a69d6b97036f05605569df8b27f065f278516422675",
-      "size": 8069
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025003.json",
-      "hash": "381bc2ba23ca558a9ae2f8ce5b361027b6f2f5e60abe10618620c3db7b1b0a9f",
-      "size": 9472
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025004.json",
-      "hash": "51b60fca6150e290f73629e00fa8d1684203fa1abbc9e7f08513f20b9f84ddb7",
-      "size": 9408
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025005.json",
-      "hash": "b4a8f8dc785df09fd5d9360a8d6067477fbf9392e3313efe5a9147a85dc2a24b",
-      "size": 5179
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025006.json",
-      "hash": "f4f0e82dcb3f0ac74b89227512a18119278ab83901b9fc90134840c5ca3ba354",
-      "size": 9052
-    },
-    {
-      "path": "assets/story/data/04/1025/storytimeline_041025007.json",
-      "hash": "a1be87dd0d187769f3c7bc25da2cf0f725116b4c21819e85ba7f024f1c7662c4",
-      "size": 9227
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026001.json",
-      "hash": "e631fe4aadf79d236a5139e4a9fcd16dd00a1bf967e59abfe174efab469ff781",
-      "size": 8396
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026002.json",
-      "hash": "3b2b36074582d96572a37808da723f4c62ad992a0d98b6f33a1d2ed2a2e11844",
-      "size": 10321
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026003.json",
-      "hash": "d1ccee9475f9f3587cd9cf81b2ea993258017298e5282343e5aa9e3b441b69f9",
-      "size": 10551
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026004.json",
-      "hash": "65b46600abb8689f6842b457f54849c831dd26ba382599a43225bd0c81957cf4",
-      "size": 10760
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026005.json",
-      "hash": "d4503e87b6d1509bbc11e62c9b3107be1cb097e79a6d8228968b2a1ff830ac37",
-      "size": 6474
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026006.json",
-      "hash": "52216cd943c2732dd6866b19d949d7f2162371aabbf20bf3e75861e0ea0d8cb5",
-      "size": 8567
-    },
-    {
-      "path": "assets/story/data/04/1026/storytimeline_041026007.json",
-      "hash": "befb410b4b8ff045feef7edfd52b100e9dece513509d3c45d5ef139422113bf2",
-      "size": 9890
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030001.json",
-      "hash": "9db885228cfa18e75407e5fa48f04bf798c82a2165c76bc2fa4429340ee7c572",
-      "size": 7602
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030002.json",
-      "hash": "aa28a646a94b3138dc29f952310b3f67d3ca2dd85cd980e5ea0206482b9fa54e",
-      "size": 10472
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030003.json",
-      "hash": "c8846cadafbf0c8964164987f4258608107c9b07919a34162b3038f6473713e5",
-      "size": 10891
-    },
-    {
-      "path": "assets/story/data/04/1030/storytimeline_041030004.json",
-      "hash": "09274ddb34b9b0c447a7b3e4bde5864a765a0cc7ea2a92faab95cd017bd0369e",
-      "size": 9006
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031001.json",
-      "hash": "fb9552be2da59707ea69d7fb25f8b6e91afdfe8eb75d1b24830d6f1f4144f43c",
-      "size": 6176
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031002.json",
-      "hash": "b356a83f7766abe8512e1176fc732ca075d2902f6a717e73aa2ef94cddd40aac",
-      "size": 7753
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031003.json",
-      "hash": "eaf73b267a551fe4d666602ac4c3dcb1798fe94f6b0c791c87e47b8376653190",
-      "size": 9987
-    },
-    {
-      "path": "assets/story/data/04/1031/storytimeline_041031004.json",
-      "hash": "8de7cfb4d3e2541f6a7da061ea58dd7c82440410595651615354ee1c50896f7b",
-      "size": 9870
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032001.json",
-      "hash": "dcf19fd644736e588189ec02cc093a3594cd9308beef8ccc08c1788de59b0ac6",
-      "size": 9762
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032002.json",
-      "hash": "b17f06905188f8bba7449c9f78bd77afae8d9b599c5e163c33bd177a4f70f09c",
-      "size": 10757
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032003.json",
-      "hash": "39e565a4c6445182f7d552e652fdf5c7ec05d376e1d89843cb2493f4c7461b1a",
-      "size": 9722
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032004.json",
-      "hash": "add18abdc239d1b9cb5c7560784af5a281fe83a52163fbc67db564fb7a0c0bbd",
-      "size": 9581
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032005.json",
-      "hash": "372c0bd7eb31f4b7c257382f393817d6895cf2f1d0cd983fbab757bc6a7d5c79",
-      "size": 7152
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032006.json",
-      "hash": "7e5bd4bb456343855bc7dfc4020158e79caa1bb9ca44373d9cf698f36e5af621",
-      "size": 10003
-    },
-    {
-      "path": "assets/story/data/04/1032/storytimeline_041032007.json",
-      "hash": "9f72d28ba9c0ec36d2a07be885be338fd82022f16822c6807d6b0f6083476433",
-      "size": 11491
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033001.json",
-      "hash": "84c535e2a12db03ac3a66214d0e51455e7be4559f1558e567e3da019a7e4ac98",
-      "size": 7454
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033002.json",
-      "hash": "b925c50ded91b38041c7f27cf2ebb6101d8897c657990d586642cc7d16559644",
-      "size": 8115
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033003.json",
-      "hash": "d5ffe17d6557bbd2a14db0c1972b2d98aa255e1d0c94494b204994970b35de93",
-      "size": 5649
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033004.json",
-      "hash": "f55beae255db091b92e62b6b4058348eae63a982dbb0e5a409952c16eda4b31d",
-      "size": 10804
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033005.json",
-      "hash": "766f89c0a4b43f0465f3d1ea280e2469975d5d2a1c75a42369a59bebd13dfd55",
-      "size": 5021
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033006.json",
-      "hash": "cf17ba5660486637862d38444ae043892fbfd7681cfe0c1c844c89af1c707dc7",
-      "size": 5977
-    },
-    {
-      "path": "assets/story/data/04/1033/storytimeline_041033007.json",
-      "hash": "5312f24d4ba60f3657b391b5c646efdb9cdfc1384ef941ba4dee2c08e10ebb4c",
-      "size": 7270
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034001.json",
-      "hash": "b383561e7dbd6a4e1dac8cab8545802c018d1b38d9f3b1e5362c4f874d117257",
-      "size": 11718
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034002.json",
-      "hash": "33be5bd95563f7dd3859415b3984f447bc34e181732206fc44cb9533725376f5",
-      "size": 9083
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034003.json",
-      "hash": "c8908533be6ff1df9e5b3bb386c9af625279ad4968f4c03e592fabd6d9b70965",
-      "size": 9032
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034004.json",
-      "hash": "0310dd7b8e2d4933ba619889ee1aa25010aa5a14fbe320b8cf9263588bc4f982",
-      "size": 7948
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034005.json",
-      "hash": "f777b83692182daeb1b5294bcf982f5259d08fcb64f9ea2206a5869db006374e",
-      "size": 7423
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034006.json",
-      "hash": "b95600a3ed60fc96a75ceb975d09f68dff2d12d6c7e070bd5f200e9abfcaaa28",
-      "size": 10475
-    },
-    {
-      "path": "assets/story/data/04/1034/storytimeline_041034007.json",
-      "hash": "67f399435f386c564f30109052b17cb11041bb13748f10dee48a2e733fad6e03",
-      "size": 10882
-    },
-    {
-      "path": "assets/story/data/04/1037/storytimeline_041037001.json",
-      "hash": "522b37babfe167c980bad8bca0ed5c3627821ec9fd212a148a04d316912cc815",
-      "size": 7065
-    },
-    {
-      "path": "assets/story/data/04/1037/storytimeline_041037002.json",
-      "hash": "b365fbcfc0283934c7106f14449fcdeb1c0cd0b08745c9097d2cf58236a24272",
-      "size": 10043
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038001.json",
-      "hash": "8cdd8677ba8fb03fc74556068a55bf3f68c0e83247573302c8c51fd28f872cd0",
-      "size": 10596
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038002.json",
-      "hash": "a1f593d4378dcd582d0a11fa08a294491cb031d91ab104f5c8f8282ce2064d6b",
-      "size": 10176
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038003.json",
-      "hash": "3327249ebc930717acef9e6049298ca27038d95cb4d3ca098bd8db253055f34a",
-      "size": 11048
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038004.json",
-      "hash": "587700e2576308d96ea873af80e3f75fc1b6755ce0c5457410960943200bf63f",
-      "size": 11313
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038005.json",
-      "hash": "58f72c064f7b751cb31efe18dea773ce3d53d423e96378005aa87279e36b0623",
-      "size": 7624
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038006.json",
-      "hash": "ad41b9150b41b8d469b1fae9a19c02a1efc02171288e3606e06dede2712659a6",
-      "size": 10284
-    },
-    {
-      "path": "assets/story/data/04/1038/storytimeline_041038007.json",
-      "hash": "f1e46ea67b8b1828ce161af5c51fb2795dde1fac908f450c2d73cee042cd5cdd",
-      "size": 11114
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040001.json",
-      "hash": "aba922dded2d08ca767610f9b453ec1a725a4d586af8479ff3bd27c3f8dfca20",
-      "size": 8133
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040002.json",
-      "hash": "28e8b77d13a4a2552e160f03cabdaca30a66f4f49649a33c877f7f330d44539b",
-      "size": 8071
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040003.json",
-      "hash": "29401d3c26abeb6b1d299c07f2de33f47e7fcd838bddf10da91b46f748bfc372",
-      "size": 8762
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040004.json",
-      "hash": "ca6ba51bfb8788976cd2a7d985f5e759a545c7f7161655dc25cfda81155a44e2",
-      "size": 9698
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040005.json",
-      "hash": "f11ba8479607febda9491809288d9f3c158e9dee5005a981029ba8277631bf42",
-      "size": 5827
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040006.json",
-      "hash": "9b3b7044f82021f318605c24bb0de93f2cca34389863452222f7ce7d98fb43cf",
-      "size": 10673
-    },
-    {
-      "path": "assets/story/data/04/1040/storytimeline_041040007.json",
-      "hash": "b010a85d5ee21c36d0050e9d9bf2826177aa487b62576277c0a0d870cf9d7245",
-      "size": 9442
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041001.json",
-      "hash": "def1bef4cce86e06b8b1a109c8007eb90ed1a6d36cab2b18a54579ab97b17f69",
-      "size": 8983
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041002.json",
-      "hash": "a2c5417824ae8116de6a5165a43a14e700aa0c34cd2bf482425f749160d367f0",
-      "size": 8807
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041003.json",
-      "hash": "108daeb611e205301b5dd315b01ac9c06867fbe3fa77384383c860917955f806",
-      "size": 8063
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041004.json",
-      "hash": "fd9701d2546d76bfb16722b20552b99f8f8dbe00c2fced417692257e438c1fc2",
-      "size": 8682
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041005.json",
-      "hash": "d3c012a92c47b1336824a39f0b24b9dd08b6480a8d7024b09a7dd207e448f070",
-      "size": 5853
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041006.json",
-      "hash": "84ee4170cec95c2510ff0ffd3213db1ce47fcad6cb0aec1fa7e9a622f14ae975",
-      "size": 10226
-    },
-    {
-      "path": "assets/story/data/04/1041/storytimeline_041041007.json",
-      "hash": "0eb14bdc4fceae13c6263fbce13306292ab7c894c149427e75cfcdc88a8e5ca3",
-      "size": 8227
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043001.json",
-      "hash": "a870227133efe83cd6c07533888e21d8c4304ddc37808f0c717174f33ff7ad20",
-      "size": 7857
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043002.json",
-      "hash": "f116f7780013dd52b12aff5cebc1639257b571dbc9d7510d821dfb79f8ddbd06",
-      "size": 6625
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043003.json",
-      "hash": "43521545f5557424dfd054f3e97566c3bdcb11b1fe820b8c79a920b265e18fab",
-      "size": 9931
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043004.json",
-      "hash": "fae53a4598e7185ee59eff4c0fbd218a6c7fe288319831f6a3f509e08f0718b5",
-      "size": 7766
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043005.json",
-      "hash": "b19a7af392ecf3965bdd253dcf6a9b358d177975f75a60200a105aaf00587957",
-      "size": 6072
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043006.json",
-      "hash": "524be10b977ef454b9e1dfe92d6a9430f71aac47c7121f248e974defcfc8ec24",
-      "size": 8101
-    },
-    {
-      "path": "assets/story/data/04/1043/storytimeline_041043007.json",
-      "hash": "1de2cdaefce996604645b9bf2cf495f6b547b89e843cd1ed818aa9db3f81dac0",
-      "size": 8140
-    },
-    {
-      "path": "assets/story/data/04/1045/storytimeline_041045001.json",
-      "hash": "4460c22aa392c5f72af978cd447c2689fa14cd4f7ca57436e5caf7204ad18935",
-      "size": 7548
-    },
-    {
-      "path": "assets/story/data/04/1045/storytimeline_041045002.json",
-      "hash": "7cb36c107b26f032bb6e34d9b35966de8e349f89b6974cdb9b3aee99d4b6572f",
-      "size": 6548
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046001.json",
-      "hash": "104662f694819975da940edd3263b0a6621d961fbf12c295a7ef580fdcf80650",
-      "size": 9089
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046002.json",
-      "hash": "9cfa0223bc75c44f7e1b6864de09131bf41a99163adc6e0e26485aab46260b0b",
-      "size": 9889
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046003.json",
-      "hash": "81172ec12c692272041810fadcd4d50b179ed0692cce99bd912692dfa627fe5e",
-      "size": 11085
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046004.json",
-      "hash": "6f6f652a149b04a9085bd7078c254fbbf64bd9359d43dd9cf9e8f4a065ffbcd7",
-      "size": 11035
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046005.json",
-      "hash": "19293dbb1f0a10a1ef2c4a3896782b8f3b5dbed735330ce5d9e4dc397db48499",
-      "size": 6405
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046006.json",
-      "hash": "6488ffbd310c4fce1b64220343fc93f6c500029e9fbf73c4297c93e379fa9073",
-      "size": 9578
-    },
-    {
-      "path": "assets/story/data/04/1046/storytimeline_041046007.json",
-      "hash": "b67aa31bdde28a0c4c619061eecf43b02339fb2afe30fdd499ad8733a89bbe9c",
-      "size": 10279
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047001.json",
-      "hash": "376a150304a2f350b270d6700ee5f1945967df3f3cd92ff69366e1cdb7e5520e",
-      "size": 7043
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047002.json",
-      "hash": "92cc6abf5ebd4701df50fcfc8624dae8b40f9fcdd4c895f4af8921f79dfbd654",
-      "size": 8736
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047003.json",
-      "hash": "9a2e7b2a486d28c7862d796dd2fe502efa6483b70b68e5535e51ef82d6dbcddc",
-      "size": 10945
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047004.json",
-      "hash": "08e10c88d7b4ad3de1dcad7f173498ce2f2caab5b48f8b36bc0038e5517c7be6",
-      "size": 10267
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047005.json",
-      "hash": "1eba1eceb7300260c74afa3009552ed69ee17fd126914cd5d7902a0d27a8133e",
-      "size": 5414
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047006.json",
-      "hash": "8079009955aeb63ef87f84db1b878aebdf910bdf77025126522b8b72d62b922d",
-      "size": 8863
-    },
-    {
-      "path": "assets/story/data/04/1047/storytimeline_041047007.json",
-      "hash": "9e6c7688ae6ebd56bdfd6d74931127ce1cc5b8de3ad2f985391af63586036aab",
-      "size": 9632
-    },
-    {
-      "path": "assets/story/data/04/1052/storytimeline_041052001.json",
-      "hash": "089216a0166e8e549f680f00e2fc5d733507b8625b4ebcf265512fcc721dc5cb",
-      "size": 5988
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055001.json",
-      "hash": "f63aa8b7e51d79e72b606bd3a63a747cf63871355f13e30f21aaa7d6178a0762",
-      "size": 7371
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055002.json",
-      "hash": "60d10aae6bf07620750d5db6af91d607db0fc1d27869d9a2648a8ad5234b8c2a",
-      "size": 8486
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055003.json",
-      "hash": "659135c9c8c9824a849aa5e784a040fa9944c8362eb8720871d9e2484343bb2e",
-      "size": 10735
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055004.json",
-      "hash": "c8d366a2ab376d03a9552054d00c8774fbd72db26a6e1ba099dca182746ae582",
-      "size": 10469
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055005.json",
-      "hash": "14c317d7b2b1e5645c3e6120b6041590ba244e3fd39013479ce85d85602e89e8",
-      "size": 5579
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055006.json",
-      "hash": "afcbabeae4309936e4d2b003c4d23930eea12397d8e7a95fc8529d286b7499f8",
-      "size": 9520
-    },
-    {
-      "path": "assets/story/data/04/1055/storytimeline_041055007.json",
-      "hash": "18536b6567c92483c243c6ddc91b1ff4c59622bf1d24f3e7f897bede0048d273",
-      "size": 8657
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059001.json",
-      "hash": "2015e68b54f53b7326a68d6f95ce0bce0cbfed03b574bbb58288079ffb1fd611",
-      "size": 8826
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059002.json",
-      "hash": "c09c5edecf0b71ea7af1b0e76a96f9343b6648b4e95fee06e2eb99a48bf07b5c",
-      "size": 12525
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059003.json",
-      "hash": "515637c572259236fc29823b1a9844a4a8840cbf2683b4682f97a2deb30e2de3",
-      "size": 11150
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059004.json",
-      "hash": "8e277e0f82980539887eb84da9e3c1141161070ebd1753deac7b0d377d13884a",
-      "size": 11090
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059005.json",
-      "hash": "298712934372540621e56dac9a365d456bc26986435eb724d0654e40a5b8c639",
-      "size": 9361
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059006.json",
-      "hash": "021d8b86b987707c6f2667a3cbe6982e0fa50d6d4fddf672f9eb4adfec169b73",
-      "size": 14683
-    },
-    {
-      "path": "assets/story/data/04/1059/storytimeline_041059007.json",
-      "hash": "95ddfe1b436603b4d52c30daea91161204d9aaf5a89d0a00e99a491f9f79041f",
-      "size": 13547
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060001.json",
-      "hash": "d46d563c1635558f78d72fe779cfc440f85440f8db2778b8ce6b135711d00a32",
-      "size": 9254
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060002.json",
-      "hash": "29699ce0934331b3f10d0bb5e7413d9fef95ddcd51b0ab5c2e9e6061c75d74a3",
-      "size": 10017
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060003.json",
-      "hash": "bfbb1ecf4aa94f3f919d66499fc4da1f549e0393fc45bfae751fc3e021db757e",
-      "size": 8759
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060004.json",
-      "hash": "2f7cf503bddf43fba9af4f1fb4bc42d842052354f9a5422ac93eb303eb57426d",
-      "size": 9047
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060005.json",
-      "hash": "f9ebfde044b147653c720d491ca0cca1ef7a8b25eb2bd8fea2a9abe061b336ec",
-      "size": 6411
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060006.json",
-      "hash": "046875bc94153b4dcb334280e5529068145173011256f0452dd738ab39dcf283",
-      "size": 7676
-    },
-    {
-      "path": "assets/story/data/04/1060/storytimeline_041060007.json",
-      "hash": "2df19e3ab815d3dd1bf0eb8dbc2b82b437929b546000515d3c6c1bf77f8d1061",
-      "size": 9435
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061001.json",
-      "hash": "8a11e355f33ba4daeb7f3cc06584f36c1e60f9e836c3550be92b3c9e7ac9339e",
-      "size": 7752
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061002.json",
-      "hash": "57ee886eb5466a540e445c25276be404316b51fbf6727067cbf1fbead7aa4bfb",
-      "size": 8128
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061003.json",
-      "hash": "8dd8dfb026310161249c0df6f7df434ec7de42b7b8554a7ed7a708322e3080a1",
-      "size": 8870
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061004.json",
-      "hash": "0ec0b75cf8ae47b76f2fa2e3ba85635a77b95edd534cf6e0af2dc81d1f4847d4",
-      "size": 9321
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061005.json",
-      "hash": "21ad91587981616e1f2d4f5647d3dcf0e7c21deb7d438bfa18167fd7167a206b",
-      "size": 5492
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061006.json",
-      "hash": "940ebd1b9dc6bde2dfecfc98267aa32f4330a6977e7df54f407c253cd7832b62",
-      "size": 8531
-    },
-    {
-      "path": "assets/story/data/04/1061/storytimeline_041061007.json",
-      "hash": "533b130437f191692235b10e7fc8852bd5e64798c62277ee39377f96b7479144",
-      "size": 9275
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065001.json",
-      "hash": "955a804d491b714f60b872e4538cb6202cb3ed636b50c9759414d6d31e29ecf5",
-      "size": 8710
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065002.json",
-      "hash": "e28550bee6d5ea202e2898b72a6d7e50bded3a7940be5c96d614d08cee0982b6",
-      "size": 10308
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065003.json",
-      "hash": "7487957d63c77112e17cbff2eb0719525e74f0a27853daf16d3bda8e47abe5a7",
-      "size": 10630
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065004.json",
-      "hash": "5ebc119dcd12b90c7791de9c79df2e8c4c451f2b66dd0f4e5b3558da9f29c5e8",
-      "size": 12274
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065005.json",
-      "hash": "a300bc16b1e98a68b63e571773e6cf3df1457d976f17e129af2e22bd6be768b2",
-      "size": 6159
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065006.json",
-      "hash": "426e227766e620502073cb8e30c0e22ce52d23eeab204896c5333a7bbe9b8892",
-      "size": 8395
-    },
-    {
-      "path": "assets/story/data/04/1065/storytimeline_041065007.json",
-      "hash": "d4a701f32ebb44abdecc8a2d916ff636bba91ad902e1994c46e5a17e368bf740",
-      "size": 9450
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066001.json",
-      "hash": "282e43726ef937aa4d4e5c43b9e643e24ed5cfe850c3a760eadbd8508d92570a",
-      "size": 8877
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066002.json",
-      "hash": "ebe9d2da8b88703876208bde64b874d5bd8011509a7e4f1b9d91ab3051d2f6c5",
-      "size": 5899
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066003.json",
-      "hash": "d5650f034a32b7ca9e527b1b8fcf23d2958c1ace01a7719a53cb4e7eb00e0646",
-      "size": 8491
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066004.json",
-      "hash": "d9192f2961801bb66e0cfc2095c37eaa3898a9d3fd645339567b81bd728dbdb2",
-      "size": 8605
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066005.json",
-      "hash": "16f4fc350ed4bce147389a1b81f4912d075257b0b6aca38ef5f9a5cfb3674ebe",
-      "size": 4983
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066006.json",
-      "hash": "3d33e77a9ca3654c8fed65d7c895ce9dfcd6c5b2c08478b23af61dfe8571bcc0",
-      "size": 8085
-    },
-    {
-      "path": "assets/story/data/04/1066/storytimeline_041066007.json",
-      "hash": "8e66aa4351a65d1cb89c3bca1b251f02a9022eb7fa9c4bffceaeeff10a18923d",
-      "size": 8454
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068001.json",
-      "hash": "fd4e6a2808520dc57e45480e2077b77b49371ab62d3a4cf4b538d1abcbb096a2",
-      "size": 10021
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068002.json",
-      "hash": "dea50163f844072a2d6a91eeb1c8855379b9c2735c2f401e020958cfe05823f6",
-      "size": 9929
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068003.json",
-      "hash": "3171026792f4c0a7a24fbc546bc60005a5f491d3c363e856a5fbae1b0306677e",
-      "size": 7390
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068004.json",
-      "hash": "887d5a4af2d18363b299b6250484bcff629ec57603326d17a1cb87af93a73c24",
-      "size": 10354
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068005.json",
-      "hash": "2b2bb01ba98ef8f7270793972186adae46f06998012bb2f31e366d5e8aba5b7a",
-      "size": 5988
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068006.json",
-      "hash": "cea96e11415428bb8735c3859a5ebf8898dc9cec188a7ea2ff5f47377d3296a0",
-      "size": 7981
-    },
-    {
-      "path": "assets/story/data/04/1068/storytimeline_041068007.json",
-      "hash": "53982ec86789c3658e4c6d7877400f9c498478a8aaa1e45a9b25901d3e378e1e",
-      "size": 9115
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069001.json",
-      "hash": "801c8f2297cbd1762cd82dccf8fc8877095260020a0e322ce7d2452b81951b6f",
-      "size": 8466
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069002.json",
-      "hash": "73040957d2d645abd053debe0301a94a6cdb418b147b81ab54da57fcf26bcdc2",
-      "size": 7935
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069003.json",
-      "hash": "3d18fc10cc0fb682c6fce155cae79f2cc5820c91a737d069f95fca7a9afda14e",
-      "size": 8013
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069004.json",
-      "hash": "de2080048e3bd066b40aff05199d501fc91d631c538f816eec42c7a61573b316",
-      "size": 9007
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069005.json",
-      "hash": "a648eb873a321ecc159543dc642456a2fa9210cca2353836388e28284897b0d3",
-      "size": 6341
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069006.json",
-      "hash": "20365a25edcc991fb7aae1e6e6c0a60e7ec73122e9c1e38957f509b98d8ba3de",
-      "size": 7000
-    },
-    {
-      "path": "assets/story/data/04/1069/storytimeline_041069007.json",
-      "hash": "74cb000e98369576d4ff3cd7420b6824dfc8eb7c816fade42a8587be1f3cc7eb",
-      "size": 10349
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071001.json",
-      "hash": "eb16a9cc4043b436688fadaed377ce1f939ee9a53768b2f88216f06da287ac84",
-      "size": 7753
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071002.json",
-      "hash": "d35077e5ba6ec675e2caf81ba1ac0927aab009b1843c7a804625759708f1cbf9",
-      "size": 7739
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071003.json",
-      "hash": "4d45a33631cac784d4bd7d7b7fc27914334b36a2f0de419d6c3d1c5edd5e4395",
-      "size": 9726
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071004.json",
-      "hash": "92e7b8d0b2b05e0f31018fc6912025971cabd53867aa6a16024f1446ff5cc494",
-      "size": 9730
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071005.json",
-      "hash": "6e198c3115b05063013fee4eb438b48a0db45eb47c79ff007481bf03bc675433",
-      "size": 7895
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071006.json",
-      "hash": "97faf379e29ffb4bab696b54c4222a647c100dc6decce5ee1c4330a0deff5cad",
-      "size": 9679
-    },
-    {
-      "path": "assets/story/data/04/1071/storytimeline_041071007.json",
-      "hash": "3a8fe425928995c75443a96ad014adcb0cc87f47edaa757caccbaff948d28f0d",
-      "size": 9234
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072001.json",
-      "hash": "d139b37bd556f02d2c09e4b1df8eac6a2e184b61c3f26566d8aa67fa913fe44d",
-      "size": 10280
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072002.json",
-      "hash": "edbac4c4db8ba375c3a556e15ab15628632e53496c4aa1031960197ecebc575a",
-      "size": 9893
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072003.json",
-      "hash": "d4c6fdad77ff44de35447bb3c97603b65645f8c8aa5a8ea16202e79b758d024a",
-      "size": 9974
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072004.json",
-      "hash": "775565395f0fc59bcb5ab251bbcfb24df8602e88ea26a1209dc12e062f05c63b",
-      "size": 9038
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072005.json",
-      "hash": "eebd61aa760003106b231bf612cc559d26333ec5e9813ffafe9490e1b3c07deb",
-      "size": 5857
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072006.json",
-      "hash": "cea119b811079d39c66c0a9d0dca96bb4da74f9aab49b56466ce41b66372e01a",
-      "size": 8457
-    },
-    {
-      "path": "assets/story/data/04/1072/storytimeline_041072007.json",
-      "hash": "dd47407976bcc21ff2f452a244e970e1bdee135b129f19a7dfd781ec5375ae29",
-      "size": 10043
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077001.json",
-      "hash": "ba3c7fea85994db17c365e5b3ea752a9b1690d30d4b1b0531d605087e2686929",
-      "size": 10164
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077002.json",
-      "hash": "4f74a12057bf53731c4323cf2ed86912a5514a2d5586ce1d501d2ed3284d17de",
-      "size": 6745
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077003.json",
-      "hash": "f23cc6a09ac17e3757f1bb6a503379110ee338272d733fb3fa00396effa48897",
-      "size": 7686
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077004.json",
-      "hash": "a15357217cb6b40cd9ed6e9b67487cb162905125f8693e704d9b01bfce3be2ad",
-      "size": 9876
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077005.json",
-      "hash": "bfc9363f1cca1149989d15cfacf729419be38c04797f15a9aa20d013181344fe",
-      "size": 6256
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077006.json",
-      "hash": "a6d39602097425526ed35dc0f75a5849acf254ddc1c6ad08ae9584534e872ed6",
-      "size": 11354
-    },
-    {
-      "path": "assets/story/data/04/1077/storytimeline_041077007.json",
-      "hash": "ba9ec5146f6d9b378bcdee85a88741790c2e9c7f0d427ea4494b406e5fac27b6",
-      "size": 8535
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078001.json",
-      "hash": "c11ec6f7da74c7f0a9c9db2775b054622861377c37757e88609698e3e55d7ec2",
-      "size": 7586
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078002.json",
-      "hash": "cc1dbaee0fc3b5b8ca26736de08830d694d0c81d26c49eda8348aa335ed19429",
-      "size": 7742
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078003.json",
-      "hash": "07bd93bd91c80e2d1312fc1d84ef6aa4449dfb7cc13781e1316e1cc1dd1b62d6",
-      "size": 10678
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078004.json",
-      "hash": "7addb0b3341042b60b9ff62c783578a4ea46e1508d58bf0ce1dd891bb92840bf",
-      "size": 8632
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078005.json",
-      "hash": "eac6de10b99d24d2f28b796a9a33b282681fcb1f4ffe353837cef1ed6f4220ef",
-      "size": 6288
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078006.json",
-      "hash": "fdf509fdd38ea8d080d58091bee9853b6905f6dcba8c2f1bcf054c0ee0482b93",
-      "size": 7474
-    },
-    {
-      "path": "assets/story/data/04/1078/storytimeline_041078007.json",
-      "hash": "b5cafa32e62e0c727352e9dd580c8cde9f709e93efee479dae09e3d03eaf5ab7",
-      "size": 9335
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083001.json",
-      "hash": "c8508a62e40eb83ec93a38487a6ae980d4b01cfa57a37abca9ddbfb0d2102019",
-      "size": 8312
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083002.json",
-      "hash": "ffaad7b0dd0ab123b34ecca3a873cbc381641c00583077fbf4aae0540dd906ab",
-      "size": 7950
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083003.json",
-      "hash": "1bb35fa8319b1cd358f04bb52b6e020b51c703cbb238a6a3514a39dff62a2126",
-      "size": 10353
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083004.json",
-      "hash": "7d9302de23f98ea0bf4eb45decd2ccdcca8d50a5b671ce9dcb1c3d920b01b9cf",
-      "size": 7794
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083005.json",
-      "hash": "06b41822111bee86ca986389e5538005754fc8bac11b77dcbf780c7d39fe2346",
-      "size": 5471
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083006.json",
-      "hash": "7167e0237913b4fd64379f39f877ab1304a623250631d2995a040c1f46fe9197",
-      "size": 8190
-    },
-    {
-      "path": "assets/story/data/04/1083/storytimeline_041083007.json",
-      "hash": "dcdc8e9fc37cc0a9ab9b552c1ffce9f77688f3278162c3cf22f55a93be44cdd3",
-      "size": 9204
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085001.json",
-      "hash": "8326a6aca604a674e6ce22b70767707132248d3acc41dd9d338c916f41e46592",
-      "size": 8687
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085002.json",
-      "hash": "f2d8ef67c44c77e820dc567f70495ec079f1619c7e86438cfe0d3b537fcc5d43",
-      "size": 8818
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085003.json",
-      "hash": "559c7b13223143f41a4fc180fd6125cb152f5a616822c81b941cea9bd8888a11",
-      "size": 7591
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085004.json",
-      "hash": "afbd23f37f2273a44d81fbff5eb3f354bd12238b41a82afc75142021c82e3e12",
-      "size": 6816
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085005.json",
-      "hash": "003f38d210cce3711e0803b65dc3ac32185aa238985467f1a8c63499e50d6451",
-      "size": 5988
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085006.json",
-      "hash": "e4f7f37b099f2fb5ef68a2918d99d07eb5142c5a4c728a7c75fc0989d3e68070",
-      "size": 7416
-    },
-    {
-      "path": "assets/story/data/04/1085/storytimeline_041085007.json",
-      "hash": "1e5a4dbde5716628cf9ea34b1ed78e04dabcf6ff6be6b4ba5d5847eb53933d4b",
-      "size": 6205
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086001.json",
-      "hash": "400c72b2f644147bc46f36d03aabed59bedc07f5fc90cb5bf1658cc44f20332a",
-      "size": 8424
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086002.json",
-      "hash": "931c53e4587a2dd093f5d91b78623080b411e4dc19eccad18a53b94222db58cd",
-      "size": 9663
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086003.json",
-      "hash": "3cc4c5ebb8f47551fc18a3d26787757a4b196a7dd4c7f7a6229926624b90d662",
-      "size": 8482
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086004.json",
-      "hash": "ae054b19019e6445070a773c5f2bd02b99c797aab740927c75a44d4a075f3c09",
-      "size": 10234
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086005.json",
-      "hash": "9f860634b076d124ab482dcebedbcbecd760d009d2741ddfa666ac2c848e3d88",
-      "size": 6108
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086006.json",
-      "hash": "6d867d059010fdb03a258aef1a043ce03e699fe8bf2dbc471d0adfcee04a1f16",
-      "size": 8300
-    },
-    {
-      "path": "assets/story/data/04/1086/storytimeline_041086007.json",
-      "hash": "df78f167b8fcc6a549d4e7ea8aa0a35f8ecffd7c033707091538c9d4f8a3bb66",
-      "size": 10135
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088001.json",
-      "hash": "2c6058d29485ecbd5ccc9b9052158066a62ff0781ee290e74fe0d41794f7ad23",
-      "size": 11100
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088002.json",
-      "hash": "47004d83b62fd83f1ed45bc199c1b2642cd2eb30d55fe754c2a0d24194fed7fd",
-      "size": 7538
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088003.json",
-      "hash": "f956f4ac46c25013c8cb35756027350009828142d5aab0f4b55be0b3e2ead553",
-      "size": 9827
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088004.json",
-      "hash": "446f57296c37ca21abcdefd0c4563c2501977e6f99c6ad98d9383a4477c479ca",
-      "size": 8695
-    },
-    {
-      "path": "assets/story/data/04/1088/storytimeline_041088007.json",
-      "hash": "10ec5a638b725f5bc4acf536bd8805e92c10c258692107bbecd5f863de9919fa",
-      "size": 9928
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091001.json",
-      "hash": "b74f0e93e8d30abd9939644bfc632ed56c48998f4fb3e44de6c74417bac4c076",
-      "size": 10051
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091002.json",
-      "hash": "6c7624004f2ab55763c538de942104b2ee7a074085b16e5f77c162c0b3754249",
-      "size": 9322
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091003.json",
-      "hash": "e85faf38985de138c36b8f9f93a80d6e632f50c21437c6024554604dd794e89e",
-      "size": 10665
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091004.json",
-      "hash": "3f8fa7497627f4d76a9435a06984a6921969c1b9c13bb0b8f8ca9bc9bbd8475c",
-      "size": 9678
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091005.json",
-      "hash": "ad6b2a469aa8676b1681714ff72bf37eac3206982ac9101be0412bc50dc10218",
-      "size": 5677
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091006.json",
-      "hash": "79cbd823b367e70d4f4edec0127a36507e754a30801bf0fcc4e7dbb10e753f91",
-      "size": 9564
-    },
-    {
-      "path": "assets/story/data/04/1091/storytimeline_041091007.json",
-      "hash": "c166d86d5e8cc8c6c8f5844e6f84411c714faf2abe0c1ac5216e78ecc91bc933",
-      "size": 9974
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098001.json",
-      "hash": "9337a4e31925c59c1bd02d4d5ff3cdf8167a8786c4d6125ebfe43dd1d9741a83",
-      "size": 8853
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098002.json",
-      "hash": "2f71345a03394976f80105b9767b3be5530297128c8fa92ce5f7982c6336f627",
-      "size": 9883
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098003.json",
-      "hash": "ae4077a86724624a44aa8eea9c8c60ada8fb2bbaa261550b84348e2ac148b74a",
-      "size": 11470
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098004.json",
-      "hash": "850cfd21bf552e4135ba7ea7a32cb8d86be2be21c74b520c5047960ebdde615a",
-      "size": 8464
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098005.json",
-      "hash": "0b25f3f9cd80394422762445c5178f3665038b67c4909e201d37aeb716eb5a55",
-      "size": 6668
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098006.json",
-      "hash": "f9b16fbe243dd367e9ddccbd2d9db19d1f89691aaddd9c8932a37f99f9741045",
-      "size": 10027
-    },
-    {
-      "path": "assets/story/data/04/1098/storytimeline_041098007.json",
-      "hash": "db44cd9e96781a96fd36ffb5ed84663bcd4d116986601ec44a454574765fbbfa",
-      "size": 10210
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099001.json",
-      "hash": "bf2652a4e5121e7714776f784f51980dbb5750528112e4d63fd7b0376af37928",
-      "size": 8345
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099002.json",
-      "hash": "ad319347402f8eac535f0d7a24e7cfa10ac12b07dc135a7510efd170fb03d008",
-      "size": 6843
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099003.json",
-      "hash": "bb58dfc8ae0d3f97ed7c4b2771de8392114f04bbca7a182439d25629302a3fc8",
-      "size": 10353
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099004.json",
-      "hash": "a403226b01e3556f2a31fe6d8395579b767f0018264d293b01d62350e43f2620",
-      "size": 6382
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099005.json",
-      "hash": "e4ed31ac8c1b3c4349fbb436431d92e6708377852e647268db20a9f4a083886a",
-      "size": 6395
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099006.json",
-      "hash": "0b9b9b8c0d1d6920b101372e765e230f6d9db4f388da595db9bbf96f7b45febc",
-      "size": 11115
-    },
-    {
-      "path": "assets/story/data/04/1099/storytimeline_041099007.json",
-      "hash": "8f4155c4c618b0c912c9e4ad69acc2a298ef11b571bdbc193d3eaa681283160e",
-      "size": 10311
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104001.json",
-      "hash": "1226244fc32541cbc4c2edede6ac9e7e5378f99ad8240758fb35b5269d126af3",
-      "size": 8747
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104002.json",
-      "hash": "1a8a6c9bfa378b767403f3dcf2bda8768826e97c90be600989d958e3137fc6c7",
-      "size": 8579
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104003.json",
-      "hash": "1b50eb5c362b2f01c1af61dcb9f771d87136d3d877c7785001b17051b7ce7573",
-      "size": 7766
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104004.json",
-      "hash": "70df52b985510a2a6580b3cfec433b709182f4e13bd7fab570db59b995779d65",
-      "size": 9036
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104005.json",
-      "hash": "7cd4e3008c1fbfa2badfef0f9aeb8e3e29f1bb6797819c3c0a26f8452440e963",
-      "size": 7477
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104006.json",
-      "hash": "8b732fce6d6998e6193818fcccea1fc3e4df11d0d0c316b493e92b27e88341cd",
-      "size": 10423
-    },
-    {
-      "path": "assets/story/data/04/1104/storytimeline_041104007.json",
-      "hash": "933d0691633b8840f0e0f6616a497e7a14b17408e7a530a0c511f13437581df6",
-      "size": 9859
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105001.json",
-      "hash": "cf8f0550cd786a4618568d8af547e1903463878299ed875b7ed2748a36b07bb1",
-      "size": 6036
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105002.json",
-      "hash": "85e5951782616c34b3807a0d9b7e7567274b677e7898221ebbfa0a0ad17617df",
-      "size": 8473
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105003.json",
-      "hash": "e9fabfa9a0369aa161f59e5b6c9daee871b75c8ca67dcf7b51ad06327d7f906e",
-      "size": 10084
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105004.json",
-      "hash": "b34b2906959f39adfd40384b361a4e15f9fccea05854d649c71f59aeacf01c35",
-      "size": 9101
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105005.json",
-      "hash": "497464d2a6d6ff9ec92f13456209c50fedb9047eda5d764c73d55f6506f36715",
-      "size": 4708
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105006.json",
-      "hash": "316f3eeb3430b43d87ea7a8f179400f5e785b8c92f1aa8f72cae19b4b00cd190",
-      "size": 9148
-    },
-    {
-      "path": "assets/story/data/04/1105/storytimeline_041105007.json",
-      "hash": "46577f49410361517bb3fc2c8a096f8e4a746cd6186debb232663bb03afd1288",
-      "size": 8688
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106001.json",
-      "hash": "611e97febf203e9112b778835ce11e3bda09e4cd01a365fae54daa8b7c73dfeb",
-      "size": 7632
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106002.json",
-      "hash": "1db96753cfaf4f0e5f0e30a28bd167189b81698e9a7cb9ea3c15fc1ec56d9932",
-      "size": 8965
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106003.json",
-      "hash": "54df4f2e13a5318cc4eb311945202f668613297fabb5fa3fb2e77a979791fdc9",
-      "size": 11018
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106004.json",
-      "hash": "cc79925265ac46f9521cac5ee8300fcfb7be488fd110a11823faf3e611ee25af",
-      "size": 9167
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106005.json",
-      "hash": "9e2c29b47e21cdcaafbb13552eb3b77e952bbbcac56a7b44e7dad529ef46304e",
-      "size": 6350
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106006.json",
-      "hash": "f33a3d7c826d2dabbd6aff8c110b97ce18599af617d05fe14c6d84ee38c7de50",
-      "size": 10490
-    },
-    {
-      "path": "assets/story/data/04/1106/storytimeline_041106007.json",
-      "hash": "000d93413d0836771846883a688b5f5d93568f3c3de64d9e4278aa67ae115ce2",
-      "size": 10840
-    },
-    {
-      "path": "assets/story/data/08/0000/storytimeline_080000001.json",
-      "hash": "af7c597149ec796f5ddf0aaed1cef4b164e9fd8575e7611a0c227ceffb036530",
-      "size": 3537
-    },
-    {
-      "path": "assets/story/data/08/0000/storytimeline_080000002.json",
-      "hash": "40343b5f5ff14d9859931c684e3b2522c91cf5e9c98134dfe40a3e11bcdca179",
-      "size": 1952
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002001.json",
-      "hash": "3f8c48d40b834582a59e914667352fa83c1c3128de6f38b4b56e11dd1d2e3ef2",
-      "size": 9911
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002002.json",
-      "hash": "810820df0e78295d781e336a68d5c08eb40976ebcc0ae2ada0a479c5cd4d2885",
-      "size": 7079
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002003.json",
-      "hash": "c6fb9f08490db494a6e6c2e3802a713159b8fd23d1b38dd9de7f9fd425f3fb79",
-      "size": 6418
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002004.json",
-      "hash": "e55731f960b4d8bf327bfa93a7f3d11bd8a67a0ecc96e13d57833501edd91349",
-      "size": 6926
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002005.json",
-      "hash": "e12ddecada6bd0f79e600ac626c17716a220874884ba8533fd4ee2e61950a671",
-      "size": 6798
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002006.json",
-      "hash": "f98e633e77e61461cde0f89c53c68e8d160b0e6661090dbd2fefaeea0d0cacef",
-      "size": 5389
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002007.json",
-      "hash": "a77e8f7069ed57ea6b02048fd0f75d367bff9eacb4272c0da5cff91cb806a859",
-      "size": 7592
-    },
-    {
-      "path": "assets/story/data/09/0002/storytimeline_090002008.json",
-      "hash": "d3e133b197b8a2bb2ad2d65725e6210ba96b4e768374a30d38471faf1ddac6c6",
-      "size": 6487
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006001.json",
-      "hash": "4e8a3a5a32abde44e235916e9030c281b9550cb536539f96efc94f4ac1557c88",
-      "size": 7577
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006002.json",
-      "hash": "fb03ae3c3c7eb6d1d2eae44393ec893337ecd16d6c5a44b9349f8a5502cd6dd5",
-      "size": 6237
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006003.json",
-      "hash": "438117a9b96e3adff7e32fa0590d451c2a2c05d0bc51045fb3621ade2fed5345",
-      "size": 10541
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006004.json",
-      "hash": "beb1f3c0c32a75cd85f04cec967a40e5f384c116ce12fe2a54760da10e7d8309",
-      "size": 6401
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006005.json",
-      "hash": "33515ad3eee7a576fc5d251a54abb7468852590819ed17e8e0b25b4dbd0cbb77",
-      "size": 7935
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006006.json",
-      "hash": "4d42472da498322a3d6812477dd16b13291407f06187c39c09442ac2e2be0b5d",
-      "size": 6436
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006007.json",
-      "hash": "6752532d7081b7566845b3abb8b97e394c2129ffd55ea6e6d79977bf349266f6",
-      "size": 5655
-    },
-    {
-      "path": "assets/story/data/09/0006/storytimeline_090006008.json",
-      "hash": "e82c20f2038d67c07c71919ea23d4af4605cc4de67fa50278b5aeae1e1072b63",
-      "size": 10674
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008001.json",
-      "hash": "9edd490cbe1e31011208d4ae39719f1ef5f63bc93669462bdbca25ce10b548b1",
-      "size": 9255
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008002.json",
-      "hash": "3d64a4c804ca45006838441a48d4735e8d1aa257a1548abe88a61aff9d991bc3",
-      "size": 8714
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008003.json",
-      "hash": "788338a2e156dfa31a11e21a74241ce2abbd3c3735401e9cbbccab81f9a3fb25",
-      "size": 7217
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008004.json",
-      "hash": "ef887cd703d0591a38df6ce4bd28f8fb31a7dfd4926f961dc2bf38e6d088a9d9",
-      "size": 7566
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008005.json",
-      "hash": "7dfc5d10605921ac7e81d166d33996ed9a9833e341163dc2a120a059fab064d5",
-      "size": 8360
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008006.json",
-      "hash": "ac2b04ca732fcbd90692f584642d487781fa1608342931d6cd2a21fbf2a02c85",
-      "size": 10556
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008007.json",
-      "hash": "60bd5d2966bcadc6ef1f5e50e987c040449de596756cb24a7749ebcbb054ff9a",
-      "size": 7501
-    },
-    {
-      "path": "assets/story/data/09/0008/storytimeline_090008008.json",
-      "hash": "d41256225c29611383fa9e12b1eb7b98e2209bb928b50f28d18dda13920420a1",
-      "size": 7124
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010001.json",
-      "hash": "03de37712824ff8a9e278d55c17d48e50a716ec1d5a6f8352c89764d9818cd03",
-      "size": 10088
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010002.json",
-      "hash": "4c66f2f5127cb38926b4d75667feb7ad94b797eec018368fcf56cf02b4f6c930",
-      "size": 9577
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010003.json",
-      "hash": "aad0b06a6b5eba88ef32d42e03102e4573040194e02607fc488048c2d4ff60b3",
-      "size": 8817
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010004.json",
-      "hash": "1bf7d6a673de8e4d423aa3c5403e6cb8ba07d2a27c39290505cf77a709771f28",
-      "size": 8822
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010005.json",
-      "hash": "d2d178fb700cce540ad808a5a15f24756b72c3ec8966eb880649a09a7d4ce5f7",
-      "size": 6717
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010006.json",
-      "hash": "56f777b76af01955c0c46efa2ba1116cbd9a82fdeecb96d301530e557e534460",
-      "size": 5309
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010007.json",
-      "hash": "f98bd7f1e1646994c76dbac9e69e5514810ec15e31e40d90b246939bf2e12a7b",
-      "size": 7134
-    },
-    {
-      "path": "assets/story/data/09/0010/storytimeline_090010008.json",
-      "hash": "745fb81bbc539fd3ff734ac5f566c2351bde8327e2f2f4585e277cca61ebc0d8",
-      "size": 7537
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011001.json",
-      "hash": "5e0f95d81dfc0461033ca6da70cbb117c26aa4d8314fa053aaac2fbf7eb1a2fd",
-      "size": 6901
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011002.json",
-      "hash": "f6a4805f08e3ad7231900bfc42a855b53c5e312bb7108e5c6d5aa35c42f3f787",
-      "size": 7860
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011003.json",
-      "hash": "4e502551a9488c36925db1d6b9ffe7bb2f4cc54b82a9b88cdd9fc7d96e4be06f",
-      "size": 10453
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011004.json",
-      "hash": "aab44bfd7db9359a9010a50ee434bb7eb043c364aaa8d3be2e9a5f13579400c2",
-      "size": 5631
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011005.json",
-      "hash": "55e9cfc5cd14af35cbc67c86f988d639ff81045403f5a222a572575877533c3d",
-      "size": 9017
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011006.json",
-      "hash": "c7236b46323f8772b471f058632b20998d91a6fcdcf66c1e69ef1c4e04858cde",
-      "size": 7203
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011007.json",
-      "hash": "194c0fce89c4f8d7cda293e31313ab84a5906be49604bee71bf6108752c2bf36",
-      "size": 6007
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011008.json",
-      "hash": "52c70c39f90ca5e117dac7993f0bf356dd3178ffeb7b0fce1558136f612909af",
-      "size": 6045
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011009.json",
-      "hash": "2ca865a921ffe039b79c88b2e3b0a465fa6b86a2928ce32167ef26275a74321e",
-      "size": 8890
-    },
-    {
-      "path": "assets/story/data/09/0011/storytimeline_090011010.json",
-      "hash": "acdf57b2b60702fae447861db06ec0595e34b10df69c0be03a97675be6a8c234",
-      "size": 10734
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012001.json",
-      "hash": "ac2e9c1c2cd80b4f68d231f0ea9922cba31bce2377f59b63eecad690dd67988e",
-      "size": 8620
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012002.json",
-      "hash": "ca181d46b4dde2a836f2df3a4d55a278601eb80ad91128af75383bfee345e93e",
-      "size": 8514
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012003.json",
-      "hash": "60b955ce7c2836b3160161f56ce26696111b563c9cd2cf8e414e3c5bb56abddf",
-      "size": 7690
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012004.json",
-      "hash": "9b0c1b49dd3ae1d456193f2c639b88b7b4c309111b558eea093e7930afa79322",
-      "size": 8971
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012005.json",
-      "hash": "4efff286434855234f1c86de30e23ba6f47e860b4575fcec1ae30592d6d81a94",
-      "size": 9273
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012006.json",
-      "hash": "dd5bc5de42e5390f5f6c41fa0e5ae1b479ba9fa17ab0c7a5201dd3c530c9cad0",
-      "size": 7668
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012007.json",
-      "hash": "7c39c8f77f107e08894b8c98a690ca0c969023ca001fc66bdd1940c475ca45a4",
-      "size": 9502
-    },
-    {
-      "path": "assets/story/data/09/0012/storytimeline_090012008.json",
-      "hash": "3dcebb6c3b4eafcfc4681ebc79aa28d0ddc036b22825083d87a5a0406f97631d",
-      "size": 6298
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013001.json",
-      "hash": "c6134c7e5b96710da684d2b8cd96ee0fa15183b8d11ef97ab360121bf806fdbc",
-      "size": 6862
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013002.json",
-      "hash": "d79385e47a1d8df9a7474c27fe93f716fb9aa9fb08db1fcd53460d1bf8fda286",
-      "size": 10163
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013003.json",
-      "hash": "aafcae0dcadda28a4ec800dd65e9075212369c673ef64b33901da37fa8939a3b",
-      "size": 11917
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013004.json",
-      "hash": "d89373aae8dcd68fbc08a75a98e37299a5993a1073db5fa648f4ea0d12570a76",
-      "size": 10121
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013005.json",
-      "hash": "54c6d68609cdc9d27df715242620b4e247d63c361223fab0d07657b8a7f3faec",
-      "size": 8383
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013006.json",
-      "hash": "8c7192c5c9c17092ccff666658b84f211284fe34d89a891f23e44df8e363d78e",
-      "size": 7791
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013007.json",
-      "hash": "bbdec74783340ca46ff98d1abd94a6a2b957f4f0297bf523bff062491da406ea",
-      "size": 9862
-    },
-    {
-      "path": "assets/story/data/09/0013/storytimeline_090013008.json",
-      "hash": "52bb7e1c24ef4a3e52effdf4666283df543802b8d300b4afca711d91d9c7cf06",
-      "size": 4180
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015001.json",
-      "hash": "e3acc84c158241f2678d40b59507ec27094943c68198f3c6580aaf4fb06abd54",
-      "size": 7647
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015002.json",
-      "hash": "b7b5a7576bfb1bcf819f1bbd6a276a7cff0de938ace46ab3c989bbe010e66d88",
-      "size": 8335
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015003.json",
-      "hash": "b4254297a7c0a3927ee1fa07330b1fa0a62098fca5d939dcd18fcba97531732c",
-      "size": 7569
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015004.json",
-      "hash": "05f9c9ae25645628be44053ade96c932a39202f15fea1281c98702282f112456",
-      "size": 6410
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015005.json",
-      "hash": "b815827d3efe3ee7eb87a08906a9a56feebc940803d0a56038887039f76ba3ce",
-      "size": 7714
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015006.json",
-      "hash": "a26e0e7803a82146df44cc09cc74f6c897164c30d962c40d05aa5f4766ef1ff4",
-      "size": 9942
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015007.json",
-      "hash": "8e693f6b68ce5f85cb8f71670e38d54c1207cb50892a53ed208f283aca1dffb3",
-      "size": 9499
-    },
-    {
-      "path": "assets/story/data/09/0015/storytimeline_090015008.json",
-      "hash": "0c039f0f91359b2de2ea8eadc4a91a4eb53637b270e39c24499389d6406e73ee",
-      "size": 7700
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017001.json",
-      "hash": "9711b623dca3dd3e83bde0f5e0e512904cc1e7e6b93111ed29593fbb09112cba",
-      "size": 6627
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017002.json",
-      "hash": "99d1be99ab8cfa1c25ffbf1285543baa9e3f4f792cdff0a8d44ac2a2ed892855",
-      "size": 8386
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017003.json",
-      "hash": "742fc074738e167547284777df8513aabfc4be5474beb61cfc94d49eab32582b",
-      "size": 10371
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017004.json",
-      "hash": "7150b1297de23162196145622c20c3c119d1358819084711078e90bf8a6c8e37",
-      "size": 7974
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017005.json",
-      "hash": "9f4e5438e57331465b39b579f6e1d713025451c7587c16fb2661dc7a229e61fe",
-      "size": 8067
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017006.json",
-      "hash": "6d8a3efb18a91999c707ed46115ecce89d5ab84d80aeb39d6e3a6eefa162bd17",
-      "size": 8193
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017007.json",
-      "hash": "b0df182303f59f73660a886e025963f4d1fc6b44f5627c966731a115e071d6a9",
-      "size": 7883
-    },
-    {
-      "path": "assets/story/data/09/0017/storytimeline_090017008.json",
-      "hash": "170137b6b861cf01904137e43d8fcf6fc53cde4c835d81a16a35e4d85632eadc",
-      "size": 8429
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018001.json",
-      "hash": "d4094883cc4f371ced8d9dd2c77f9c30bf6f17ee5c6519ef604ad504574bf3cc",
-      "size": 7496
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018002.json",
-      "hash": "02de30ee018c87b27af17c6d580ac733d8e6f67eccd71ca7a6d2e6506e738565",
-      "size": 9179
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018003.json",
-      "hash": "421692dc02eef50f28d7874c010b225ac0b191031ccf28faf2c57354d8b77bf4",
-      "size": 7091
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018004.json",
-      "hash": "590c9893a5961ec30364866afaf1b22ccf510da45d79760b6c54416f5ddb17cb",
-      "size": 7329
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018005.json",
-      "hash": "32cb2db5cafe806c81fd14dce4f6ee46eb4d126607d1c5e9ea7123be7961cf32",
-      "size": 9328
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018006.json",
-      "hash": "bbaa4e935d2864a335c9cb3a0148910569fca5366e410a03137f5e85b82683c1",
-      "size": 9118
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018007.json",
-      "hash": "403dc7c7d5f202c7773a6740090d39f8953eb881ed8821d8f754e393f01a77f2",
-      "size": 7764
-    },
-    {
-      "path": "assets/story/data/09/0018/storytimeline_090018008.json",
-      "hash": "c45fb25d8175ae89ba4f08ccea763906d2284cef798b23910948d8a1ab8c2b0e",
-      "size": 6556
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020001.json",
-      "hash": "be8de8f0016e25f2a443a1285ebe97cdbf367023507e9da223c92de8c733bbc6",
-      "size": 7276
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020002.json",
-      "hash": "7f928a00f3f9c4875e64cc8a9fbfb4585743e2384ae4fe1166a55fcd3986ccb0",
-      "size": 7301
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020003.json",
-      "hash": "322e1c86dc56470e67d8d62b21cf99d663dd17b4a8cc35445a8bc78b3c5917c9",
-      "size": 7130
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020004.json",
-      "hash": "f322fb5c6122570ea7afe7ded8a4ed47eae959882f9bc3d40531af02139305bb",
-      "size": 7233
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020005.json",
-      "hash": "7367f27c1e3fdd77c4a653398c705d5c59ebc4e29ae06cefe686c07a3a01227e",
-      "size": 8200
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020006.json",
-      "hash": "8e16c0bd8a78a292c3f94251427d8add73f25a8d07b9c2ddac4a14fdde34a852",
-      "size": 7140
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020007.json",
-      "hash": "39ab3bd9c955c01dc3b384058a879da254cecafdf80e34cadc875cecec14da4e",
-      "size": 6308
-    },
-    {
-      "path": "assets/story/data/09/0020/storytimeline_090020008.json",
-      "hash": "6567f1bba3cab9bdab2e1995379cd9812f7d65bcf66d5ca6ca2c2d4bf5558ef5",
-      "size": 7243
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022001.json",
-      "hash": "b1bdacb6ad3ff76e0e90a04e6f7ceae46cd87ff47d8aae9500f4badd69ea3794",
-      "size": 8404
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022002.json",
-      "hash": "39744aafb5e3753c062232ebce8ec2fd653bdc602d5cc686bdfa4ee96f2a915e",
-      "size": 5765
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022003.json",
-      "hash": "6dab648f80fa545d462bdbe90e186211e53e9150353991ff5012b968fb9ab3c2",
-      "size": 8283
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022004.json",
-      "hash": "5c01fbb8a4817b45cdb28590fd4beb144d6a8bdbcc0e021e8ace1e2af7bf1b83",
-      "size": 4841
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022005.json",
-      "hash": "8dc224c9f76f9274bdfb19e3fbb12d2c107925d44fffa2bb91595622194c45b0",
-      "size": 7846
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022006.json",
-      "hash": "801d4b14e77c284d27e6da1850cdf426e7d9ab2698a19d289e41954f27d226e3",
-      "size": 8190
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022007.json",
-      "hash": "bc38afefcbb60f456d9ff5035c62ea439ba0ce7dbfcf5dae3201193301cbee5e",
-      "size": 8471
-    },
-    {
-      "path": "assets/story/data/09/0022/storytimeline_090022008.json",
-      "hash": "1c1d99cde9b755a6ccae903924a5196ac514c4521708c16e82a4b790329f9f32",
-      "size": 4655
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023001.json",
-      "hash": "a7466ad3e3537ddcbd4fb1e4cac66435774ff18161490245e5884b57de895b2a",
-      "size": 5554
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023002.json",
-      "hash": "fd1d270b5e02652b52f4384162478e1eb0e9000c7d5ba4524a42f51ba961d2eb",
-      "size": 7148
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023003.json",
-      "hash": "970c0ec146e599a9edd4404f6a9da87dac1fd36441ff7a580037dc5eccbb770b",
-      "size": 9141
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023004.json",
-      "hash": "83cfae0bc50469e5f399f8e7649143cf761aa984148e8d736f46743f0dc32a4a",
-      "size": 6955
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023005.json",
-      "hash": "79fe5e6413f7530228df58cb1831e937c5932ac5dfd20c24253753f82fce07ec",
-      "size": 8215
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023006.json",
-      "hash": "101a0c7c6c716fdde0c97905b2a511f9645a4a9e0053c2649243a8ba2dd359b8",
-      "size": 9359
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023007.json",
-      "hash": "852b375a886664303a284019323c01a883759e51cc8ed55cc3cfafd45d0570f7",
-      "size": 7397
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023008.json",
-      "hash": "28d757e140d6f524dbdac7fc88bfea0a167c64031f39a76bbebce9f4c6189efa",
-      "size": 8362
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023009.json",
-      "hash": "cb3f3200773317de62de30059b722d85956a59f83e9b3ab58530120cc9419d72",
-      "size": 9527
-    },
-    {
-      "path": "assets/story/data/09/0023/storytimeline_090023010.json",
-      "hash": "f40233ff0822fe46971a3aed4a7d331709a73e5c9310fd382c1db0b66604e68a",
-      "size": 7424
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029001.json",
-      "hash": "0a6867cca347a4e1abcd98e5806a15c4b385f034652791d1fc3fe41b0f2ccb6c",
-      "size": 8256
-    },
-    {
-      "path": "assets/story/data/09/0029/storytimeline_090029002.json",
-      "hash": "20af186b273daef57b4899e37ef90d701eabc46fb50d873b697dadee978558d8",
-      "size": 7348
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000001.json",
-      "hash": "44a6e9a7dcb5f8a820349d0a690788e78a54a934422d3effc134cfc8968cb8d8",
-      "size": 2037
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000002.json",
-      "hash": "e8caa7da411998d83524e995dd63ea8549a9d87845cd7c465ea3e3294555c071",
-      "size": 1563
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000004.json",
-      "hash": "320fba38169be526921a3f0c71eeaf46f8771e2c82841fd9901e457d4ff026b0",
-      "size": 1614
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000005.json",
-      "hash": "a09760c37c8796982f629c474fd12c5c2ba3acaaba80b2f403822fd89f2ac045",
-      "size": 1876
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000006.json",
-      "hash": "1359c4f9039c145bf8ef0141e9e9e22b3c576ac830a15d2b85be6f2b7db1fea1",
-      "size": 1771
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000007.json",
-      "hash": "b6ceac177d9966261108d00e2a8986d2145cb3ec588fdf606081d0d65e68c23d",
-      "size": 3377
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000008.json",
-      "hash": "fc487ef745a2185061c1fd1e1fe462379451e965febd6128f8523024f0a44a6b",
-      "size": 3213
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000010.json",
-      "hash": "b9a7f5b79f288fcb73bb56c5c6ff1efb7aaa99d13b35a6a5d6c96eec9ab5615e",
-      "size": 2724
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000011.json",
-      "hash": "c46c96b5318607c7c87b2e334c8688c3fc2266c23ad58925da7d13c748d5cf46",
-      "size": 2847
-    },
-    {
-      "path": "assets/story/data/10/0000/storytimeline_100000012.json",
-      "hash": "cc8796e603f42073bab636efb05730f4461560d4a5b41642ced46f1bfbadb802",
-      "size": 3801
-    },
-    {
-      "path": "assets/story/data/10/0001/storytimeline_100001001.json",
-      "hash": "e7f5be215911f4a313a421b3f8f7e9b3ecd0e0edfd1065d510ef913b193f750e",
-      "size": 7615
-    },
-    {
-      "path": "assets/story/data/10/0001/storytimeline_100001002.json",
-      "hash": "75595d24e4448495f770d62ffc12bec30adc8d52df2f43ac0c5e891837bef82a",
-      "size": 7917
-    },
-    {
-      "path": "assets/story/data/10/0001/storytimeline_100001003.json",
-      "hash": "667fee0ca1068546bfad4338954a0eb4f82d3771d5cfb8715fd51f9ad5e80f93",
-      "size": 7560
-    },
-    {
-      "path": "assets/story/data/10/0002/storytimeline_100002001.json",
-      "hash": "632f128e980f72bd0d62876b1164838f1c67b7f39e677ef481a2e304d1f93bb1",
-      "size": 8613
-    },
-    {
-      "path": "assets/story/data/10/0002/storytimeline_100002002.json",
-      "hash": "96a06eb44165149a3ba3384cba62dcfbdd5aa63286ba58368cf332e3e9bf02a4",
-      "size": 8162
-    },
-    {
-      "path": "assets/story/data/10/0002/storytimeline_100002003.json",
-      "hash": "bd70c2d509bf93dc2d540a8e7c34701be05ba0b718d59e337cc33e2715eaa781",
-      "size": 8502
-    },
-    {
-      "path": "assets/story/data/10/0003/storytimeline_100003001.json",
-      "hash": "c550312be39ffa1bfe4ab6d239bc8eb2d18b8836c646fe5f8728926720b1330d",
-      "size": 7744
-    },
-    {
-      "path": "assets/story/data/10/0003/storytimeline_100003002.json",
-      "hash": "7a776c3d4e98586d407d7414eaa127a99a72947805b5e6e11f016b510dd7290a",
-      "size": 8950
-    },
-    {
-      "path": "assets/story/data/10/0003/storytimeline_100003003.json",
-      "hash": "d24cda5feed80876ed2c86c98f9ae0c1cadfa0249172162897d939bf47153438",
-      "size": 7915
-    },
-    {
-      "path": "assets/story/data/10/0004/storytimeline_100004001.json",
-      "hash": "ad4ce8ad902f45d72bb6c5630020b040be83869b52f5a50cd98d4cf33de59536",
-      "size": 2504
-    },
-    {
-      "path": "assets/story/data/10/0004/storytimeline_100004002.json",
-      "hash": "6f8e7f56d19f89f3cf2b245ab8de6a1c78e7f3358fca1442b8454b48d207dbf0",
-      "size": 2261
-    },
-    {
-      "path": "assets/story/data/11/1004/storytimeline_111004001.json",
-      "hash": "d3c0312f7e5f270a57ae426ed5788bcae139af50596878871e13cf0767aa04f3",
-      "size": 258
-    },
-    {
-      "path": "assets/story/data/11/1004/storytimeline_111004002.json",
-      "hash": "50b96306ef88a4ca268fe5159b1984c4700463bcea0e39b9a9ac25c3d601fc0c",
-      "size": 240
-    },
-    {
-      "path": "assets/story/data/11/1011/storytimeline_111011001.json",
-      "hash": "0d1303ec8d5b5c391aac2c524478630b937aca6d72ec92b4364351b16d9b4162",
-      "size": 241
-    },
-    {
-      "path": "assets/story/data/11/1011/storytimeline_111011002.json",
-      "hash": "3e5349a90a33f86370a0c5359867f57676308c4cb858f57c0a82b7a3e35e3c32",
-      "size": 245
-    },
-    {
-      "path": "assets/story/data/11/1018/storytimeline_111018001.json",
-      "hash": "d03f10f06d8695e017c080deb22d9682fb1894ada5f2f53c9c6f77d59b4278a0",
-      "size": 231
-    },
-    {
-      "path": "assets/story/data/11/1018/storytimeline_111018002.json",
-      "hash": "1fb289076908e589ae0034c2402016dde55cd7b1020ec646d21abe45aa101c9b",
-      "size": 239
-    },
-    {
-      "path": "assets/story/data/11/1025/storytimeline_111025001.json",
-      "hash": "46206240cbb881eef22b9c50211aa95e4a2f171dd110f5694649d3279bfdb072",
-      "size": 276
-    },
-    {
-      "path": "assets/story/data/11/1026/storytimeline_111026001.json",
-      "hash": "3dd37d5c26855c3886c5cff72c3d8989ec7999922ee15c0fa7b39925d5e96c4e",
-      "size": 208
-    },
-    {
-      "path": "assets/story/data/11/1026/storytimeline_111026002.json",
-      "hash": "f6a2688fb40ea9347ccbc299114952f1acc095e68444ae773b54dd1add24ac27",
-      "size": 277
-    },
-    {
-      "path": "assets/story/data/11/1032/storytimeline_111032001.json",
-      "hash": "165ec1ace4a1d42a4c368cd60f2586bb2a4e9dcefc7ef1e76167d8c96fd99479",
-      "size": 237
-    },
-    {
-      "path": "assets/story/data/11/1034/storytimeline_111034001.json",
-      "hash": "abc33dadc77c6a1f94e9067311c88ea5ea9dfe96e1cc41d48cd2b849e48cab0e",
-      "size": 192
-    },
-    {
-      "path": "assets/story/data/11/1034/storytimeline_111034002.json",
-      "hash": "ee6bc12127a113c7ede32966fdae2f68dccbe209528aad0b5216b2b57a54a75a",
-      "size": 199
-    },
-    {
-      "path": "assets/story/data/11/1041/storytimeline_111041001.json",
-      "hash": "647ea5f141151b93f103fa7ce02955acb51b92a39ad750ed077d7f40b05b19c7",
-      "size": 294
-    },
-    {
-      "path": "assets/story/data/11/1060/storytimeline_111060001.json",
-      "hash": "c539919bc40f321c6ad14b60849dce0d4969b4e3ff688bad7a04d3a6b91c3263",
-      "size": 254
-    },
-    {
-      "path": "assets/story/data/11/1060/storytimeline_111060002.json",
-      "hash": "929321bcf89acaff8c67ed5d6d3d5bde03304dfcdb5ac8ee5e7e4e245279f368",
-      "size": 239
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251001.json",
-      "hash": "fcb1eabaeb3199073722891ffcd74468810182c4d09f55ce3e5969cb49e0c59d",
-      "size": 370
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251002.json",
-      "hash": "e98eb9c9238d6bed18c5aeb6f7e2c8edef1366486336e990e6ce6874e59d6087",
-      "size": 723
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251003.json",
-      "hash": "e89867a5ccaa3ac387b844d6c624bd2fb64b4da4a3be8b179ec61b222ba91062",
-      "size": 617
-    },
-    {
-      "path": "assets/story/data/12/0251/storytimeline_120251004.json",
-      "hash": "3e92c1f09b08fcbc9c254e0f7eca6ee4f5ca9aa9cc0ffd2ebb80c7f5f4fa79f2",
-      "size": 550
-    },
-    {
-      "path": "assets/story/data/13/0001/storytimeline_130001001.json",
-      "hash": "49e9a07a91c704382137d4c9fbfda384c16e83c6dc5dce49e587063a2c328a6e",
-      "size": 3970
-    },
-    {
-      "path": "assets/story/data/13/0001/storytimeline_130001002.json",
-      "hash": "5a3c59d30fad2577b1d0de17962d8f2f6299c2df4398f7425244d1e38270f542",
-      "size": 3081
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000001.json",
-      "hash": "042f6133afec52415c4f16e18f820d3da7ea14b2bf3fa0bb500a60a8b4001404",
-      "size": 2537
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000005.json",
-      "hash": "a958f819b15236b452c0a4daac1023e5adc40c003b98d729b0d57798fa0ac7f9",
-      "size": 453
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000008.json",
-      "hash": "48bb16ee229416625aa9ce870688b6fed221d8a3f5079af429f450368ff3b84c",
-      "size": 361
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000009.json",
-      "hash": "fd316d99ce50aecab29a437166e0fec657a2d49717a3764e176788084d243803",
-      "size": 404
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000010.json",
-      "hash": "3476b0ccdc39671f870f24250bda8d92c81acdb470a76287a64dcfeb564fce05",
-      "size": 407
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000011.json",
-      "hash": "db724e78a44b4c6eb98e9286852535e29f44d2d8eaf952c7d85e3ed0a7bc67bf",
-      "size": 435
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000012.json",
-      "hash": "f8f8fccde96cc0ee2789f318e39753364ee6b92bde04784a519d9d3fd29be25f",
-      "size": 424
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000031.json",
-      "hash": "214950ba23142289efed6733ca937157dee94f334542f495fe73ba3b21e5f94e",
-      "size": 579
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000032.json",
-      "hash": "ebd76663a8da23000602132a3d0896e1a3762cec727b84d759f86f9f3a0637b8",
-      "size": 485
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000033.json",
-      "hash": "8e167e67cc774692b103eabbf394a1f0fb7aa226c9cb830bd5f449b7bbee3a3a",
-      "size": 562
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000034.json",
-      "hash": "8671929109c0d1b373bd338f36e92f22f289c837829b790991f347b0758997f2",
-      "size": 898
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000035.json",
-      "hash": "c545149fef66c53234b4ef2ad918043926f7df22337b72ccbaee705c5d1c262b",
-      "size": 625
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000036.json",
-      "hash": "8b7fed87a2f80911a977aca29bd00e1f7aa1051dbbf0e33b9351444326de5ce0",
-      "size": 3617
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000037.json",
-      "hash": "4897f6e1489c4e060dd1a9062f8adfc41712008596b2a609936f66e8077ba52a",
-      "size": 235
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000038.json",
-      "hash": "1267c2049b2f78c6d7cd4107e75e5d139a184e4b6496de2a4139ccad5bcc6e4c",
-      "size": 210
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000039.json",
-      "hash": "987e6aae5057236e89418b0b00c534e61655b3a1cc8cf2192f3cff1d2f7dee7a",
-      "size": 257
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000040.json",
-      "hash": "d705052fb23103507a7961770c9bed1844acedbd1af2292fbe14ccc7fb0cfca0",
-      "size": 232
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000041.json",
-      "hash": "27b8293614a8e7ab6a91f7fe0070935775b5989b8219c6916a4f712362d65eb9",
-      "size": 3182
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000042.json",
-      "hash": "21d40477d5271905529cbf2ce0d436913026b2bb670adaf6b297e1328df085f2",
-      "size": 312
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000043.json",
-      "hash": "d36ca49ca15228a2ade4a1fe4c50aa7d6b2e2f8ee5eaa1635ceddd384c3ac817",
-      "size": 931
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000044.json",
-      "hash": "f1d30836b6440846c2d0b92f5ae593b09db051a3919269474a5110f2f5e49fb8",
-      "size": 896
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000045.json",
-      "hash": "e26346a9981942e35af69209a23b31c017c6e00cb51a1078e87f9ee1487964b2",
-      "size": 1085
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000090.json",
-      "hash": "13d7e927bb5050f4bbddc23db6e9dcfeebe5ac4a00fb150861e97957b4ac6eff",
-      "size": 314
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000091.json",
-      "hash": "2d921699a382f40a5ce42ed2d4adc37236dee5f2868bc2b34f14ee0b0da54dbb",
-      "size": 8522
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000100.json",
-      "hash": "dedc55b35659fa402157d4fca931aff67af6ccb4958697faab5e1a03a742c016",
-      "size": 3150
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000101.json",
-      "hash": "e3c7e26169c95cde977f8dd01b8028e3dfbdcea801ce8665182ca36bdf273103",
-      "size": 852
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000102.json",
-      "hash": "f7f9aca7f660594b31520886f1b2af7827b546c903652fa7d0c85490244efd74",
-      "size": 606
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000103.json",
-      "hash": "9d6ffbb863b674038bd753940ff06b4680522a9089c55663157571dcd0a70660",
-      "size": 824
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000104.json",
-      "hash": "2e12bad7de63aab892585f65a79a80c388434b47523a178868b4ef3ed0aaa68e",
-      "size": 762
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000105.json",
-      "hash": "5db6faaf33b2938ba2fbda2db3bd9b262d54110128682d13baa1d0a6f5c7e82c",
-      "size": 758
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000106.json",
-      "hash": "a0c0e55983fe8a4adb7c1ab057ef2a304cd251ae052bbf930628d3a2b957f4fe",
-      "size": 779
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000107.json",
-      "hash": "07bd929aea13212df63aba649b9e6c9d8b3b005f66024bf3b7bc85327b5c26c7",
-      "size": 1030
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000108.json",
-      "hash": "d98bde679d8dde0ada946aa1a9614dbba6fdefef7963a93de9b0e9b2d913c418",
-      "size": 921
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000109.json",
-      "hash": "6aec697f0a37dbf675a8245001bc4f35ee0f1eabb0caf264a0693a5202958cb9",
-      "size": 819
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000110.json",
-      "hash": "01c4377664d57806146ed03f4f8e391d9cb202254541306214d39077fdffe521",
-      "size": 1357
-    },
-    {
-      "path": "assets/story/data/40/0000/storytimeline_400000400.json",
-      "hash": "9df60fcbbf29c5998dd52afa211df11749aac061870c0b00343568db8c24f8cf",
-      "size": 643
-    },
-    {
-      "path": "assets/story/data/40/0001/storytimeline_400001002.json",
-      "hash": "3c3efac7de466ed827fa1161dc6c0a71a39094d06f7b2b834eb9dd88d5435689",
-      "size": 10453
-    },
-    {
-      "path": "assets/story/data/40/0004/storytimeline_400004249.json",
-      "hash": "e913891600b50a2024ed1b4eba4abd75f2c4e40f2637180d7e1b6abe22c600c1",
-      "size": 2606
-    },
-    {
-      "path": "assets/story/data/50/1007/storytimeline_501007100.json",
-      "hash": "0a84d6fe4eceef95d4864eb56197367d713ca75bd4107fbfb2c950ae9cb84ba7",
-      "size": 4847
-    },
-    {
-      "path": "assets/story/data/50/1007/storytimeline_501007101.json",
-      "hash": "8636724ab4e8ca64ed672571df0960e91ab76b2530521095021ed95e0283204e",
-      "size": 4149
-    },
-    {
-      "path": "assets/story/data/50/1007/storytimeline_501007102.json",
-      "hash": "1952600a2bdf03be8b3aa3a98ff271d857b158b4c3dc7de07bd6a7c1012d907b",
-      "size": 4555
-    },
-    {
-      "path": "assets/story/data/50/1007/storytimeline_501007200.json",
-      "hash": "d6c200228f72df5729044e120b71a4838ee8c2a87c980bdb48b7239a0c3198d3",
-      "size": 1924
-    },
-    {
-      "path": "assets/story/data/50/1007/storytimeline_501007201.json",
-      "hash": "d25bb2d3ed54c3a431e3a6de3625f98e22841f3f0f7f750224e82a2960a80851",
-      "size": 897
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041100.json",
-      "hash": "356769c5579293bf571d45f414287f714fb07905122036e0d777bae686e3b465",
-      "size": 11057
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041101.json",
-      "hash": "c7f6739259774b3fd66f758a8570f62f14227d2769e59a5f37c12043438a9c1b",
-      "size": 7418
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041102.json",
-      "hash": "537cfb18bb8b4717f2e1b00ce1e9be7e9575b46243616ee918541943a321d8d7",
-      "size": 6040
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041103.json",
-      "hash": "3c2b231f1b0c98d37845ff58d255160b73b5484d479466580ca3a6a65a5961a2",
-      "size": 3181
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041104.json",
-      "hash": "e3944402667bd5189a2f9c47a1c0ab9270644bce762bf3f6117a4e07643e3a6f",
-      "size": 8207
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041105.json",
-      "hash": "943ef32edc9f5f2ca7b5ce60af7b086f8bf768e01832b3922315469ed02e2d27",
-      "size": 1008
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041107.json",
-      "hash": "f4bf9799bb4cde1c221490d3e0ae3ff507316c6fead25a1c8f32cbad3f71676e",
-      "size": 7787
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041108.json",
-      "hash": "fb3e8596e65b8aadd7f2cd06e47f17b7f602fb7e226a816de4f2964283a0ec5f",
-      "size": 8620
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041109.json",
-      "hash": "32b389fbbc0d0c2a3064d190a598f2cb07a53ae4bae11ad20240c9165dde09f9",
-      "size": 11348
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041110.json",
-      "hash": "eeb59accff7fca5743a1048302db40736ea6e5a1fbeac212f4e0b2721a9dcbb0",
-      "size": 2981
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041111.json",
-      "hash": "fc39720c3e1ed50aa02ca70042f3b107835be85b8ec280f1e50203e8d3adedcf",
-      "size": 6305
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041112.json",
-      "hash": "2d16f98791fe97f53c236bfcd2f5da0855c98d605e4731a564ced167ba09663c",
-      "size": 7391
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041113.json",
-      "hash": "a05b84d86f9a1028b14591c00cd980aafcb1010662419f5a398edf6e2f41992b",
-      "size": 8779
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041114.json",
-      "hash": "61c99a0e324b50214b76e385d363135a23685d039293f2ce765371a1ae23501f",
-      "size": 6428
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041115.json",
-      "hash": "42f286820514b3093f4b05e794111e5d5c1dcc1db577dbc8f9204266ac7dbc55",
-      "size": 8762
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041116.json",
-      "hash": "ea42329a9f26f0182d67058922a43649b65a46870d1785dbca54324c653442cc",
-      "size": 4063
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041117.json",
-      "hash": "6309049259261aad73ebaa3d32bd102a88ba012387df75c73ba310d5c7eee676",
-      "size": 8114
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041200.json",
-      "hash": "fac263504bcafa4938e42a6500165a51ddc4a462fa9d6d6a93a1307f48900168",
-      "size": 1396
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041201.json",
-      "hash": "4961da83dfecb2d6236f02c0a44b3771ecfea87ac71560a8b425debcc77e1c5b",
-      "size": 1657
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041202.json",
-      "hash": "75761227e67575b2015c238669f6f1b20b0f3bad81dfdb038aab15f960bc16d0",
-      "size": 1759
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041203.json",
-      "hash": "8bbf4e665a556e12eb893a57f2d44b216078c6a667e456adfd785374190da4f6",
-      "size": 862
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041204.json",
-      "hash": "979776cd5b16892d112dc0cdddfc8d56974fe2315e0988bda7cbb57317dd6807",
-      "size": 4261
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041205.json",
-      "hash": "8d8beffe4056d32d3aad2ff46ab2fb21149b233a544642e9b8a69d1e12f74ec2",
-      "size": 2624
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041206.json",
-      "hash": "c70a07b62094442baad1b00adcf94d47df67d7c0c103e4c1080e5a5433553ab2",
+      "hash": "99a90d0a46eac83bb37797a67774eaabceab2245e24318749139843bacce7ff7",
       "size": 1014
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041207.json",
-      "hash": "1cebb6ec6ee9404860902102674d1ddaf4d9f615bf82673ecd9dc7f585c3d16a",
-      "size": 1199
+      "path": "assets/story/data/00/0008/storytimeline_000008013.json",
+      "hash": "3c24934cb7cdbcd8e4bf7eed747fb01af11ef664223e3deae83f90b33a4b004e",
+      "size": 849
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041208.json",
-      "hash": "5fa89932cdc1589d3c2cd592bf02df6b5f39a0cdc1c1a1fc6179bf1cb869ee21",
-      "size": 1382
+      "path": "assets/story/data/00/0008/storytimeline_000008014.json",
+      "hash": "089c2618dc1bee770992ea33c759a25ec3c62f060ced12e0570a7bec1cbcb0a8",
+      "size": 731
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041209.json",
-      "hash": "403b170fa1726aed3762cdbc788d4ef03b50bc7655f6f8f1876875c971da870d",
-      "size": 3293
+      "path": "assets/story/data/00/0008/storytimeline_000008015.json",
+      "hash": "96eced045b4e1d00547672f031abed13585430cbe5388e8088e8e2943eeabce3",
+      "size": 724
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041210.json",
-      "hash": "29a940d24b8232098c8960fd7e3d69893a18b41941b1ce9d1e8f1fac71396367",
-      "size": 2164
+      "path": "assets/story/data/00/0008/storytimeline_000008016.json",
+      "hash": "aec8ff006c20f9f7f140cd41929403aa2904b653e1db75e566cf63d30a061a81",
+      "size": 886
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041300.json",
-      "hash": "31feaab42e255bc4294c26f12eb790d824f9de579610ef066bf3fb4cbf060887",
-      "size": 1692
+      "path": "assets/story/data/00/0008/storytimeline_000008017.json",
+      "hash": "d88af47d7352c81cec4403009f67f48c920b76dbb0f048ce611c1083e1cd024e",
+      "size": 924
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041301.json",
-      "hash": "47a41ceeb02c1eaf74bec5b2b5a51100ea1c91f824e1e7e8e7a755cbf817c505",
-      "size": 2681
+      "path": "assets/story/data/00/0008/storytimeline_000008018.json",
+      "hash": "bd32a88e017b88230442342cac1b91a0caf7d093ae2d94bf0956b019a2bf63e4",
+      "size": 583
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041302.json",
-      "hash": "4863fb922d6e5f042c6afdd7655f2ff790710ba7c4b4ebc04e1b705a8eed854c",
-      "size": 14280
+      "path": "assets/story/data/00/0008/storytimeline_000008019.json",
+      "hash": "fea02323b664b848bcd67f6a81f7018b72b77b4b77a3a1a8fc1351ab0cec4aa7",
+      "size": 695
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041303.json",
-      "hash": "6db47943598817cd67b55b1af84436092eef81987c90386ca0fbab82ea0a7331",
-      "size": 3964
+      "path": "assets/story/data/00/0008/storytimeline_000008020.json",
+      "hash": "342ed5cce4749ed1f171594a464444f9906197f3fd960a68fecd26b9ea128c84",
+      "size": 811
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041304.json",
-      "hash": "99b1060a8f9b1c5d7c7c347d6fc143cf4a5a679cf80c6b95339c09ed9afa29be",
-      "size": 2407
+      "path": "assets/story/data/00/0008/storytimeline_000008021.json",
+      "hash": "835bf66b78a0be965f1d3a4c816061b0779463d7e53c21b153f507b277b9bfe6",
+      "size": 811
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041305.json",
-      "hash": "275ceb93ce34c1b35f2ce65f257cc68eb066320f4abeccbc4b7b5597bd182383",
-      "size": 3968
+      "path": "assets/story/data/00/0008/storytimeline_000008022.json",
+      "hash": "ad4ea162332a6d00c2db5614b5acc78e21b8b22a2dffca979ec07f0f7785c687",
+      "size": 732
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041306.json",
-      "hash": "ee631d22052464695caf380f564d05eadf5fc6c6f7aa4b47d13421646b8bd820",
-      "size": 5607
+      "path": "assets/story/data/00/0008/storytimeline_000008023.json",
+      "hash": "58b817bf15f964cad33b62e2113fc04a89446c1141daf9fe8d26f01311b67c6d",
+      "size": 748
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041513.json",
-      "hash": "e73ddb4b03073ad63887b09204219ae25a25e831b03093c76efc3266cf3fbce6",
-      "size": 8786
+      "path": "assets/story/data/00/0008/storytimeline_000008024.json",
+      "hash": "e4fc9d1384bea977d448ea3338aca19ff6560ae8374ef4d0b14eed88d3ef382c",
+      "size": 970
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041514.json",
-      "hash": "ce5b58c8185b8eef4a29cbe9dd03066fa23d406faa94d8039976a23167be5dfb",
-      "size": 9518
+      "path": "assets/story/data/00/0008/storytimeline_000008025.json",
+      "hash": "9b88c0f582ff552ec798fe83be25a57ebc2f0decccc49de79619593905468223",
+      "size": 712
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041515.json",
-      "hash": "a64b2eb253c85f6cf4a9aa51be548fffca08fd23500e2ef0c546ca86c164ba03",
-      "size": 9466
+      "path": "assets/story/data/01/0000/storytimeline_010000001.json",
+      "hash": "b2e84337f20493497cba597c2d8d51300a14bbbfbc58a9a204e015d46dbabbd5",
+      "size": 1898
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041516.json",
-      "hash": "51932decff53ce48e33e2a1ad5e65cfc8b53414420c5e69250a3788ac30a9df7",
-      "size": 4450
+      "path": "assets/story/data/01/0000/storytimeline_010000002.json",
+      "hash": "e6fff55bd8ef3c937c132c1c03efc67a6e398fba8eebfabb1bfe5523a709b35d",
+      "size": 1575
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041517.json",
-      "hash": "1597e0eed49e2b8e00f1d0d9d5adf36a1ff402e0cb37e8775671a0d3f852c51d",
-      "size": 1410
+      "path": "assets/story/data/01/0000/storytimeline_010000003.json",
+      "hash": "2b017a3fc3a3372d6503ee878e368b836c70ae8ecf4553c1616808138b902a15",
+      "size": 2675
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041518.json",
-      "hash": "90af6bdfb95efd6d89049308c014dd425229597062092dcc81c1b043553640f9",
-      "size": 1255
+      "path": "assets/story/data/01/0000/storytimeline_010000004.json",
+      "hash": "52bf1421d67af3f1736c3f32dcb08d94f6c7cf1e4cbde047aa5838b4179e3d7b",
+      "size": 1031
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041520.json",
-      "hash": "020a3404ec7b06cedbd966c6be8539b47347534b4b6deb4fc4c21d3e0a5eeba8",
-      "size": 10794
+      "path": "assets/story/data/01/0001/storytimeline_010001001.json",
+      "hash": "587cb24c21597cee158c51ff7e149a94926e2aa0a4530a91846fab56537c9e17",
+      "size": 602
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041521.json",
-      "hash": "e5012cc0f126f70bc67218662bcc06603644992e83f4a488c916bb9c24f573f8",
-      "size": 1005
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041522.json",
-      "hash": "1969f3a1e32340ab7a1dee070eb95be3894db6a063b3fd1884348c01605a5597",
-      "size": 1409
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041523.json",
-      "hash": "deec05f75ce08021c5a473895a2a50eafc7d446f8ac17f9ebf559cf099a8583e",
-      "size": 3742
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041524.json",
-      "hash": "98c22411d7feb7831bb8444cad9003eb40ee794a1184cae278ecb4f37715d7ae",
-      "size": 5874
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041525.json",
-      "hash": "6a54e60519b918c5ca6dd02c745c6b9e5cc98f93723742cd67ba43c650bd8ad6",
-      "size": 7573
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041600.json",
-      "hash": "de81e240f1ba0f7acc232e83aeacfb6a5b804792f8388cac3919fc2c0f734b4d",
-      "size": 962
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041601.json",
-      "hash": "57faa9ad8b02b6b78ad39d3dbcad55a79a0e2ac616b01d72c497b95dc10ec759",
-      "size": 837
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041700.json",
-      "hash": "f54e906aff6ee5dcae527dd6a26c491f01845ff8c8e13917ae1838998684f9e9",
-      "size": 1255
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041701.json",
-      "hash": "149f398bc6cf515467c9aa6d60d3592f22e22ca031a0cb79504b715b00569b11",
-      "size": 959
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041702.json",
-      "hash": "bf632c42eecf7277923f9dd3ff2d856097b540e9676308c35471dbdf44c0a190",
-      "size": 8400
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041703.json",
-      "hash": "3b5d19724f396a4c905770a9f4fce079ebced9174b1396ba76274e25fcfb347e",
-      "size": 8558
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041704.json",
-      "hash": "51046768a02f492fd0e093018fcdfd0c38bc36a9cc267616f64496e343ca5bb8",
-      "size": 14494
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041705.json",
-      "hash": "9058d5e56e04d3748ba956201418d35281c424730ff2717916c7f352620f9099",
-      "size": 8143
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041706.json",
-      "hash": "c15dd61479eec11a7226dc4e2969541d46bb7ef06f248b5837810b5cbcc2be4a",
-      "size": 7285
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041707.json",
-      "hash": "c1cfb0658d23232fad4387ce49ae915a0c4424afb957bc85f22da09a1ad083d5",
-      "size": 4597
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041708.json",
-      "hash": "efacc93a4e18f5f3e7e58529f5995e32b92cc1234147df437713e91e0cac3ea0",
-      "size": 2191
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041709.json",
-      "hash": "29234ad20296f5876d9a3843d26ba43bf6583d398c6d61105d8a571724ff6dd3",
-      "size": 2278
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041710.json",
-      "hash": "0ee6784bd63797175cfde9f525dcdefbdf917bd437a66488de036b722193a761",
-      "size": 2347
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041711.json",
-      "hash": "a4a88af2b32c922669a6203134bcac0b2571d833b5ea34910e2c210f4ca20bdd",
-      "size": 3038
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041712.json",
-      "hash": "91ac91f237a473b7a2679b44cdbaedfc96265e262aa03add8cd6d11946642467",
-      "size": 1811
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041713.json",
-      "hash": "0357bb5e5058d374f7db6666990e1a762a6195ca537858f613040fccd008d9e1",
-      "size": 3430
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041714.json",
-      "hash": "7521702ffa3f7a8fea912dd231ebfe763a899f79c86a022c02546522db45138e",
-      "size": 5331
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041715.json",
-      "hash": "2f500dff4fcc47af30df6ea3de6438f8ecb968273adb9f16ee94560e43b24746",
-      "size": 2259
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041716.json",
-      "hash": "d43195029083bea0287fe748f0a7478a99be1bafe13077a9f1c6df07c734bb16",
-      "size": 2528
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041717.json",
-      "hash": "8a3fbd7ca843ddb5c882728d5528fa32d320eccf83308ad6ed818a75cdb8a749",
-      "size": 3601
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041718.json",
-      "hash": "69598c0ad4529ab86e08492e55bcdf2a3dbb9ce4a60006791a68c1bcfc2566ca",
-      "size": 781
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041719.json",
-      "hash": "744252550ac8ac7870a32d35ca4e5348b65771fd74abec29e2f560f82ae9ce7c",
-      "size": 1155
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041720.json",
-      "hash": "b3bf27deff620c80a26825f1fa5b200dc0d6ba70c5a7afaed763c81418591cdd",
-      "size": 18564
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041722.json",
-      "hash": "fea5f258e8991b9d43f55c8ecddd51e41f2d71049a1840da2e8834628d5afee8",
-      "size": 1581
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041726.json",
-      "hash": "04ccace69009adc9bf4a4713d49329bf99ef22cada8b5781fab3470f0d6a7f67",
-      "size": 1839
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041727.json",
-      "hash": "2e9d4d1f232b10b48bc3c38c9e988ecf8fbc9aa770ce2aabd3a9b1eacced50f9",
-      "size": 891
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041728.json",
-      "hash": "a8bfd54ed0181e0b996bd0b0f7cf25033b57d2a79cd465ce63f7a23b4a632723",
-      "size": 650
-    },
-    {
-      "path": "assets/story/data/50/1041/storytimeline_501041729.json",
-      "hash": "c4bb0f6dfd8be7572631ec92bb8662a4ba698f396fa9008521f12fa1d4a5d627",
+      "path": "assets/story/data/01/0001/storytimeline_010001002.json",
+      "hash": "907ac02374f29be423a449cbfe9c65dc5ab74da0abdf3b86bb92f6ee55c1cb5b",
       "size": 815
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041730.json",
-      "hash": "2e9d4d1f232b10b48bc3c38c9e988ecf8fbc9aa770ce2aabd3a9b1eacced50f9",
-      "size": 891
+      "path": "assets/story/data/01/0001/storytimeline_010001003.json",
+      "hash": "18064b43074e9cd006d5aa13380dc4e4180db9879c08bc1ae146108ef5240cec",
+      "size": 344
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041731.json",
-      "hash": "a8bfd54ed0181e0b996bd0b0f7cf25033b57d2a79cd465ce63f7a23b4a632723",
-      "size": 650
+      "path": "assets/story/data/01/0001/storytimeline_010001004.json",
+      "hash": "7053db6192c681c4c86fde86f0ebd34903c390873c471cf7ffa969206f97f1fc",
+      "size": 535
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041732.json",
-      "hash": "b1ee3991397590c5040f6140e1b32270589d2d5f09cfa2f68c88ae17edf3a799",
-      "size": 561
+      "path": "assets/story/data/01/0002/storytimeline_010002001.json",
+      "hash": "f87586faf14cadf1dd513691f96c2c5a866f2332508a16572224dbe35c464cc4",
+      "size": 217
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041733.json",
-      "hash": "163e78ac11b6b350d0a7d6bf45d415e7294b6da277c347e6e9792922d5e980a5",
+      "path": "assets/story/data/01/0002/storytimeline_010002002.json",
+      "hash": "15377cc6c350de72792c8ada867332e06dbc2810789e24f1f7f4ade4b0b53b74",
+      "size": 1038
+    },
+    {
+      "path": "assets/story/data/01/0002/storytimeline_010002003.json",
+      "hash": "5ac8e9e89dcdc38a42bd8b0fe6420b636117c06ec6ea62212e9528add58f0615",
+      "size": 557
+    },
+    {
+      "path": "assets/story/data/01/0002/storytimeline_010002004.json",
+      "hash": "290f2f32e8220d4d23d76af02efafa13918aec3a260e7d022f2f660a5272fa45",
+      "size": 363
+    },
+    {
+      "path": "assets/story/data/01/0002/storytimeline_010002005.json",
+      "hash": "ef6ca7bb144ca37bd42cb3d4c6de576267e67d88c77e8c7a7180d02a7ba79e37",
+      "size": 307
+    },
+    {
+      "path": "assets/story/data/01/0002/storytimeline_010002006.json",
+      "hash": "89ebdd9053cb12e4b2e7fd6fa442f37120f55f8a75d1f54dacce4d978055a8b4",
+      "size": 366
+    },
+    {
+      "path": "assets/story/data/01/0002/storytimeline_010002007.json",
+      "hash": "1b2c404fcacf3d10c9993b4bb1d03ed67f96eabf71cf9ca4b6b3461d0cd425e7",
       "size": 421
     },
     {
-      "path": "assets/story/data/50/1041/storytimeline_501041900.json",
-      "hash": "ed1017e0d55a770c986156c5e8941bb166ae501a0884fad4c4537cfba070566a",
-      "size": 1091
+      "path": "assets/story/data/01/0002/storytimeline_010002008.json",
+      "hash": "9bc8e71c06433a7150d2630c38dce70bc3b7a75edcf09d4dbeaf7efe18abad4f",
+      "size": 1396
     },
     {
-      "path": "assets/story/data/50/1052/storytimeline_501052100.json",
-      "hash": "c0bcdbf86a6b1266e2f4246d886f0ea0662d7ed7b15732cf7e9959f4d02d79a2",
-      "size": 5873
+      "path": "assets/story/data/01/0002/storytimeline_010002009.json",
+      "hash": "4fdfde27c16649978085a463e4ebf503bb434fd6132f9b450242a4e5f5e17108",
+      "size": 1265
     },
     {
-      "path": "assets/story/data/50/1052/storytimeline_501052103.json",
-      "hash": "5dce1de963dd7124e634081cea1ef663636e364e5c56e35aff3ece31b3d09bb1",
-      "size": 745
+      "path": "assets/story/data/01/0002/storytimeline_010002010.json",
+      "hash": "9ee6d83f9461963868c6e6ddf34c2167d22676fc07eb7d57437c33477e99ef04",
+      "size": 436
     },
     {
-      "path": "assets/story/data/50/1052/storytimeline_501052200.json",
-      "hash": "ef4c23391174a73bca6bdcb06842eff59dbf3e24e05c9106cf032de8df6eec0e",
-      "size": 1638
+      "path": "assets/story/data/01/0002/storytimeline_010002011.json",
+      "hash": "24c1bedd4e632e4d7d3efa1cbc27321d1343a507b54e2741d134e27cef683b15",
+      "size": 834
     },
     {
-      "path": "assets/story/data/80/1008/storytimeline_801008001.json",
-      "hash": "5a6652662faee8eb05974bd0f6dd4c3b7b8def8094b0b2ca69a5401753bb2be9",
-      "size": 2813
+      "path": "assets/story/data/01/0002/storytimeline_010002012.json",
+      "hash": "2086adbfe7a3bd32f9aaa83519baf3535935c6666887eb4994e898fb4e8aedf5",
+      "size": 721
     },
     {
-      "path": "assets/story/data/80/1008/storytimeline_801008002.json",
-      "hash": "42ce2f24737865a55b1b5cfba816c6ad9946a6787be677c76fe7d176281cc03b",
-      "size": 1997
+      "path": "assets/story/data/01/0002/storytimeline_010002013.json",
+      "hash": "1dfd5210abab447f1ba5e5600359420d48fd31f845e223b3581c3c46a904f179",
+      "size": 619
     },
     {
-      "path": "assets/story/data/80/1008/storytimeline_801008003.json",
-      "hash": "a664b9ef572a758b3e4e4cb81db181d8c3427d18e5e991e4ab71f535ca94130d",
-      "size": 123
+      "path": "assets/story/data/01/0002/storytimeline_010002014.json",
+      "hash": "68f86567c68e24ea20b64521ee20c88579ff94c83c7f6a9dc2e642be908155f7",
+      "size": 754
     },
     {
-      "path": "assets/story/data/82/0039/storytimeline_820039001.json",
-      "hash": "a95a1303d359625f9c825e18764b15b999bfca6617f5a59b9a0a63b46dc0622b",
-      "size": 7323
+      "path": "assets/story/data/01/0002/storytimeline_010002015.json",
+      "hash": "e33958d4d1ef3205809303264948ff1c5fbc4815729ae8f9aede97ce79ce1238",
+      "size": 747
     },
     {
-      "path": "assets/story/data/82/0039/storytimeline_820039002.json",
-      "hash": "7987d59dc55d18466706300108f5eb8882cb10813eda24e668495dd17edbad77",
-      "size": 3649
+      "path": "assets/story/data/01/0002/storytimeline_010002016.json",
+      "hash": "b20bf9116d3b8c28557033443e46beec7cb17d802fe3bddd4325e5454691bc36",
+      "size": 732
     },
     {
-      "path": "assets/story/data/83/0005/storytimeline_830005001.json",
-      "hash": "2740ceec21e3fbe2611caa2617a797a92fe655f5f3039fd0e1d053f2adf1e69a",
-      "size": 2871
+      "path": "assets/story/data/01/0002/storytimeline_010002017.json",
+      "hash": "7f6e75f6c6317e478c0097915db19f3d9403ed88818ecd9251440949c515ea63",
+      "size": 1007
     },
     {
-      "path": "assets/story/data/83/0005/storytimeline_830005002.json",
-      "hash": "0f52dd2fcb538238218b6773b024c9a77a297e3cb8b47c6373ac04b32577b9cc",
-      "size": 3348
+      "path": "assets/story/data/01/0002/storytimeline_010002018.json",
+      "hash": "b516a0f51efc02d998ec0bfdb6cce4d1d12183987e03242a6f734bc117a66b32",
+      "size": 379
     },
     {
-      "path": "assets/story/data/83/0005/storytimeline_830005003.json",
-      "hash": "a47cbcbc3b873840f632f53e33e23eaf432c908b8d7bcf7936b339c3794a1748",
-      "size": 4065
+      "path": "assets/story/data/01/0002/storytimeline_010002019.json",
+      "hash": "a482cb5509cfe615e868db05ecf81952e177a041a30b65b8f39b8a54e1bbea1e",
+      "size": 990
     },
     {
-      "path": "character_system_text_dict.json",
-      "hash": "8ef24795673180793866cbcf1e885469e6b0f3ba25777d2758dcbf6a7d3cf8f2",
-      "size": 214016
+      "path": "assets/story/data/01/0002/storytimeline_010002020.json",
+      "hash": "f12319fb33f0fc02705324fbd1d1f39cff1529fc40d5c2a14145f9de6e2c2e99",
+      "size": 710
     },
     {
-      "path": "config.json",
-      "hash": "6aec910cbb6b88746c9c2fcfabc94dca51a4f58b9ab27f5b23946cfc18fdd946",
-      "size": 578
+      "path": "assets/story/data/01/0002/storytimeline_010002021.json",
+      "hash": "75f4101a4c585901f9a50fa4f5b11e4eb572525343f6469d730217fdedf57d9f",
+      "size": 675
     },
     {
-      "path": "hashed_dict.json",
-      "hash": "9c23ab86e9956cf88b4c1b2afb03ff22dfbc594a323f8f01ded7fe3060cc7406",
+      "path": "assets/story/data/01/0002/storytimeline_010002022.json",
+      "hash": "457e93e315cda5051af9265bcbf64b7bbbd8ec0cd852221d4f6d27a32f78090e",
+      "size": 487
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001011.json",
+      "hash": "2d6bca53a6c8ab1a674645d157f987d9533cb56d2a1ef1ac5fccd6c34b7d6d84",
+      "size": 7319
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001021.json",
+      "hash": "35c35162b2c3969dde6ef68f10466b07512d7de1f8e42d056cc9052f3f8fc106",
+      "size": 9341
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001031.json",
+      "hash": "62be640a087d2d8ccc37fb9249c3684055f9883d1f08ee404a6477d1f84f5938",
+      "size": 8909
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001041.json",
+      "hash": "1e9dff6eb396d711c07d3c077fc1c6135b55bab7e7472e31ff373e1aad0de68f",
+      "size": 7386
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001051.json",
+      "hash": "9a66210bb3b3eb4fe10cee750956792bba674ecfcf7cda926a3b133a294a49d5",
+      "size": 5386
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001053.json",
+      "hash": "d401da045e71f0ea2d49258b2674ed71b4e16ecd988188fab9c5bbf5a66ab370",
+      "size": 2320
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001061.json",
+      "hash": "82512d2aaf841c30e17dd4ed184851198d77bb90b1fa0d477c411a9fca59b1f5",
+      "size": 8738
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001071.json",
+      "hash": "b81cde17e92987efe52a954d2780b96f6d502f7b63dd72f472e50a81a90536fd",
+      "size": 8663
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001081.json",
+      "hash": "5bbe12be871a0ed85bf2857096044189844f1e59dc8f1bd02eb454fc8c2bb913",
+      "size": 8023
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001091.json",
+      "hash": "aba2b1f45353943a0f0da227cea79fb279ec3674ff760f4c4792076384d1445f",
+      "size": 9040
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001101.json",
+      "hash": "f02bccaead0c693cc4ea5a29b5a3b2309d4e251fa7c5c1180e2ff2b0c8cc5cf9",
+      "size": 10132
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001111.json",
+      "hash": "9f782650582c14dea163757b3e0299eb8e1a96f9aa57e34b22fde6c9671d4def",
+      "size": 9583
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001121.json",
+      "hash": "cd729dcc71f4bdb78e4c10db5325c18f2950769af075320134f49853539332ff",
+      "size": 10309
+    },
+    {
+      "path": "assets/story/data/02/0001/storytimeline_020001131.json",
+      "hash": "672a51d379d096882d793f7f0803c3a3973f1ace184636fd9b2d90f7a656980d",
+      "size": 8356
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002011.json",
+      "hash": "84fcdeb1c10e7385ef17c216f389fb516f8c46175029c94d76fe6e035961debe",
+      "size": 8171
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002021.json",
+      "hash": "34110556834c812a02bd650a998e7721d0c83af9ebe64deca01bb9388f077d4b",
+      "size": 8722
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002031.json",
+      "hash": "9c8b974575653a6af3e5e83566cbcedb545db43d71dd0012b1fd318445cb0f54",
+      "size": 6451
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002041.json",
+      "hash": "56a343723fe43ab2dd19537bb40319e6e64f7be87da48bcc55df3b58de612544",
+      "size": 6705
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002051.json",
+      "hash": "f9b8e12fdbc856160933c640e2773126950682e2d1793f8fa6bc0585e7f947df",
+      "size": 7254
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002061.json",
+      "hash": "cac34087f666ddeecb5cd0d7fabb79885cdab3e5185ed3aa9475fd27c758d9f1",
+      "size": 2733
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002063.json",
+      "hash": "dafb6e6f0a469668ea656be2beb94dd5153545bf34ce7926c037ea89575dbc93",
+      "size": 3246
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002071.json",
+      "hash": "1e4c7b1e1c9a6debd74b4c4cda6d31d2336a0ba45296e57206dbd39bab4a37aa",
+      "size": 8573
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002081.json",
+      "hash": "da822057892c87035ffac28e1eedf7f708352249d23be9bb444e957401a601e7",
+      "size": 8495
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002091.json",
+      "hash": "f0196b96ba354f22d098df5c2e5ce241644c2ec811dde5f37052085bfb7f5428",
+      "size": 9438
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002101.json",
+      "hash": "280885501637320f5b869faf01bd8ec11da2672efe896f6d3e5bbf25e0c8ebb3",
+      "size": 8018
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002111.json",
+      "hash": "67febce10c4f83ba5700e740d16d80b2a34dc2e7029d2b7d16d3d24646c34ca2",
+      "size": 8100
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002121.json",
+      "hash": "f84bebe95e6fcfda4a2ca3347285c37bc0771292bd79096bdd42526c2628b802",
+      "size": 6496
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002131.json",
+      "hash": "49aa279087540508982d9c0f3597380ed9be5b862fc709bea48790bd0590e06c",
+      "size": 8258
+    },
+    {
+      "path": "assets/story/data/02/0002/storytimeline_020002133.json",
+      "hash": "3c75f609a4e4f1047afee8191877b3a0d6610ac1cce258a8eaae5ce2da19d659",
+      "size": 1932
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003011.json",
+      "hash": "eabd7e784f4a70052c8ceebf3e4d4f08bf57bc56c26601704e8fdd6fc0d5bfc7",
+      "size": 12221
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003021.json",
+      "hash": "cd0cf97c45ab619baf424c587d82b4e752ba1041a177e0a8a3eca36569ae54af",
+      "size": 13275
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003031.json",
+      "hash": "1d674a1179a718fda7ff8ff55efc9f5fb3f56ad7b8fbb0b416350781c4594f70",
+      "size": 9154
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003041.json",
+      "hash": "25f9318da3f311cfe9c919592d22427c63f51ce13883132b9d95f61d539ff56a",
+      "size": 9630
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003051.json",
+      "hash": "7d994f10aa9ce0eee1e930752a07ae321429aedc426eba0476c062cadb55bd88",
+      "size": 9554
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003061.json",
+      "hash": "85f688b5ce8cfe897ca3129927879912b4e6614105d7a98bcd3c6bc5eef17d07",
+      "size": 6950
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003063.json",
+      "hash": "731262af3720ba20266a7efb26e258e1bb816362511629bd3993c661de6b4c7e",
+      "size": 2086
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003071.json",
+      "hash": "d5e6437f2fd2f79880635d19ebe4ac9011497442f5655c7918967d232e0c9510",
+      "size": 7879
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003081.json",
+      "hash": "2f6e2fe58333ae2a786ccc3fd69dacb08a5e211fa2c3aaa5a7b8e1d5db9dfba3",
+      "size": 10146
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003091.json",
+      "hash": "68336100dd0bc3349e9ca01347cf2ca9fda031c2d54c63ff85e70340fc141768",
+      "size": 11477
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003101.json",
+      "hash": "4e4075f619bcc77575bb0ad9e6b5e0916ca9cedd05b1b9cd0d900c6c44e16255",
+      "size": 6154
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003111.json",
+      "hash": "8b7ca6c2afc83eeb6e788a8f398de067959f89ade6ec6f1bb895f928b1cdd93c",
+      "size": 8824
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003121.json",
+      "hash": "5a8c9ee0bb487b9727b3ebea9a9f337bea06dffc957ba7593920494822268d4a",
+      "size": 12366
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003131.json",
+      "hash": "13be31683a55912e058636619065b919b068da54a985b49cde472dd329511838",
+      "size": 3099
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003133.json",
+      "hash": "350cfeab10713bbdbce02d9508e481687ade941b091e95f73c179342492e08a4",
+      "size": 5165
+    },
+    {
+      "path": "assets/story/data/02/0003/storytimeline_020003134.json",
+      "hash": "901ac7812707c3276876e454d9839fb656e86f4f1b6dbd4527562c428c2bea0a",
+      "size": 735
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004012.json",
+      "hash": "fe9460f47b845a15fd69c7d51bd62eba00f395dbad21f4066c66b3b804c3230b",
+      "size": 7782
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004021.json",
+      "hash": "a723f8d9a4f35c8581202c99e4c3f7108ca934145137cd9771af3da693de49ca",
+      "size": 11629
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004031.json",
+      "hash": "2251fca2139ad459908cf43770915c4f81493d4d1d02ba82ff09e614f2a831cd",
+      "size": 9799
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004041.json",
+      "hash": "5fbd0021afe84d57c45c3f1af0865e9e2b423756ad86f03470aa4cc3afca2e0a",
+      "size": 8685
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004051.json",
+      "hash": "5df85d7202242e3c3d67f20f9a04f1d59fd7ded0e1c24cb45f3fffb5cee804da",
+      "size": 8785
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004061.json",
+      "hash": "7abc91ec6e1df8ea49eadab325378f570756b7450c5fc45a8b9108c7c7587b3e",
+      "size": 7471
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004071.json",
+      "hash": "828de69f38ecc3085a96edf4f565c975a66a81ff824ce2951423cd5b261282d7",
+      "size": 3071
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004073.json",
+      "hash": "920855a13cf1e2e2d46413190e792cf6c1a74594162ee3e731cd86a5cf05db27",
+      "size": 2504
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004081.json",
+      "hash": "cd29f6061f8f2caff833cd7133f73767ef57d06f1e1febe32f0419b0b4701bbf",
+      "size": 7980
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004091.json",
+      "hash": "c9939e53aba76bf0c9f05395e51358d264695386ab75ac81c43d1321154e1a98",
+      "size": 8696
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004101.json",
+      "hash": "50983ddb490dc61da4bc5cc684b524b4caf27cc8db4beb132a8e46c88969f3e2",
+      "size": 6996
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004111.json",
+      "hash": "d36f296eb538d67a6bd8b3464dd1a46a3f3f5a2a88f48c3e5282b662a83b013b",
+      "size": 12730
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004121.json",
+      "hash": "9932df937cf2f6dc995bc7cbd28e160a25ea079fff59478376abd45719ee905b",
+      "size": 12356
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004131.json",
+      "hash": "af62e4607dfb83edd03423c6f8f09d7109505e6f9c7d107e451ea31da1fe6513",
+      "size": 5695
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004133.json",
+      "hash": "40272e15053fc611775cd5bbfd4a28b7e6a6d0c35b4080d5df045d851457ab17",
+      "size": 1580
+    },
+    {
+      "path": "assets/story/data/02/0004/storytimeline_020004134.json",
+      "hash": "46f4b0f2f473271c7ddbc74f4a41333708a1de0b227bbaaa94f33bf1706615b7",
+      "size": 1684
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005012.json",
+      "hash": "7e7306ec3a2efbf6c308763d555481c3124c12013210a87de84b4b55f5cc94a2",
+      "size": 9381
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005021.json",
+      "hash": "4489d9d3a73f9428be32eecbf07f45581ec26cdfdb239d04347d911a0e9c6cce",
+      "size": 6991
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005031.json",
+      "hash": "f454a277bbd02716f7bbabb17dfd53f1f7f29441c834a512862b8212a9e83185",
+      "size": 9525
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005041.json",
+      "hash": "f1cd843e1af522dfdeb39ff5ad96fe3ac3ac176368531c95f98fbc736776d277",
+      "size": 6924
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005051.json",
+      "hash": "0569428cc5fff339fd27247c6c9ccdd9f36356d7cafa2a52a01a9885c1c6fabd",
+      "size": 11351
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005061.json",
+      "hash": "6fb94acf1d5ea7a87a6e580409f5bb27c7b419ecc29eaf6e3d6e854885ed73b3",
+      "size": 9491
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005071.json",
+      "hash": "ac6c37f3e87d6239a437e58b7567c01cfaf96f0da5fc3f485680745a7526d3fc",
+      "size": 8765
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005073.json",
+      "hash": "9b0cb7ec5685cc8c422ebab47beb9931fa37b24882bc3f2e79f9c6aaa3b2f5b8",
+      "size": 3676
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005081.json",
+      "hash": "ff8ab7a527d9e8a767753f2df266f1af7d4d24b3fcca168f7f0dd03540dd2d78",
+      "size": 9335
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005091.json",
+      "hash": "82dd6a07d5a2f0be8b38343165495157d3a1ee34b0eb79bfdc1ab63d80f971ec",
+      "size": 9322
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005093.json",
+      "hash": "3872aeba4ab48c8b0d9108d9e42da5d25f80398f9103beafb5cac98b6673d054",
+      "size": 2373
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005101.json",
+      "hash": "86833d71884dab685a592419526d6c1e841e5a15bac38f7f5b7ffa9cbbd6a543",
+      "size": 12109
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005112.json",
+      "hash": "7784886ea0fc548c40fec76e589888df4ea06677ce260cc2481e964245aa4b7b",
+      "size": 11122
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005121.json",
+      "hash": "d52467fa7e8ede04d3d4c6224a1db9e037a91848ebc156fbed0449a0c13baefa",
+      "size": 15902
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005131.json",
+      "hash": "45b093630ce17a1d4355ad52cd19afa5c077a297b1cfcc89e011d82d26bd5443",
+      "size": 3907
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005133.json",
+      "hash": "d6a15568d8d1b0429eb57a527dd17716bceac31de7a9e606407b9e185fb9aecd",
+      "size": 5256
+    },
+    {
+      "path": "assets/story/data/02/0005/storytimeline_020005134.json",
+      "hash": "3cdf5d5741d6ff99a10d0bdc5d5b83eda2d389ab870d2c961bd0b6c10e0b87d1",
+      "size": 1271
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006011.json",
+      "hash": "9b76f752a37cae4a92e6f316ea3c3be18d8d9999b7f50de8aba4899bcc875ad1",
+      "size": 13607
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006021.json",
+      "hash": "8d3560de523041525b43d550871824d11e6907c7475cb29927fcaa97d02d83ca",
+      "size": 10646
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006031.json",
+      "hash": "c45e228dfa10bcca505e7df6b6b463b60615cb3036cbff2858dcde9c2ea76426",
+      "size": 8809
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006041.json",
+      "hash": "8fd0d616674fa8986154a5835f952407cce027c513192840ec180ffe359a7a8f",
+      "size": 12439
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006051.json",
+      "hash": "2e94818a25ce14fef92857b8634e50e45718522b17c1395e2f8a5399dbbde963",
+      "size": 9620
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006061.json",
+      "hash": "ce73bbd44f0154dd382ddb19924cd906797176d2c5024174634cb7edd3363c10",
+      "size": 11505
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006063.json",
+      "hash": "5795f24ec63f3fa96a020f3f60b9116c8793eafe9ee239b3f9990f606f30e924",
+      "size": 6099
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006071.json",
+      "hash": "91b484db9a1b6c3d414385e5cff4607caab7e09ebcb4301322d543c2bd9b032a",
+      "size": 14279
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006081.json",
+      "hash": "15e41491ebbd6b7d47f719ab2e1560ea3922df3b2d063c3e469fd144a01f37d3",
+      "size": 8363
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006091.json",
+      "hash": "dd4f4c64ab3d54b73594126db0e9b139dc8fedc2e4344edb1db36c5f2caf73a4",
+      "size": 7085
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006101.json",
+      "hash": "ef60007b81d18fa98e586062a09d947e8434803120f3216b1269cba3fbf5d6ac",
+      "size": 14820
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006111.json",
+      "hash": "883b0df8ead22d85ee65f7aff8ea8328b0c5961d315d6a85f8123b6e1c7a4714",
+      "size": 7943
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006121.json",
+      "hash": "bcc344d123685011b5ac57942ae5e18ff08ffd4b90e40df2fe042afb6741ba98",
+      "size": 13017
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006131.json",
+      "hash": "dda77d3a2cd27227af9f6e8c29f4798364d854c3aa5402637cb19fc1917520f3",
+      "size": 6555
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006133.json",
+      "hash": "0476857278c811cdcddc17637b6c431e85baa9b486127602be3dc59e444d4377",
+      "size": 5496
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006134.json",
+      "hash": "fa34e7e9ec306707b9bf7731409a4bab970c2cb078753efb39c026aa7f67579a",
+      "size": 727
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006141.json",
+      "hash": "e29d5267e60056a1f6176529d4bbb7de8a0c45c86ae3fadb4fe425a2d52c53fa",
+      "size": 8519
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006151.json",
+      "hash": "37faa49b26247db97aa733e13dc8b5664b345dd44705fa6eddebff7fbbc39d10",
+      "size": 12748
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006161.json",
+      "hash": "4136a970db4a915dbae3e494acc2ba18c1572bcf7d80bd167262211a29b07c7e",
+      "size": 12492
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006171.json",
+      "hash": "e85942540a448f0b64ff45d1cb7b142088d90dc0ad5f4d2f419fd25a1efdfd22",
+      "size": 11641
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006181.json",
+      "hash": "4b38bd510faeb902becab7405edca9e93923a96b065b0dcb831c79a29b4ed1a6",
+      "size": 9612
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006191.json",
+      "hash": "7bc5fa8ee6c5a3359d59409738cd4896f4324723eaaeeb826d4344d376f07d9d",
+      "size": 21449
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006201.json",
+      "hash": "ff2d7c0a2f75d6c993c82f208b02c2fde471cfb3a02a9dd9b0b581902780abf9",
+      "size": 10755
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006211.json",
+      "hash": "e91b8f7e7461684bd499662515ba56c496c411a825f1fd92c62c93f87025204c",
+      "size": 14932
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006213.json",
+      "hash": "bcb4849050dbe2ccd680523d6381c1cf40fb2f97216de5d0c2f6f65b34d9bb6c",
+      "size": 7880
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006221.json",
+      "hash": "a573753dbc2aa8831e51c97172378423477585e67aa0282755d136a99b7ac7ed",
+      "size": 10162
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006231.json",
+      "hash": "f37f06783261fda64d4c5dbf2a6cfee46debae90869fdc9b1adabb6a212f692c",
+      "size": 5350
+    },
+    {
+      "path": "assets/story/data/02/0006/storytimeline_020006232.json",
+      "hash": "ae27a5e853a8fb42566d6d59f86faeca35668082a39c3f6a192bdbeb66db1bc4",
+      "size": 4492
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201012.json",
+      "hash": "5e33cb6e3b2da102689ec8df8da849509156eaf3567f40fc85857e56f02b5b9e",
+      "size": 15691
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201021.json",
+      "hash": "42174f741d862afea9e752e905247e8340692810f8ef143360662b195b17b308",
+      "size": 11470
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201031.json",
+      "hash": "4c6240c5103cd6376ffd33c92a4bba600859bec8c9f2f142951e6ac1a6cbec27",
+      "size": 19025
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201041.json",
+      "hash": "c38b28a991df24c6ff9e4c4e703f078a14a11a00932314db1ab9f3e8b1b2365d",
+      "size": 11537
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201051.json",
+      "hash": "64762647ff04bcd3dfd875315887c04d76a783b5f78fda71a38db72b60e1e7e6",
+      "size": 11425
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201061.json",
+      "hash": "ad909d11c838993d8096d013ebfb93d70f3d8cb0a200d3ab638a154fec8a2964",
+      "size": 16001
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201071.json",
+      "hash": "cc66ab5eaa20e0458ffb22bd8fa756d3dbd37b879c91d71f46d127bd0f03dea6",
+      "size": 16563
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201081.json",
+      "hash": "ddc08a829c9ffa9cd27c9887f34d7a2e0bbe34b28c8abff10bd4c30fa8607209",
+      "size": 9754
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201091.json",
+      "hash": "91197b4163a611c14c40aa4636153f70931507d5f44b2073b924f4b59880be5c",
+      "size": 14518
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201101.json",
+      "hash": "9fe54344300c63b9b8899bc8d79287621ffeb0731492cdc75e6a77b733391b10",
+      "size": 14481
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201111.json",
+      "hash": "62d6f86028a41fab0ee9e7f32044526c8989b4f976b1ecbb926a81780d1263c6",
+      "size": 13014
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201121.json",
+      "hash": "867eb19c8068f58919ad54d348e23dad38bd172f12f383cedc8ab19af89c9888",
+      "size": 10289
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201131.json",
+      "hash": "9570b28996f5dde5b01658e00b86b25d9e86912b1341af3ad217be6cca614e72",
+      "size": 6283
+    },
+    {
+      "path": "assets/story/data/02/0201/storytimeline_020201133.json",
+      "hash": "c4355e96f1a06bb2a29b89a6b2907a617132bc3fa6442b70daae88450f76cb98",
+      "size": 4355
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202011.json",
+      "hash": "3423baa2d618c4d5d6f797a71f9e489e8aeb621683f86dfd1bfd71b9365930a0",
+      "size": 8165
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202021.json",
+      "hash": "6b9f4e73919c1c2b0ffbdb30f4d041a18b5f3be12387de5c5e1ffd3b24d1dc70",
+      "size": 8804
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202031.json",
+      "hash": "685b011e966fcf3b4abdcbaf9d69f6e06d605e2a6954b72655eebcbca48501ea",
+      "size": 6170
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202033.json",
+      "hash": "9f35463dfc9f0ce81a339b931685ff66a8f9eb9d2473cfa2fe803075f07dada3",
+      "size": 4435
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202041.json",
+      "hash": "1ad8c902c37fa60e7692ee88f146761aca1a0ef3458c87fcb7782d8a37eb8c55",
+      "size": 13092
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202051.json",
+      "hash": "cb9aa310af062caa8b2ca2a2507b05e6de815ea955b679099ef8f6995a722d76",
+      "size": 9815
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202061.json",
+      "hash": "488ce429f38cda4c9bf62d8a0c91037596f1b6f8a66968dd903fe6663d1561da",
+      "size": 8085
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202063.json",
+      "hash": "cc128d00b2c15760edaf54841f6e9a8dbfe3360278ee0dd4606b9bce8c72c84c",
+      "size": 5264
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202071.json",
+      "hash": "40a7f1db8c484cb70873611cf6ac7f9ed88f9346e53edcc9fbac59cbe0e2e050",
+      "size": 11405
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202081.json",
+      "hash": "3cc07e0c1dcfbe9d5c2b4d461b307aa57c350fc06b297da170ffc0473b11b162",
+      "size": 13938
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202091.json",
+      "hash": "8925108afd57e820bf36a8bc25f83477639587c0b095251571bf42b8b34e959d",
+      "size": 8609
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202101.json",
+      "hash": "3957c6bc9fbadebe073fc878db1c1ab728a6e1bc4edf14108246a79a2366acf3",
+      "size": 12739
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202111.json",
+      "hash": "583ae08964c304375a62dc5bf71e9d984f360c0086bf91ad5ae06887ae4d1f27",
+      "size": 7872
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202121.json",
+      "hash": "ea491940b94e9a5256164b70f466792958f921fe6877d3b0e803a1cfa5dd97a8",
+      "size": 19853
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202131.json",
+      "hash": "024b8546d07424d7b1608225e5fea341ffea440618c3ee9112f7da55bc1511cc",
+      "size": 4684
+    },
+    {
+      "path": "assets/story/data/02/0202/storytimeline_020202133.json",
+      "hash": "ca80ef94d321366988b3bceb1ea13356d78bb38415f9cc2867a3bab126bdf713",
+      "size": 6188
+    },
+    {
+      "path": "assets/story/data/04/1001/storytimeline_041001001.json",
+      "hash": "ab0677d561853f83c284ac4567eea961acba19661085b2f5df3f81ec41cc32c3",
+      "size": 9735
+    },
+    {
+      "path": "assets/story/data/04/1001/storytimeline_041001002.json",
+      "hash": "1f5cbb407189e060e4badd771bf4ea384d6a6e606fd7715d417f8d39facc8a0e",
+      "size": 9313
+    },
+    {
+      "path": "assets/story/data/04/1001/storytimeline_041001003.json",
+      "hash": "1c416c025bda0a9d5de7e2bbfa4606d6b4a99a4b44917e16d01c9f358b6679b8",
+      "size": 8904
+    },
+    {
+      "path": "assets/story/data/04/1001/storytimeline_041001004.json",
+      "hash": "7f3e432e75d396499e3c85e05ac261ef0342eb356727b6257499a22a7f07ee9a",
+      "size": 9937
+    },
+    {
+      "path": "assets/story/data/04/1001/storytimeline_041001005.json",
+      "hash": "e69b762b6ae7b99a24f96d9966f18c62c52df2dadce08ef4c2f93be2df58a202",
+      "size": 6065
+    },
+    {
+      "path": "assets/story/data/04/1001/storytimeline_041001006.json",
+      "hash": "fde4400c1181952d7774891f30cb94d0945e5167cd9ad7cd9d4d1409205eb84d",
+      "size": 9521
+    },
+    {
+      "path": "assets/story/data/04/1001/storytimeline_041001007.json",
+      "hash": "6a93c4ad8ecf2530593c03df63dd010723cfb7b5794f7d201b1360b2bb32a31e",
+      "size": 9273
+    },
+    {
+      "path": "assets/story/data/04/1002/storytimeline_041002001.json",
+      "hash": "ad167d7906801fa86744cf10e748a22b3761f8b0fd132c90aebd3ceea5600691",
+      "size": 8334
+    },
+    {
+      "path": "assets/story/data/04/1002/storytimeline_041002002.json",
+      "hash": "bf21ffd6f78b6bdf44c56c6d6c35944c3f4fafbeb7de4c8d9ecb531ea0e3ee30",
+      "size": 6740
+    },
+    {
+      "path": "assets/story/data/04/1002/storytimeline_041002003.json",
+      "hash": "db84a7a0e54ea2f4ee114c2deeafdf597be28b323d0f94fef82e0282babba51a",
+      "size": 9353
+    },
+    {
+      "path": "assets/story/data/04/1002/storytimeline_041002004.json",
+      "hash": "395b1cdf94e4df64b192522fb66d61eefe990f45e3adbcca5830894358389f40",
+      "size": 9308
+    },
+    {
+      "path": "assets/story/data/04/1002/storytimeline_041002005.json",
+      "hash": "d510d17cfee54c953f144cff095af867d881e28c1e11e2a63651896c69d636b1",
+      "size": 4794
+    },
+    {
+      "path": "assets/story/data/04/1002/storytimeline_041002006.json",
+      "hash": "82b0d5af8e2b33286e62918e7eda6c4ac944bf25bb2958ab123d77f526c88035",
+      "size": 8093
+    },
+    {
+      "path": "assets/story/data/04/1002/storytimeline_041002007.json",
+      "hash": "4bfe98f398d8bbd29b4ad9f88c953758c6c40c167b1ba9d4fbbfe983b7c99e01",
+      "size": 9554
+    },
+    {
+      "path": "assets/story/data/04/1003/storytimeline_041003001.json",
+      "hash": "9101e1d89593857508b59d0a346a9bf1703159b81658f368d7a9f9a39c3b0267",
+      "size": 8295
+    },
+    {
+      "path": "assets/story/data/04/1003/storytimeline_041003002.json",
+      "hash": "daa4f8531e1cdb819ced0d46fec2334dfd634fdb5cee84d72b76fb0a02d55f35",
+      "size": 9583
+    },
+    {
+      "path": "assets/story/data/04/1003/storytimeline_041003003.json",
+      "hash": "839696a166b66601b771e15f8749843cc345404022583d169c769d63e615645a",
+      "size": 8455
+    },
+    {
+      "path": "assets/story/data/04/1003/storytimeline_041003004.json",
+      "hash": "14571714d4a64c12518ba31c9b00a8c5a1a2f6a0cd47e38ca2da1ada0c6f49d8",
+      "size": 7767
+    },
+    {
+      "path": "assets/story/data/04/1003/storytimeline_041003005.json",
+      "hash": "e74306c1f3e3e6f6e3c0028909a2274c616799909c2a1350c9ad82da69af77bc",
+      "size": 6188
+    },
+    {
+      "path": "assets/story/data/04/1003/storytimeline_041003006.json",
+      "hash": "026c980958b6d0c87e3497d40b91c40b5fd73b2acacce776fd71fa0e6871af23",
+      "size": 9276
+    },
+    {
+      "path": "assets/story/data/04/1003/storytimeline_041003007.json",
+      "hash": "bd68fd3326fd22586dbc6a285b14a78aa4f5751a460793c8767c590da628a42b",
+      "size": 9908
+    },
+    {
+      "path": "assets/story/data/04/1004/storytimeline_041004001.json",
+      "hash": "1335d9586426b6f4256b92603fc24d4963cc1de9f090a0a11cb354faeb44acd3",
+      "size": 8513
+    },
+    {
+      "path": "assets/story/data/04/1004/storytimeline_041004002.json",
+      "hash": "ef94ac3c46d1cc3cb956b6511d88e3b44f8289e951359a223b47d27f2384e0e9",
+      "size": 10734
+    },
+    {
+      "path": "assets/story/data/04/1004/storytimeline_041004003.json",
+      "hash": "f8cbc046cd90e8a42f8dfa1ce278312cdd8d0ca1dacdfd47d7a9a82884db6872",
+      "size": 9824
+    },
+    {
+      "path": "assets/story/data/04/1004/storytimeline_041004004.json",
+      "hash": "11f9c3a513322a9fba162de71830ac2b780f5dbf2c717baab0d7ea27e7fd689c",
+      "size": 10436
+    },
+    {
+      "path": "assets/story/data/04/1004/storytimeline_041004005.json",
+      "hash": "422e1cc2af2296f5d518ac6f65249c27c9b5ce72f4d0449a4609ff40ce6090a7",
+      "size": 6561
+    },
+    {
+      "path": "assets/story/data/04/1004/storytimeline_041004006.json",
+      "hash": "98191685955f905877734f907d57734835cf28cf50ef34ffa5e95f7194eb9608",
+      "size": 9949
+    },
+    {
+      "path": "assets/story/data/04/1004/storytimeline_041004007.json",
+      "hash": "514d5cbfea3a702461ae597721bd6e669f04dc6c6df57a79ec49284e3344ce59",
+      "size": 11588
+    },
+    {
+      "path": "assets/story/data/04/1005/storytimeline_041005001.json",
+      "hash": "9b7fe9b0f94a8144290ec04ad913247d65311ccf769a98e532174950c727b875",
+      "size": 8879
+    },
+    {
+      "path": "assets/story/data/04/1005/storytimeline_041005002.json",
+      "hash": "18b9c88677d076b6d129334f7935a7c4b12233c493f43103b3a49da86ff72bff",
+      "size": 9897
+    },
+    {
+      "path": "assets/story/data/04/1005/storytimeline_041005003.json",
+      "hash": "85a4484f51f9b330d6045b5d3f12da6db1465b49b0112dd9b403284150b2e513",
+      "size": 9259
+    },
+    {
+      "path": "assets/story/data/04/1005/storytimeline_041005004.json",
+      "hash": "cd8bb4c8cbccf6714c569013bae736a6d95c2c115f671cb1394c3228ad41971e",
+      "size": 10685
+    },
+    {
+      "path": "assets/story/data/04/1005/storytimeline_041005005.json",
+      "hash": "0cb62f7799f6762658487ebbfb23d25fac6b1b745de9454a8f3d29bd43688680",
+      "size": 5240
+    },
+    {
+      "path": "assets/story/data/04/1005/storytimeline_041005006.json",
+      "hash": "33f81d0301b56793e0adee994ffb18b86db9915c139ec1aa994ea4c8fd071dd0",
+      "size": 8742
+    },
+    {
+      "path": "assets/story/data/04/1005/storytimeline_041005007.json",
+      "hash": "a9777c71b52adfe29633e337e1e06326cf1dd78a1274123014917bd5c05115c6",
+      "size": 8742
+    },
+    {
+      "path": "assets/story/data/04/1008/storytimeline_041008001.json",
+      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
+      "size": 3
+    },
+    {
+      "path": "assets/story/data/04/1008/storytimeline_041008002.json",
+      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
+      "size": 3
+    },
+    {
+      "path": "assets/story/data/04/1008/storytimeline_041008003.json",
+      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
+      "size": 3
+    },
+    {
+      "path": "assets/story/data/04/1008/storytimeline_041008004.json",
+      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
+      "size": 3
+    },
+    {
+      "path": "assets/story/data/04/1008/storytimeline_041008005.json",
+      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
+      "size": 3
+    },
+    {
+      "path": "assets/story/data/04/1008/storytimeline_041008006.json",
+      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
+      "size": 3
+    },
+    {
+      "path": "assets/story/data/04/1008/storytimeline_041008007.json",
+      "hash": "a7c4d54776fcb179f048728766a52d75dc450cc2a5072b7e2c238aa9b2cff3b6",
+      "size": 3
+    },
+    {
+      "path": "assets/story/data/04/1009/storytimeline_041009001.json",
+      "hash": "a965d43d93329a634004bc217f324e836a117365376a541cca32de1e71280ba2",
+      "size": 7113
+    },
+    {
+      "path": "assets/story/data/04/1009/storytimeline_041009002.json",
+      "hash": "bd751251dcc711fc0ebf09fedac630c31845d9b3ebbb6bf6f0fb9556536b85b4",
+      "size": 7576
+    },
+    {
+      "path": "assets/story/data/04/1009/storytimeline_041009003.json",
+      "hash": "d1a55b551ae2bea43a59c70b6a0cbf164cf055d4a8ea9936ad5e7b2463fb41bb",
+      "size": 8825
+    },
+    {
+      "path": "assets/story/data/04/1009/storytimeline_041009004.json",
+      "hash": "860af9684012d440010c28316905258a1fb3692d60e21506edb3c9a74aaf47b5",
+      "size": 7781
+    },
+    {
+      "path": "assets/story/data/04/1009/storytimeline_041009005.json",
+      "hash": "28a73b5d735dc701bd7fb803830b1ffbac14a662485fb0fb51c00ea98e55a055",
+      "size": 6071
+    },
+    {
+      "path": "assets/story/data/04/1009/storytimeline_041009006.json",
+      "hash": "8d29a16a9bce2ae06b0ff0d8f37ebf7607c633ed1830d95efaa933b4d820a529",
+      "size": 9644
+    },
+    {
+      "path": "assets/story/data/04/1009/storytimeline_041009007.json",
+      "hash": "39a80faec3095532e7e06ebfaf2059e12e1a5156ccc2daa024c17e5f4faa44fb",
+      "size": 9516
+    },
+    {
+      "path": "assets/story/data/04/1010/storytimeline_041010001.json",
+      "hash": "37027530a681f4fd254515f89c3f518ea4e7f910ddbd93a206864d0287d2011e",
+      "size": 7545
+    },
+    {
+      "path": "assets/story/data/04/1010/storytimeline_041010002.json",
+      "hash": "f94ab83d3b62d7028d932d9989fcdee14ca7d9db0f5a3248ee0db9193e2afa67",
+      "size": 8951
+    },
+    {
+      "path": "assets/story/data/04/1010/storytimeline_041010003.json",
+      "hash": "b9373bdcebf9b8cc2b611f0ac563668094c9e05b5feaee9843da6db5641f6645",
+      "size": 9378
+    },
+    {
+      "path": "assets/story/data/04/1010/storytimeline_041010004.json",
+      "hash": "3e90ed0349eac551ac3e0435b05c89807e64488f1c9d7936ef218378c910ff97",
+      "size": 7349
+    },
+    {
+      "path": "assets/story/data/04/1010/storytimeline_041010005.json",
+      "hash": "6598b3bcf987a80c8f1bc5c8cae5dda592892b24a3a45bf03ff9b841cd7ce7c1",
+      "size": 4845
+    },
+    {
+      "path": "assets/story/data/04/1010/storytimeline_041010006.json",
+      "hash": "975c9d0eea0e25343492b73637e7a7e0bb461cb614e1b2427277674cf6eccb39",
+      "size": 7980
+    },
+    {
+      "path": "assets/story/data/04/1010/storytimeline_041010007.json",
+      "hash": "c6c190064fcc4100d38846b2900e1cffe9819cfac1fc3375d70aac3802e99862",
+      "size": 8776
+    },
+    {
+      "path": "assets/story/data/04/1011/storytimeline_041011001.json",
+      "hash": "ed77375159e0eec86f01f44c44b10ea67865d3bde20209e888438105bfa728ff",
+      "size": 8652
+    },
+    {
+      "path": "assets/story/data/04/1011/storytimeline_041011002.json",
+      "hash": "a9fec0dcf97cf750214c2c093f46c377d16cc3ebd5dbc4940ec179366e013c3a",
+      "size": 8482
+    },
+    {
+      "path": "assets/story/data/04/1011/storytimeline_041011003.json",
+      "hash": "c943243f15393a48b1882ad5dc0fb50e59b272913c465636e76acc792c84b1c4",
+      "size": 7489
+    },
+    {
+      "path": "assets/story/data/04/1011/storytimeline_041011004.json",
+      "hash": "48437538f41adf7e0e07eccbd59997963eb58f563d9d44f7c11c120306cb57a1",
+      "size": 9612
+    },
+    {
+      "path": "assets/story/data/04/1011/storytimeline_041011005.json",
+      "hash": "d9978f430a83d32324a9bc88e553cb9690fa7edbaed5e8685f062edc9b6d5a05",
+      "size": 5516
+    },
+    {
+      "path": "assets/story/data/04/1011/storytimeline_041011006.json",
+      "hash": "df50a142408d5b242a03b71cfc9059e1a29ebd1cb7d70a3a586694d9c3c0e41b",
+      "size": 8120
+    },
+    {
+      "path": "assets/story/data/04/1011/storytimeline_041011007.json",
+      "hash": "1cda466adaa2a31b0ce9ad240c77ee097ae8ec5a4913bd726f197e6824bda056",
+      "size": 8296
+    },
+    {
+      "path": "assets/story/data/04/1012/storytimeline_041012001.json",
+      "hash": "eab23a18eb9d4c237561a7ef3aa6b5b13e9a5e937f848bcb28b63265c70335b7",
+      "size": 8772
+    },
+    {
+      "path": "assets/story/data/04/1012/storytimeline_041012002.json",
+      "hash": "0560f5e2762cab92651427f47f622f774825199aa4ddf5e139562acf5e59589c",
+      "size": 9214
+    },
+    {
+      "path": "assets/story/data/04/1012/storytimeline_041012003.json",
+      "hash": "d99a8d3ed5d48789b5e642d76ae6534ad91c7fef03f5a2698d6020ef9c88257f",
+      "size": 8990
+    },
+    {
+      "path": "assets/story/data/04/1012/storytimeline_041012004.json",
+      "hash": "2b29f315d7b5d15b5a047dc94a1d906224aa9205b856592f192b7f11c5b89ba2",
+      "size": 8997
+    },
+    {
+      "path": "assets/story/data/04/1012/storytimeline_041012005.json",
+      "hash": "a3096b27b0afedb25a9caa218d7d7d35bfc9df17e5d6548557286f4a06e96887",
+      "size": 6115
+    },
+    {
+      "path": "assets/story/data/04/1012/storytimeline_041012006.json",
+      "hash": "25205328404bcd67cbfb185f8a6375e0ae94a25f816f7fd5e859261616130d1a",
+      "size": 11549
+    },
+    {
+      "path": "assets/story/data/04/1012/storytimeline_041012007.json",
+      "hash": "ab3c9d7cc1b384f4ceec7059251b0a5b4888a6f5e8585a63d0645920c733215d",
+      "size": 11234
+    },
+    {
+      "path": "assets/story/data/04/1013/storytimeline_041013001.json",
+      "hash": "168d64e223a0d0a6f10034f832fd23d2591946b9d4f9995cc1d67df4b43e0cc6",
+      "size": 7225
+    },
+    {
+      "path": "assets/story/data/04/1013/storytimeline_041013002.json",
+      "hash": "3f4df43cb707bcb8b5c83473c31ea0b5f9ade98518bf0be3ac0fafa28e635b24",
+      "size": 7352
+    },
+    {
+      "path": "assets/story/data/04/1013/storytimeline_041013003.json",
+      "hash": "eca842e6ecbd55e921ebd2dea6ca8f04d59c1ec6423e1dacb9739b4809410558",
+      "size": 8500
+    },
+    {
+      "path": "assets/story/data/04/1013/storytimeline_041013004.json",
+      "hash": "8f6e30959998107c40a34fa4b45f0120af4b94e1f379ad1716f5b2aa9b58c35a",
+      "size": 7641
+    },
+    {
+      "path": "assets/story/data/04/1013/storytimeline_041013005.json",
+      "hash": "4f79682b7a10306a8a0015cdb42c5054d7d162bb8f0e5c8465ec17d7e284f92b",
+      "size": 5102
+    },
+    {
+      "path": "assets/story/data/04/1013/storytimeline_041013006.json",
+      "hash": "d731d6ae5e294fe6d2c2ea26a36838c860713a12be219198106a7afba9f30596",
+      "size": 8685
+    },
+    {
+      "path": "assets/story/data/04/1013/storytimeline_041013007.json",
+      "hash": "7f3e15e7f75b425dc2a5559de8047cc88b0e2942ad3297ab7274b01888cced37",
+      "size": 8859
+    },
+    {
+      "path": "assets/story/data/04/1014/storytimeline_041014001.json",
+      "hash": "9a66d211eaa9aa4b2761d42a18164a17227a0640dee1e3665144ae0ad3907b91",
+      "size": 7356
+    },
+    {
+      "path": "assets/story/data/04/1014/storytimeline_041014002.json",
+      "hash": "b01dec0d6d911cb24396e2467ba7b0c570e7d146d6bb6d0a1b7babd929a6663d",
+      "size": 8741
+    },
+    {
+      "path": "assets/story/data/04/1014/storytimeline_041014003.json",
+      "hash": "a2764687ca468b4b2db8c052a6c5d2ea97af19e36b2ed51129e58ac6dfcdce24",
+      "size": 6682
+    },
+    {
+      "path": "assets/story/data/04/1014/storytimeline_041014004.json",
+      "hash": "005be4699d7d1125203319aa31c0a199ab8edef557f8ede1f59e4b30b8955bbc",
+      "size": 8665
+    },
+    {
+      "path": "assets/story/data/04/1014/storytimeline_041014005.json",
+      "hash": "7efb5c07142b9db795b3aadc008bbb750021511d105205b51db8e1311b74ce55",
+      "size": 5350
+    },
+    {
+      "path": "assets/story/data/04/1014/storytimeline_041014006.json",
+      "hash": "aa197b5c022ec790f34da1e2941145b847cf8c08de96f55711aed97432fbf228",
+      "size": 8484
+    },
+    {
+      "path": "assets/story/data/04/1014/storytimeline_041014007.json",
+      "hash": "eb2f39b250b8e91fc97f2df7c074e4b41bd01beb5d3a9f954faafdf887564acd",
+      "size": 9492
+    },
+    {
+      "path": "assets/story/data/04/1015/storytimeline_041015001.json",
+      "hash": "c5d6d5766ed8a6aabac347216a5657ea40ec45a849a25ccfd6648dc73f9225a5",
+      "size": 7617
+    },
+    {
+      "path": "assets/story/data/04/1015/storytimeline_041015002.json",
+      "hash": "06e683a8f3fdfcfc9ac2f3a8c011892d89c00eea67021478a885652b85bf3ae1",
+      "size": 7582
+    },
+    {
+      "path": "assets/story/data/04/1015/storytimeline_041015003.json",
+      "hash": "4577a90583ad2869f5d8e0a0396b229dfc1f7b1635a4cb8ba2ca593381044e2d",
+      "size": 8636
+    },
+    {
+      "path": "assets/story/data/04/1015/storytimeline_041015004.json",
+      "hash": "c74c6b83d6cbe20dbb08fb862680b3bc467adf49abe5084334681f2cbe3cb6aa",
+      "size": 6606
+    },
+    {
+      "path": "assets/story/data/04/1015/storytimeline_041015005.json",
+      "hash": "c37ccbe1d148ef7a38f556deb78f55e33b2cfda87719848798180e4fd5333975",
+      "size": 6293
+    },
+    {
+      "path": "assets/story/data/04/1015/storytimeline_041015006.json",
+      "hash": "399b57da8f3066a3b284cfd9aea7f341295194e4dd63a65d42a9d16cc5b43f7f",
+      "size": 10043
+    },
+    {
+      "path": "assets/story/data/04/1015/storytimeline_041015007.json",
+      "hash": "177cafe1dfb43c7bba3b34c7657f40deef69065a1eba856684a451db5f188e1b",
+      "size": 10240
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017001.json",
+      "hash": "178b30f237be698a172c5dfb971a14e087f1e4c63c3dcf7b596c26aba47cd87b",
+      "size": 6286
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017002.json",
+      "hash": "fae465d26b4ad9176a4f7f234f5f41689b4614c3d4a1d1d185fad2e1d6511ce9",
+      "size": 9127
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017003.json",
+      "hash": "72a5849d335e0b142ba3bbd077c6c615b0f153d694477becfef2d4f7f2b870b0",
+      "size": 9527
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017004.json",
+      "hash": "1894a121110664bffcbec38bb45308a13442e2dcee7f649f19b2e45fea801e97",
+      "size": 8276
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017005.json",
+      "hash": "73967fa48eb1333a3ef3cee0f99bb68a07e4a412a694c3c22102a0da70f7875f",
+      "size": 4891
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017006.json",
+      "hash": "4fa76722c297792ce0973f509969c09bbbfa001131bb697e4e34640b85b82ecf",
+      "size": 8989
+    },
+    {
+      "path": "assets/story/data/04/1017/storytimeline_041017007.json",
+      "hash": "d0b43ccc1d530529365326673c59de98d1a5fe656118d9afd78fa42da1839e49",
+      "size": 9093
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018001.json",
+      "hash": "d803b8436f677bd82bf576d3d37cab8b850d8210b919e87606932c2d4919830d",
+      "size": 7798
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018002.json",
+      "hash": "f1c287186085f2fa002158337909bbc06f3ca658ca89c00fa9030829fc394bee",
+      "size": 9403
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018003.json",
+      "hash": "c0dbb6f7b9b7b6837d66e85167b782a01b412b253e1f01abcf2238eb13d483b4",
+      "size": 9296
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018004.json",
+      "hash": "dca7635bb6fedeae4cfd1e8dc06674f4fc98a565e7ee2a4fa3259f25f7936eb9",
+      "size": 10188
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018005.json",
+      "hash": "8c6b17904f6e6e9e677aeaf4afa9329b7d64be44cd9554067cf2177b4892ee52",
+      "size": 5757
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018006.json",
+      "hash": "44ef40efa2361ea223ea5339580e3661cc2574cb40405d427083859ab82fbdcb",
+      "size": 9203
+    },
+    {
+      "path": "assets/story/data/04/1018/storytimeline_041018007.json",
+      "hash": "571838dbf02b798f73428a74e49f53e9487ca0f25d9f02974b64601a0119b81e",
+      "size": 9077
+    },
+    {
+      "path": "assets/story/data/04/1019/storytimeline_041019001.json",
+      "hash": "3393a5ada831ef2c48cd16aec7c3d03fa00549f88584cf1e3d04e315ab397548",
+      "size": 8836
+    },
+    {
+      "path": "assets/story/data/04/1019/storytimeline_041019002.json",
+      "hash": "9dd168e5aac5862b4090d5fc7e85184416aaa87a7e6f5be3684b7bc67956fdbd",
+      "size": 12006
+    },
+    {
+      "path": "assets/story/data/04/1019/storytimeline_041019003.json",
+      "hash": "64c2e3412a0171c1ae7605b5dc557b16e53b86f69022892fc94d08157b3dbd9f",
+      "size": 10063
+    },
+    {
+      "path": "assets/story/data/04/1019/storytimeline_041019004.json",
+      "hash": "0c4e3ff8ca7affe97451f3c90413d62df71d9767bea1e463ce65caeaf963f8c7",
+      "size": 11156
+    },
+    {
+      "path": "assets/story/data/04/1019/storytimeline_041019005.json",
+      "hash": "dfbe46309a243434fa55e0b99b0dc506a1be16958fc490b5e3157b0e6031180a",
+      "size": 6893
+    },
+    {
+      "path": "assets/story/data/04/1019/storytimeline_041019006.json",
+      "hash": "cf18b8e5013e13a25ecda9b3bdb026d5dbdb27a65e069f7d26605ed782c5449c",
+      "size": 9723
+    },
+    {
+      "path": "assets/story/data/04/1019/storytimeline_041019007.json",
+      "hash": "66e1260771605c0a8e33797c68c3d003ad4532b3e3f0b4e77e83bfce62684815",
+      "size": 11081
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020001.json",
+      "hash": "6a63f1c0d08c22ff6c35fe4b665a6488985fcefe6728a17cc53945fd7f2a6dc7",
+      "size": 9374
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020002.json",
+      "hash": "992fcffdb849aefe30ea965e1c999f648fc71582352119f2ec76a5003a46dafd",
+      "size": 9374
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020003.json",
+      "hash": "350eecc1642924f848351456bd7a1b73dd81604f6241ba0979d4f4688ddbae5c",
+      "size": 9315
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020004.json",
+      "hash": "e717cc252fadd07c6cfff95dd67df5322c521ca5bcfb235281375d50cbbe23d4",
+      "size": 9987
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020005.json",
+      "hash": "c4fd087d242fca0dc45ad8f719933abf73c880d3b10f8e7f41e7fbe40a0d9e3b",
+      "size": 5350
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020006.json",
+      "hash": "c026f1c59424e287eee99d2f5a240a5c575bf905674f366e0f2ed5094d20e2a5",
+      "size": 7062
+    },
+    {
+      "path": "assets/story/data/04/1020/storytimeline_041020007.json",
+      "hash": "422779ad47e0a80c5595bf4f201ca759b88725bb35af950f1b38904231cd3483",
+      "size": 8087
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021001.json",
+      "hash": "6bb55ffebc350a4ad0a1df32b8e3c94f4ba8e080f866aa117003baf24c9ed669",
+      "size": 10628
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021002.json",
+      "hash": "4b32a02a58a0714dcf8cc3a3a539d104b748a3a8a2688a9c9850bc51c10dd6e5",
+      "size": 8910
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021003.json",
+      "hash": "6c4010b39916e1ca8f409a7b4816a681ef12014c10a5195f81605765ba107b13",
+      "size": 8767
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021004.json",
+      "hash": "f35b99c2452dd31c98b4ce4e3b2ccc8d15940231bca211d0d7c119c643ab6baf",
+      "size": 8572
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021005.json",
+      "hash": "d18a5979fb9e1ed33575dd2fab3c960af97a00056fcbb442d051d928959a3edf",
+      "size": 6492
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021006.json",
+      "hash": "2b9d436635216866f1d009a92c6dd79f5a51476da6d17ed7bef7cd76741ef678",
+      "size": 10175
+    },
+    {
+      "path": "assets/story/data/04/1021/storytimeline_041021007.json",
+      "hash": "991369e44412e687ed784ec64d6e009c3447c6e24e1efdb0dc7b16bfb142d577",
+      "size": 11073
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022001.json",
+      "hash": "59f4c303bc0b9717d0b409bbacf1a2ff39629f9c8f344f47e31c4851cb4240d7",
+      "size": 7349
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022002.json",
+      "hash": "48099fad8035927cfaeba74ede5bad227d7934955478b75934d785c43b839e6d",
+      "size": 10026
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022003.json",
+      "hash": "9f9e6ed565cf2f349f0a6b22fcce1738cfa5dffe3327162adb411a7165bab4e0",
+      "size": 9631
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022004.json",
+      "hash": "db20ccca60d032d904e186ee853d4998d314775513a7d3448ec37a2a5b9a2b27",
+      "size": 8409
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022005.json",
+      "hash": "eb8a06a33857010f89fd017aac2bc12e4fed79bf2391ed5429600356e9f2f65a",
+      "size": 6142
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022006.json",
+      "hash": "59cf9510335aaa864aad5642c71894d2eb0d42f073834228d65989210e3376f2",
+      "size": 10359
+    },
+    {
+      "path": "assets/story/data/04/1022/storytimeline_041022007.json",
+      "hash": "32985f24b5c911717d54dea419c9a54643d80cca9f16f6bca57773d51128a911",
+      "size": 10207
+    },
+    {
+      "path": "assets/story/data/04/1024/storytimeline_041024001.json",
+      "hash": "81dc61f9f297b3e558da7ab4360a9fd58dfa2608249fbf3439eb2335903f4b95",
+      "size": 7445
+    },
+    {
+      "path": "assets/story/data/04/1024/storytimeline_041024002.json",
+      "hash": "49c06e0090f870f1757f74394e49f1265b6a75b9ac4dd4d85dd3bfab6746cd51",
+      "size": 8446
+    },
+    {
+      "path": "assets/story/data/04/1024/storytimeline_041024003.json",
+      "hash": "7451bfac30d493c23d3c7264c18269cc46e1f17722239c68f6a8e7ac78585940",
+      "size": 8411
+    },
+    {
+      "path": "assets/story/data/04/1024/storytimeline_041024004.json",
+      "hash": "b29b9325d2d71a37483f2bec8e036aa85021553aa9211908b47591b810c875d5",
+      "size": 8660
+    },
+    {
+      "path": "assets/story/data/04/1024/storytimeline_041024005.json",
+      "hash": "fcc03f75cbe151ca2b4456df685df9d8c9ff207e84f35b31c72aec54403d3b04",
       "size": 5290
     },
     {
+      "path": "assets/story/data/04/1024/storytimeline_041024006.json",
+      "hash": "d5d2bc03ac36499982e837f8f4ff862c14954c692bf4073b5c1ab6dc23730320",
+      "size": 8562
+    },
+    {
+      "path": "assets/story/data/04/1024/storytimeline_041024007.json",
+      "hash": "ce7a8485e9857616d194bd21b6292755553e6d5d179a9365b7967683eb93caf6",
+      "size": 9263
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025001.json",
+      "hash": "968bdee5c50547a2a05a4ae01484c887bdaa6e4ed4da580e84da5072ab47c893",
+      "size": 7602
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025002.json",
+      "hash": "b0fbb383ac214980f34bc08b031ceecf5c861965bfac38acbce18b39896f94ce",
+      "size": 8166
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025003.json",
+      "hash": "c19c8afa1a19266ccd44e5963dfeecfcc270e4df55f36251fb3b64df24a136bc",
+      "size": 9577
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025004.json",
+      "hash": "06151cc5d04a5d3bbf9630e13632f419e61469699f4dd7c73b5a1dae1eb57ab7",
+      "size": 9519
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025005.json",
+      "hash": "f800948680a31bce81beb156f6c1b3700af6fb5eeb45d6947217b9e79e1665fb",
+      "size": 5230
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025006.json",
+      "hash": "44da94506e9f869fc10756608d1e2c87e055f95fc5b6c80a00f9404e42585682",
+      "size": 9135
+    },
+    {
+      "path": "assets/story/data/04/1025/storytimeline_041025007.json",
+      "hash": "f6350e1ef904e5564b3b1da445522a941be789079834720858ba29523284f1a8",
+      "size": 9324
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026001.json",
+      "hash": "89885fbfc6e8c4d2acc6cd90d2d8576231d74ec9d46355dd6101eb0d8f635429",
+      "size": 8497
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026002.json",
+      "hash": "24e24e8fc90c73135c7363618ad3c674e06b4ec978735023d7303f40398b47f1",
+      "size": 10448
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026003.json",
+      "hash": "f7162bd99ec67b7e91f881035e68a255696ba01b7eca50e115164981b504848a",
+      "size": 10700
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026004.json",
+      "hash": "6ceae82351e9838a3e9fd40ab609ed05a6cadbaf036f5a4c350f1e49480927d7",
+      "size": 10907
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026005.json",
+      "hash": "d39917654d090be9a3fd99b870bc7d039ce98ed2efbfa164a1d2ee7c53f6c7ab",
+      "size": 6579
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026006.json",
+      "hash": "da23adc0b94acd6bfd21c6be2b45b78983d9c699e1fbf8812f010bae16561ee7",
+      "size": 8668
+    },
+    {
+      "path": "assets/story/data/04/1026/storytimeline_041026007.json",
+      "hash": "4aab93a9aa71b6a3e4bf4b1c35778263abb491edcdea414a8f82635dfe3c9371",
+      "size": 10017
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030001.json",
+      "hash": "ff2338fcdcea63d765f4dc83de5ebdae188ae1093ff76ab496ef55394da6a624",
+      "size": 8371
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030002.json",
+      "hash": "e5cd554807d56fcf5efe0983b49a85a8abb1f4d97bcdd66ec918f3b8bd19037a",
+      "size": 11462
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030003.json",
+      "hash": "b8e05ea721c224466d39173656ae47b09a7c61f6714364c9e1a808a6bff77fd9",
+      "size": 11798
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030004.json",
+      "hash": "b780dfe89413bead136d7eddc0ac01c7fc886297452de0f5a4633c2fff609941",
+      "size": 9749
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030005.json",
+      "hash": "0276e85397217a5deb03f3f27b2164f802cb2a468cf9c45897be7ffb49829125",
+      "size": 7046
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030006.json",
+      "hash": "8d88376018af48a18c9b58db8c17b06a595bfbea10515805c479523bae683b06",
+      "size": 11330
+    },
+    {
+      "path": "assets/story/data/04/1030/storytimeline_041030007.json",
+      "hash": "9fcd0e48f7be133aa6f8a5f4c4e1161cc72a886655c493c05c939f208f346915",
+      "size": 9336
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031001.json",
+      "hash": "c89da1d575bdd92cbf33102a79ed5484098ef57d24906d522e3c21b9a4765a61",
+      "size": 6300
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031002.json",
+      "hash": "6e7c78c8dd631f3b975ba0b04d3c9736fd72f9e725cf090e45787535d970e107",
+      "size": 7902
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031003.json",
+      "hash": "041fb20c876825f614e6bebbe99a1d585a37f7411f24802d21752264d53e321d",
+      "size": 10174
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031004.json",
+      "hash": "d9b40cece60664ff778b76ca1dfa3e8d56767c23075659ff9b37b7d5c8b2bfac",
+      "size": 10135
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031005.json",
+      "hash": "71a9e7e337cf8dade03fb62005281fefe85ea47adf082f712aff072217b558de",
+      "size": 6116
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031006.json",
+      "hash": "af7beb192e9d1b15c2f14dc7002185f7bca79b2320e063ff5d13dd36d4cf50db",
+      "size": 9384
+    },
+    {
+      "path": "assets/story/data/04/1031/storytimeline_041031007.json",
+      "hash": "65d61c24c144d144749cf137f74d6e80f6f06e7995717d563ab5a0a4c70e3af1",
+      "size": 9280
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032001.json",
+      "hash": "c901be4ce9d17607d8358cb15e4ee29305c894414be68466a385114fc093f148",
+      "size": 9863
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032002.json",
+      "hash": "bcb8bf6abe339f5e78f22d884700dec4665b0d07893d6442ceac70e6ce57ddac",
+      "size": 10904
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032003.json",
+      "hash": "24793d73e1061e09677f8224bbf0a06ada6349274b8061144839145562c81db0",
+      "size": 9847
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032004.json",
+      "hash": "974ff9dfdd4b6e919f4c49b133363fca23dfbc171dfc1d63c7ad85059ae6600e",
+      "size": 9674
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032005.json",
+      "hash": "605971aa3dea05908a8b66665279321efbe3e0cb4d8c9d5bb30892a9ad9c31b2",
+      "size": 7253
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032006.json",
+      "hash": "e8b57e826f7498f418c09c941db7bd2698239a2da7fe1dce14f202cf7a64a6c4",
+      "size": 10117
+    },
+    {
+      "path": "assets/story/data/04/1032/storytimeline_041032007.json",
+      "hash": "8b5807f19ea3c17628553ce625c9bc3525d5eebb0e653e6560600e00683e7d1a",
+      "size": 11642
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033001.json",
+      "hash": "953fb2714c11855f1b8e7ce716a8b8643f4b3be20e1e72d994be1b1aa420c62c",
+      "size": 7591
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033002.json",
+      "hash": "e000f91c5ed9be71c79b394ef42707e76ca9bd72a1662e34bc943b6a2f923c7c",
+      "size": 8192
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033003.json",
+      "hash": "978663cfba39c8779fa829a48467820f03f924af1b5a43cca7c911dfc5c9393d",
+      "size": 5718
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033004.json",
+      "hash": "d8ed1e4048991d93c295c39546ff3a870a870bd445acf0df9e2dce374fe4a344",
+      "size": 11139
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033005.json",
+      "hash": "104a0783a98b459e7e7fb652b77c7eaf12ba88a59c5285de06ce2288e4488472",
+      "size": 5084
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033006.json",
+      "hash": "f7af526d41467192947453ed2cf25cc1b55bba9320bb5354922e322be37bd7ec",
+      "size": 6086
+    },
+    {
+      "path": "assets/story/data/04/1033/storytimeline_041033007.json",
+      "hash": "14787fcf4c7c773c1a928172a4e75536593d0552cdd7446907e41265b13fc94e",
+      "size": 7417
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034001.json",
+      "hash": "b0a502722805fac13a70579d4923dd9620ca09bbaf25310659b5818efe8f5392",
+      "size": 11865
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034002.json",
+      "hash": "3461179c2008b629bf0397c8fa824470b99b57f866e3089a31431e532190b9a7",
+      "size": 9184
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034003.json",
+      "hash": "da4df44914f11fbaac2c9866309616e069eae1f42047ec7083564c32964fb701",
+      "size": 9133
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034004.json",
+      "hash": "a0f465fec7c08584320a84b7378d49876b6413967c20c5ff9a599ec9bb78464f",
+      "size": 8124
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034005.json",
+      "hash": "6a0e73339ae3a12d5795cef3a0cce4e44ea9a911e8cddb9c97aea0c9f10aa206",
+      "size": 7528
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034006.json",
+      "hash": "c0ef17784f6100481f43c03d44a6e87ab30ce8925b88a4bc514b302c110c834d",
+      "size": 10636
+    },
+    {
+      "path": "assets/story/data/04/1034/storytimeline_041034007.json",
+      "hash": "c6225f25e2ff8b6c1fe423e9740e90fba43d62d33197c831728f709c1f3a19ad",
+      "size": 10995
+    },
+    {
+      "path": "assets/story/data/04/1036/storytimeline_041036001.json",
+      "hash": "ab0108a2e6e05c00d1a631a5dace17f76aba8fd2f3e7403658314a1b9bc55758",
+      "size": 10661
+    },
+    {
+      "path": "assets/story/data/04/1036/storytimeline_041036002.json",
+      "hash": "1da7da62ae8f3e53a25ff2b4a86cc118b57eb95364a10e34df02806e1e20c53f",
+      "size": 10019
+    },
+    {
+      "path": "assets/story/data/04/1036/storytimeline_041036003.json",
+      "hash": "bf6a289b1457f1b8b42f22a7805d80c8ed2dfff5fc8c66da89f129620cebc908",
+      "size": 12133
+    },
+    {
+      "path": "assets/story/data/04/1036/storytimeline_041036004.json",
+      "hash": "951ac62182c0de0d339435634e46f2a3caac4a166415dec29e6a6fa087ddf130",
+      "size": 10896
+    },
+    {
+      "path": "assets/story/data/04/1036/storytimeline_041036005.json",
+      "hash": "4ea0269d1f3b2db4f45de0528670a1332ce277f4525a97bf3f850f4121a107b3",
+      "size": 7158
+    },
+    {
+      "path": "assets/story/data/04/1036/storytimeline_041036006.json",
+      "hash": "11e211b43193eb4612bf65eaa33214cd1451ac9924678d17fa1b2ae0940be3f4",
+      "size": 7978
+    },
+    {
+      "path": "assets/story/data/04/1036/storytimeline_041036007.json",
+      "hash": "098c749afdd9bb83abad663ba6b4f54f8f1203c734c10a15bf8496cd193d7cac",
+      "size": 9214
+    },
+    {
+      "path": "assets/story/data/04/1037/storytimeline_041037001.json",
+      "hash": "f40a3a4de47f8e19f31f6543a77161bef9bfe2d236ac46c15edce2ecca858ebe",
+      "size": 7162
+    },
+    {
+      "path": "assets/story/data/04/1037/storytimeline_041037002.json",
+      "hash": "a7f1b3915c7f080f92b8577e79db5f18c226541bab1c93daa523f6f73e0d5c1f",
+      "size": 10150
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038001.json",
+      "hash": "54ade6d98ab6c6040a6f495d8a5cc367bade3c967373128121a4f5d5f334e42d",
+      "size": 10929
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038002.json",
+      "hash": "efc2334307d57f4a173cb701756c4c0a0960910e42fbfd046516869996be3a56",
+      "size": 10547
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038003.json",
+      "hash": "018fe74366561eb0679f293af6b7ff5196333440e917d1feb16a76c64a5058d0",
+      "size": 11242
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038004.json",
+      "hash": "d3de2bd4f53533051c09109b8871d1fd8cdafc98c15ebc11da43984564d35f66",
+      "size": 11536
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038005.json",
+      "hash": "a653d2dc0c4136d3d2d5062ce8ffb62631904912bcbc0e85dfb35c990ca1bc6d",
+      "size": 8069
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038006.json",
+      "hash": "4285a00ae769a928372821763c11f9ec42516dbea497550fb91624cd658710b0",
+      "size": 10434
+    },
+    {
+      "path": "assets/story/data/04/1038/storytimeline_041038007.json",
+      "hash": "ec8b356097d408026385da66f5fc736cc42cab550cb754ca86ed9fac5f253d60",
+      "size": 11273
+    },
+    {
+      "path": "assets/story/data/04/1039/storytimeline_041039001.json",
+      "hash": "fa2832b30bcb4311174dc31c0b930c0d404845266f6003b0dff1d440b068129e",
+      "size": 8685
+    },
+    {
+      "path": "assets/story/data/04/1039/storytimeline_041039002.json",
+      "hash": "2e405a3abe742ef8ad960f591d4076aa7b547ba58a29e5a5dc4ad69ce69e815b",
+      "size": 8734
+    },
+    {
+      "path": "assets/story/data/04/1039/storytimeline_041039003.json",
+      "hash": "29f274b2435273820e706aa7b733f16f0c5c576d62e90e90fb8d6dce8419f22a",
+      "size": 10481
+    },
+    {
+      "path": "assets/story/data/04/1039/storytimeline_041039004.json",
+      "hash": "9999495380db1c2e537c32d158fccf857685e6fbbdce6ba9a85ba428ed5c6555",
+      "size": 9059
+    },
+    {
+      "path": "assets/story/data/04/1039/storytimeline_041039005.json",
+      "hash": "226ad6fda3803cb1fdb9104ded8a1408bda3d94f26be29d6d859d322984b39d6",
+      "size": 6267
+    },
+    {
+      "path": "assets/story/data/04/1039/storytimeline_041039006.json",
+      "hash": "349506af18aa9811a75fd27f8c05bff0e86031b5390df722eba23faa6978bc3e",
+      "size": 11578
+    },
+    {
+      "path": "assets/story/data/04/1039/storytimeline_041039007.json",
+      "hash": "a21f15d1efa5ec73c3b40e3ed450b48e257cab4090eedbd7ac2b1ba9324ebbd6",
+      "size": 10300
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040001.json",
+      "hash": "6ababdf22a44f2891ae5dfc0ba4a9792afb88a7a6b720fd9db9cc10e0066f406",
+      "size": 8210
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040002.json",
+      "hash": "549ad02f21c30709c30445f4b8271dd55025b7472d878f284fe8022d32c783a6",
+      "size": 8166
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040003.json",
+      "hash": "a03453cae099dee6e9de916f75e0ade9925d7b31ae61b794167814e39c9b2f26",
+      "size": 8883
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040004.json",
+      "hash": "2c88793a241542faec5a614038cb5e91c789e53c821ec11e52c26298493a9f5b",
+      "size": 9791
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040005.json",
+      "hash": "0dfe3a669de3f15bc22c344f34443decbb68e72c02b1a109ca36eba254f23cfc",
+      "size": 5892
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040006.json",
+      "hash": "45466b7f0ffcf9c406e8ee808be51850cf5a8330b3aa65a65f5f97788c54634e",
+      "size": 10768
+    },
+    {
+      "path": "assets/story/data/04/1040/storytimeline_041040007.json",
+      "hash": "335a93a6909587210a612871ab9f50397941b0bce78d3385cb745c9f2cbc19bc",
+      "size": 9515
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041001.json",
+      "hash": "ad7c4c5f70c480ab52cdbe09d1cc448290659fdc174971977c4881bbb98defdf",
+      "size": 9126
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041002.json",
+      "hash": "0d7df8d6232069817d9c9a3e0d979e5b374e1eaa810278247b7c212b0582d3a6",
+      "size": 8922
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041003.json",
+      "hash": "919391d2dacf601c13b554b55ff1d3da7037987607e93ffcb4e051b7854797f6",
+      "size": 8172
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041004.json",
+      "hash": "a0022d3acd4b6400602d26b67a0fe4cc8e6789797cc9c1fa1a1e1a6e633f09a4",
+      "size": 8779
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041005.json",
+      "hash": "9e9f8a2a879ebd4902fc5c0ec70f7c94384ffd537515bef7b91a766c13e4c9a0",
+      "size": 5926
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041006.json",
+      "hash": "ba28ac3e20cfa521836fad99821db34b75772bf3a802c687ebd13ac55f99995b",
+      "size": 10375
+    },
+    {
+      "path": "assets/story/data/04/1041/storytimeline_041041007.json",
+      "hash": "2786a594e2d061843bf76df6af791b5c44438c6ffb3b7aab354b86e7bf52ce0f",
+      "size": 8398
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043001.json",
+      "hash": "39a717683448bf9a921174d5a76b98bc72f7c33f68f0d2aece3b562c54bd2c7b",
+      "size": 7952
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043002.json",
+      "hash": "6c1e8074b51af33d0fcf1ae90545d1345a70b0ac0dd2272d42dadd64fb7083c1",
+      "size": 6726
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043003.json",
+      "hash": "fbebd6cb1bf8c4df5905c43a1796e8859553bee06b7eee527e9c588d97ce980d",
+      "size": 10030
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043004.json",
+      "hash": "2c948a182214c76cb214be96f85f0e67da0b84bd99a55db04fe6bda4f2a4ac38",
+      "size": 7879
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043005.json",
+      "hash": "7f42b5c7608d3d3734ee73262ef1d6ab4d226f04997f4cbdb764bd8a16b4f0b8",
+      "size": 6171
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043006.json",
+      "hash": "e2234a74a9b688b2af359ec0fc54a25674af2592a809a62b7d125ee143aca45d",
+      "size": 8216
+    },
+    {
+      "path": "assets/story/data/04/1043/storytimeline_041043007.json",
+      "hash": "9e9ebde4104c15e49210ca0907d1830fc57271bcf95f246b74586065161d9b95",
+      "size": 8307
+    },
+    {
+      "path": "assets/story/data/04/1045/storytimeline_041045001.json",
+      "hash": "8b3af7019a4d68db2711f00e860520db459b964be51da963e8a2bbe086d2152a",
+      "size": 7645
+    },
+    {
+      "path": "assets/story/data/04/1045/storytimeline_041045002.json",
+      "hash": "d11bcff6c41f818c2c4e1537310f223b8448627d25c2e3d147310ffd14d7073e",
+      "size": 6619
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046001.json",
+      "hash": "772de4f8b5f41fd358a28074d249e00c988892f73b5a535960e06eb0d093dbb7",
+      "size": 9198
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046002.json",
+      "hash": "08d5da6294f5ebdc7a4fe46785e3f9e1a3937d3abe12c37638ea77de2ab32228",
+      "size": 10020
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046003.json",
+      "hash": "86a45f5ddd93f55db0bed2bb2c89f4c0f89ebbb581d7e36d56c02e61cc790219",
+      "size": 11277
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046004.json",
+      "hash": "d18cc6c43ded5143e0955ccf2a915854486673fb485b2f3f568264ef1871f698",
+      "size": 11260
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046005.json",
+      "hash": "4e46f8167887b512f4edd2beec8f8d56fe62df101a676d8ce0996f6b86c72237",
+      "size": 6504
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046006.json",
+      "hash": "a3102e565717797fca9efa9f4a5d7f78424da671f30bfe8aa9908353999d2b70",
+      "size": 9719
+    },
+    {
+      "path": "assets/story/data/04/1046/storytimeline_041046007.json",
+      "hash": "7c5e1163d448f9952953b09bd2972f5f3e5e4288e94e55906e0b1a51875ed838",
+      "size": 10406
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047001.json",
+      "hash": "ea06ef77785057667315d53433f02facb8aea00e06eb7bd39be16c466c869f2f",
+      "size": 7177
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047002.json",
+      "hash": "d72869fb65e17c2de0785ea4f685c9a49b46eebb44be47795b2ea6b7759ca513",
+      "size": 8897
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047003.json",
+      "hash": "0badca2bea793fe6058e3a58ab1b17bece207eab390c11a07e5b6901d4b536b4",
+      "size": 11116
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047004.json",
+      "hash": "f8478e6cbb55ed4e3d03d1162378e591952a0557aacaa72b04f9988f300d6110",
+      "size": 10438
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047005.json",
+      "hash": "14e9a5733e4574a0e502fa0d8d39b11197be2484e848a0f7fd4bff55a4ebe349",
+      "size": 5475
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047006.json",
+      "hash": "94d34c8bf350ed8c7663405dffb7375cc4a5e70b35ec1864eaa25ed0b3690500",
+      "size": 8980
+    },
+    {
+      "path": "assets/story/data/04/1047/storytimeline_041047007.json",
+      "hash": "a9f097e3fd0906cae3a34f545e8327085bd4be2d9292af845db54a35fd500cbc",
+      "size": 9791
+    },
+    {
+      "path": "assets/story/data/04/1052/storytimeline_041052001.json",
+      "hash": "2c464b5672f7c68cddeccc2959d865de691bf3962616bfe2739ad37892a0ce94",
+      "size": 6042
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055001.json",
+      "hash": "067522c18266286e692ba4ee5e4197b1c90307f97fc4bccca204fb783be50bc5",
+      "size": 7637
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055002.json",
+      "hash": "458fcd0b1b7107a01bbddd6c60d711f80960b4d6a4142aa8be635f9b8ca8be17",
+      "size": 8658
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055003.json",
+      "hash": "01725fe6e771195216141ab9e4e7783b429e29521c4cc86003f793b7ac9d4aee",
+      "size": 10912
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055004.json",
+      "hash": "f1382f18245f208e9fe96fd1e24a22322e79b161d7cd7d44bb6280744ac8b4f9",
+      "size": 10599
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055005.json",
+      "hash": "36b2ac9d126ca7ad10a44ee22bf2a081d0798b4c90b11e1712518873c79cb4a6",
+      "size": 5645
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055006.json",
+      "hash": "7503dcd7eb7b037049cdf8824d5c184be6db17ba125aaaab37af9d70f004ffe5",
+      "size": 9651
+    },
+    {
+      "path": "assets/story/data/04/1055/storytimeline_041055007.json",
+      "hash": "b24bf491d82ab380b42e355dacf37c8a3eda73e5f8a8eebc6752653618fc5769",
+      "size": 8764
+    },
+    {
+      "path": "assets/story/data/04/1058/storytimeline_041058001.json",
+      "hash": "3693568a2faa8d6f9439e838b9a55d21ba7b12f33ac65f1a0ab0b8046530be02",
+      "size": 6568
+    },
+    {
+      "path": "assets/story/data/04/1058/storytimeline_041058002.json",
+      "hash": "161a2b56f9da767384a588c5ed722c40af28feafa04fc30d374709c6d0914056",
+      "size": 10463
+    },
+    {
+      "path": "assets/story/data/04/1058/storytimeline_041058003.json",
+      "hash": "f13c771fa5f98fbcd53f83e2cec65a53ca58f5109363a1437d2bf92322319907",
+      "size": 7390
+    },
+    {
+      "path": "assets/story/data/04/1058/storytimeline_041058004.json",
+      "hash": "47a7f4585d9d59593b1726ca17e0f2b695bc96781118dd56e2891dbd68a780de",
+      "size": 9832
+    },
+    {
+      "path": "assets/story/data/04/1058/storytimeline_041058005.json",
+      "hash": "e99811b9bab4f4baf7c44fb32481278183953cac93c12c446203634a4795649d",
+      "size": 6325
+    },
+    {
+      "path": "assets/story/data/04/1058/storytimeline_041058006.json",
+      "hash": "cc13988bb2e128aa75ef71d8c60608073bf861ea1814e9b7a68e056c133076b7",
+      "size": 8020
+    },
+    {
+      "path": "assets/story/data/04/1058/storytimeline_041058007.json",
+      "hash": "2ebe77ecc8f7a82eacfe06fe78f840f1aeb883624ce4304069222e22766b35fd",
+      "size": 9918
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059001.json",
+      "hash": "bb050d6615cded978dca3f5690fd3ffed508bce2327e43da8204ec72042461de",
+      "size": 8959
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059002.json",
+      "hash": "4f6f1bd7a167ac417d90a6db51d820346d92c900375f11f1ef177cef559ebdd9",
+      "size": 12736
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059003.json",
+      "hash": "5ffbdaabe6b5bb10669d6af5f623c6982066d73727fa3c445a0876719e45ce35",
+      "size": 11451
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059004.json",
+      "hash": "ef25265cee38ef12a390cd0fdfd62fc0f18f54669ee0726ce7b540536cbc1ec0",
+      "size": 11275
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059005.json",
+      "hash": "9c536de10b88e628455359910ffd821b926b91fec88c74b3912e11d469e2b4ca",
+      "size": 9594
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059006.json",
+      "hash": "da5e5a2357f3b1fcb552de5e823bdcd4b07e7260a99d48b27a18b8b9ed86375d",
+      "size": 14880
+    },
+    {
+      "path": "assets/story/data/04/1059/storytimeline_041059007.json",
+      "hash": "b28a43ca325a62805aea14f27fc28fb8f539618b79f005efc68b9490afc7b84a",
+      "size": 13728
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060001.json",
+      "hash": "50b3ce182624e6645978525d3e02b804abc03aeea036c605b08f6a6f84bfa9c5",
+      "size": 9353
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060002.json",
+      "hash": "cb71f992db7cdef18489a7e6a394dbd4169abe78f7eaff5e87cc074adfb304a0",
+      "size": 10136
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060003.json",
+      "hash": "6b178c91853c79783715614229196bba417411bb79754836ff9ed1b74da54757",
+      "size": 8854
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060004.json",
+      "hash": "7270f82476d7e7c57251daba1ea796ec1c7c4a5283bf705cc841386bbbe9f975",
+      "size": 9124
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060005.json",
+      "hash": "bd22c7aa5834e923998c4a42100e358ec3e5791021d451d3d8c55024e24ea160",
+      "size": 6492
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060006.json",
+      "hash": "95783ba5861667f782bdb973a6062627739bde0c2ed2b44597138ef05d6054bd",
+      "size": 7769
+    },
+    {
+      "path": "assets/story/data/04/1060/storytimeline_041060007.json",
+      "hash": "ca903fde356656557b2abdd580757b8c57cc830e6fdcd79038f11c7ce481acb9",
+      "size": 9526
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061001.json",
+      "hash": "6370cc6c18e93b353658ba47a907911e199cad684bf93f7fd2aee963c3c18e51",
+      "size": 7845
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061002.json",
+      "hash": "ae951910f9979324da8be71dbc7b7b4a8ef05fae2162f48c5b1f8de9cb9fdc7e",
+      "size": 8247
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061003.json",
+      "hash": "0b4ec5582abc671fc743eaafe7155645d9b1f7cd40648bbbe457970f35aaf9b8",
+      "size": 9009
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061004.json",
+      "hash": "f98432c1967d2755cbff0bd1065c0ee6ababb79d0757ff9eae151ff01fdff862",
+      "size": 9444
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061005.json",
+      "hash": "c4db242cada7475bfa8161f56ccabd33fed3a8b2ea2756142e9053ab23518f47",
+      "size": 5561
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061006.json",
+      "hash": "d87f1c66f0a998f32edc029dd4a1925996dd83052c14b487a6bb49b25a5a993d",
+      "size": 8630
+    },
+    {
+      "path": "assets/story/data/04/1061/storytimeline_041061007.json",
+      "hash": "6ef96a4f8980e7d00eb239c9cad9bc0ca07a66b4f7b712ff883378de2b72443c",
+      "size": 9362
+    },
+    {
+      "path": "assets/story/data/04/1064/storytimeline_041064001.json",
+      "hash": "953b20f1eeb2710ebc098de6f546b13b15b61e607924ce4201ccdb2ded7c77c1",
+      "size": 10416
+    },
+    {
+      "path": "assets/story/data/04/1064/storytimeline_041064002.json",
+      "hash": "66640c42dacac6291c77817fd7e9f2707f45f14ed55d6dab3d1d50e0d613a41c",
+      "size": 11012
+    },
+    {
+      "path": "assets/story/data/04/1064/storytimeline_041064003.json",
+      "hash": "f5195e9ccb537a7715a32ea73de4f70a75a481c470a6614cfb8ef753aa055a38",
+      "size": 8005
+    },
+    {
+      "path": "assets/story/data/04/1064/storytimeline_041064004.json",
+      "hash": "db8098692602eae92fbbbeed5475288c0e515229f94d57b00d19d95436fa2bf9",
+      "size": 9587
+    },
+    {
+      "path": "assets/story/data/04/1064/storytimeline_041064005.json",
+      "hash": "7650153a996e9ddaf1b94a443f1a127e75f63027ea910aee78c973df6f84a854",
+      "size": 6297
+    },
+    {
+      "path": "assets/story/data/04/1064/storytimeline_041064006.json",
+      "hash": "d61f4ef8dfc7fb9a0a051b9149eed00eca9c7a2fb4fa3414c8b69c51137c7087",
+      "size": 8465
+    },
+    {
+      "path": "assets/story/data/04/1064/storytimeline_041064007.json",
+      "hash": "82d73e05995130f25abb79aeeb7593471f9c44a81a46e54e20b05715fb1bdbfa",
+      "size": 10261
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065001.json",
+      "hash": "6103f579c5ba6b78e0ba22b62499ee175de258b444d0e182003a318dc35f7d69",
+      "size": 9009
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065002.json",
+      "hash": "df1a242185a2e25b6a36d5ec208971cb0ed7d4fc8da2d75e87d432f0fbce6054",
+      "size": 10465
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065003.json",
+      "hash": "5c1ba57df6dd0fa8b86ee0fdec1a74096fa6852a529c5f5ac801c43a700133ba",
+      "size": 10829
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065004.json",
+      "hash": "d46629a5fc0db42b910b0045227fd582aa10e4fd131dd6b3c19fb9c615433c0b",
+      "size": 12459
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065005.json",
+      "hash": "711c9f908b12dd463207e5d97f4a78a9e9484e82c0cd83a9a1a336e36014c400",
+      "size": 6264
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065006.json",
+      "hash": "1997fd54aaef54c60be8732dc220f832b3fa9febae56b6da70ea2d60b441a884",
+      "size": 8504
+    },
+    {
+      "path": "assets/story/data/04/1065/storytimeline_041065007.json",
+      "hash": "339d82b253c52e16ddf6351260bb0f9a8019571c5c49ce623aa1574f1f278b0c",
+      "size": 9555
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066001.json",
+      "hash": "d1d8a6ebf0bfbaed37cc3c6f223c19d54a3278bd4f0bd85e1ac01b00a87a67c6",
+      "size": 9008
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066002.json",
+      "hash": "ca674af14cbe7a2fd45f523410fca5d8dd749c29cccb4470e0d7a185ace861d0",
+      "size": 5990
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066003.json",
+      "hash": "8669d37a2dc52bb04e46fcfc336588be5f8f8e11523a9c5dffc7098c527d10b0",
+      "size": 8596
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066004.json",
+      "hash": "c2fdde26706da16dbe53e97c60be1cac77b3c784bf65d3ef3abaea78b6671334",
+      "size": 8720
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066005.json",
+      "hash": "a069b5da1ea1c0690ecb7ddb9d02983e2086c1bb57432f13fe23d9596407b730",
+      "size": 5072
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066006.json",
+      "hash": "5357f4600302a7ce5a2bf09589024facf74aeffd2dd84519473951de88aba470",
+      "size": 8206
+    },
+    {
+      "path": "assets/story/data/04/1066/storytimeline_041066007.json",
+      "hash": "29fb5f16c94467ecdb2373b4f41c467a80c1a7390fe4baae76dd1600552b8ba5",
+      "size": 8555
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068001.json",
+      "hash": "058002e4ceca7f54c456960b0bdc09a4d23c4f070db40e1b5a6a83cb33afe675",
+      "size": 10156
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068002.json",
+      "hash": "cce4638827921e2a49af7f8f8c5f50bf525253021a7a7a7f34538048fb988877",
+      "size": 10114
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068003.json",
+      "hash": "1e6bb118583d5f129288ef78506a36a0a24cc37aab895f2d7ecbd10ce3dcc7f3",
+      "size": 7577
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068004.json",
+      "hash": "a4d1966f9321c411165922a8fad281b60d868a64575522d9befca920a70c572c",
+      "size": 10519
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068005.json",
+      "hash": "3d52d45ff2bbcf2b0495c63fd7df27d66df788c9d7219fe3cc16a66e55c36ae2",
+      "size": 6167
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068006.json",
+      "hash": "a9cd7338928db91ce7a9f1d575c0b4b7eda55b32f5b57ba4188ee2ecb658484a",
+      "size": 8102
+    },
+    {
+      "path": "assets/story/data/04/1068/storytimeline_041068007.json",
+      "hash": "b9155035592789e2d6ce5b6b0c31fc7335dec81fdd1fec2e97deb70062536dd1",
+      "size": 9246
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069001.json",
+      "hash": "6d62f100771eeac05f13e08edbc483b2aa47b0696b4eaca4c33584cc9f43028b",
+      "size": 8587
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069002.json",
+      "hash": "3084baad9fdbbc748a2d805df4faa6411cfd4140d530630d688030a8c5435362",
+      "size": 8046
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069003.json",
+      "hash": "5e2615dc50a4447ac6b25571de283c759d2c2766dee55d3ae4803d9a158e2b9e",
+      "size": 8100
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069004.json",
+      "hash": "90767d6a12dbb45d9810abfbd62d0a3a032bb23a3c5c38faf883065c1a172357",
+      "size": 9116
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069005.json",
+      "hash": "d689bfcb28f90f383f47542509cbccea99dbaa7f96530307c59d73171eb7742c",
+      "size": 6470
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069006.json",
+      "hash": "e40b09838c363fd5f847413588d51d0602b0225626a2c44304da9b909b8b727b",
+      "size": 7153
+    },
+    {
+      "path": "assets/story/data/04/1069/storytimeline_041069007.json",
+      "hash": "7b5a4dd4dc3e4c20a8a864c1575c6b7fcf1b08657d8bf06a71c06f53adb6f644",
+      "size": 10566
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071001.json",
+      "hash": "51e95d8a0265f0b33ac5fbe88b168e9a43c1f1a7db9c55b5cdbc837efddd6625",
+      "size": 7870
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071002.json",
+      "hash": "e6a3f4ab5131ed1eb9fa7462bb670748710fdf52ae86a441252f61a4006fc9ff",
+      "size": 7844
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071003.json",
+      "hash": "c702fa339e4d064d233e7a7edd30397c7881a12600bdd831a4662bbdcb4f1e02",
+      "size": 9875
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071004.json",
+      "hash": "997825077cedd0c218cd14fa20e039c69dbb8b2227da1998393629637859c589",
+      "size": 9905
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071005.json",
+      "hash": "08c33fa6a2a9a5c56d0e77024dad201df57a5efc03f9b319ea248cd6a2022a59",
+      "size": 8130
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071006.json",
+      "hash": "7cf7ee708a34d0573cb57f3874914b6abe54c77c4c58df0f2f30180eddfe82d9",
+      "size": 9934
+    },
+    {
+      "path": "assets/story/data/04/1071/storytimeline_041071007.json",
+      "hash": "ec84c45ff2a2a391d4cbe1fd934e589366bb5c6ec3f3beb2168d4eb0c324ba94",
+      "size": 9431
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072001.json",
+      "hash": "60a6a9acb699de613d14c4f532f830acbafa773718c205ff91ed890574a619ba",
+      "size": 10447
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072002.json",
+      "hash": "8856d04fef9a348db9d4771bac6b9b555040dc0e00df67956be03f58864d2e24",
+      "size": 10050
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072003.json",
+      "hash": "26a79d4876c774806948c90dee833e83dfec23b0e42928b2fb1429aa981e24bb",
+      "size": 10097
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072004.json",
+      "hash": "93d8b8eaea9794af644f60a9aebdeda71f575fb2926bacf6ec9da20ea3b8fa2a",
+      "size": 9165
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072005.json",
+      "hash": "2a90df135f96722d8be7b5b20c4e58ae7189aaca974b4816086deb04c9ffb3d5",
+      "size": 6017
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072006.json",
+      "hash": "6f5d2d0ab6fcbb511f0e483a4a311e8e7d8bb034534a0be40fa9926a51441900",
+      "size": 8562
+    },
+    {
+      "path": "assets/story/data/04/1072/storytimeline_041072007.json",
+      "hash": "e11fb364145e7aa1e9ee1d913d5a8ccaa7267bb75c6376e4beef201cac94e16e",
+      "size": 10154
+    },
+    {
+      "path": "assets/story/data/04/1076/storytimeline_041076001.json",
+      "hash": "88f371997a44b3be5921fe19cffa5392a741e7a76dc3cd37c7b00a928e9d215c",
+      "size": 6866
+    },
+    {
+      "path": "assets/story/data/04/1076/storytimeline_041076002.json",
+      "hash": "995c5a8f4eac70e70efd7f681e01dc2b50f1eec6dc55427e92c9c272bebe212b",
+      "size": 10821
+    },
+    {
+      "path": "assets/story/data/04/1076/storytimeline_041076003.json",
+      "hash": "5c488bdb1d8d39b8cd07bd14d8e7af18d85dcd6b780c61498b5c886817c571ca",
+      "size": 8417
+    },
+    {
+      "path": "assets/story/data/04/1076/storytimeline_041076004.json",
+      "hash": "acd4d6ada03170fcdf8dbd70a388fc0ef22bae5a5ef11365429300b8b5084913",
+      "size": 7802
+    },
+    {
+      "path": "assets/story/data/04/1076/storytimeline_041076005.json",
+      "hash": "3fff59dfaa857d94b4bad2597920f27c0db939096359af9ede418845c5c29a08",
+      "size": 6618
+    },
+    {
+      "path": "assets/story/data/04/1076/storytimeline_041076006.json",
+      "hash": "995b0a4fe0ded752dc6edfdfe3aae03621904b231dca85fc8fb09700a0db8f9a",
+      "size": 11240
+    },
+    {
+      "path": "assets/story/data/04/1076/storytimeline_041076007.json",
+      "hash": "85fefdfe7185a3af22cfdcfe58114942b0f9b1ee521ce80cf2c86333ccf1ba72",
+      "size": 9374
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077001.json",
+      "hash": "9096fb3177b75efb9eb5b3b6567a83b72105ee5bff0269f42bd8420623b01607",
+      "size": 10281
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077002.json",
+      "hash": "4a5327ae49b2ddf1f9dbdfbb78cf11f877f7b249178fac12d2d67b020416825f",
+      "size": 6838
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077003.json",
+      "hash": "af365fcfc2621dbfb6222bbea72c200f4b4f989692f0d99166292aef9e538ac3",
+      "size": 7795
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077004.json",
+      "hash": "4d1636d38551d3e163ffdded4a5bb04a2197744b4daf505023c5ce456fbe591e",
+      "size": 9981
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077005.json",
+      "hash": "b00b2b4e9be4acfa3c89581668df8231e422b11e2992517586be41b4eefed4f9",
+      "size": 6357
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077006.json",
+      "hash": "705254de82a0a62c6063575d26bff058b84bdc7e5df5c0ae03bf1480e4910366",
+      "size": 11599
+    },
+    {
+      "path": "assets/story/data/04/1077/storytimeline_041077007.json",
+      "hash": "67cb31e9c1394bfa35e85899afd0dfae44b0494778219c540cbd7e5845d2676a",
+      "size": 8674
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078001.json",
+      "hash": "bcef0973e27130aec9cff3c22d81ee087bc7beb04d8eb01e74c57ff2d7244754",
+      "size": 7683
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078002.json",
+      "hash": "59f95f1db1c5654e521e953f3aa7343bbcb0bac25aaeb2a11b3961da7362bc01",
+      "size": 7849
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078003.json",
+      "hash": "7d5df3f5822b102ccab6f89d4c67ef5fa350b014024ddd2c2212f1cec4c4a7c5",
+      "size": 10821
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078004.json",
+      "hash": "b0430813092cf2804f7594e658539d38be2f32133a2067ca2a0b899fa103e438",
+      "size": 8743
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078005.json",
+      "hash": "401d8cb6faede81b3774f2e453dec6dc377ae0231b80822cc63dcea1537a5a47",
+      "size": 6369
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078006.json",
+      "hash": "fbcd063bf6fe237e82aa9dc69788774f1b84ce0ba9bb6a082c65161a8aa27c2f",
+      "size": 7567
+    },
+    {
+      "path": "assets/story/data/04/1078/storytimeline_041078007.json",
+      "hash": "6a7b8bf5d7abd851c47acc02a41bcc8483381b0d5d4a6e46478d62095f44f5e4",
+      "size": 9434
+    },
+    {
+      "path": "assets/story/data/04/1080/storytimeline_041080001.json",
+      "hash": "4ec1e740b7de95ed53e7575b0f110cb177f9710508fa2de8f4d601445daa5560",
+      "size": 6710
+    },
+    {
+      "path": "assets/story/data/04/1080/storytimeline_041080002.json",
+      "hash": "24bbc5f70a87df3f720ab9d2ebdf74bbf0fd75c131ab166d32124c4092a072b5",
+      "size": 7576
+    },
+    {
+      "path": "assets/story/data/04/1080/storytimeline_041080003.json",
+      "hash": "8ddac5b6e8ec5fbec8727b24b0fb2b4b60b517f971ebd29d494bfa40610c7fc5",
+      "size": 6866
+    },
+    {
+      "path": "assets/story/data/04/1080/storytimeline_041080004.json",
+      "hash": "f95b7b81baa77fbcbd81ce5c6c8bec6bd6174418103410dad807dd5580af2a41",
+      "size": 9769
+    },
+    {
+      "path": "assets/story/data/04/1080/storytimeline_041080005.json",
+      "hash": "d76b95fdd0644bb3b209db7d7321221581679fc4c470c2fc2084cb6b74459219",
+      "size": 6341
+    },
+    {
+      "path": "assets/story/data/04/1080/storytimeline_041080006.json",
+      "hash": "5824c786ecb05a3b36dca148df4a591571912f0a134f29100b4aadd9f843bea4",
+      "size": 9756
+    },
+    {
+      "path": "assets/story/data/04/1080/storytimeline_041080007.json",
+      "hash": "1289b162fd8b428d3448cf225c717df02845666d0c2787ce82f833f188f5a6cd",
+      "size": 10246
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083001.json",
+      "hash": "b1e0f0e6a2c2aa2f0425408d80db81d47e629cefebb21b383a20b0cd92326f28",
+      "size": 8435
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083002.json",
+      "hash": "92a1ac9adbc6ac73de9a6079b2499d9bcb9f84cf373923997c2de7978ff69fd1",
+      "size": 8055
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083003.json",
+      "hash": "9f92bce583e38be8d2f085fcfdcc9f119f04fd143574a2470b1081c9cd52f98b",
+      "size": 10542
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083004.json",
+      "hash": "e5fff583eb1c3647e5348402909a0d923ff3a379b145d35d2d69823554f11f70",
+      "size": 7891
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083005.json",
+      "hash": "dec6b202348a0b310746ed73af36ebaa0c7ad94644251067c0d90b522bfd74ab",
+      "size": 5546
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083006.json",
+      "hash": "44e190e629fc8cc5e8c3656ce02560a38e72e98592908b2db9200a710c944e99",
+      "size": 8267
+    },
+    {
+      "path": "assets/story/data/04/1083/storytimeline_041083007.json",
+      "hash": "3b74d4c9cf4eb954ceccc9995aede244b98ff8e732445c03d024e5b10918cf28",
+      "size": 9323
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085001.json",
+      "hash": "dbf7ad322f7d091cdab12767b8214a637610067c7af86001c55be74dbd0808d5",
+      "size": 8834
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085002.json",
+      "hash": "f5fbee32e9fca69b274d6fa711170ff2eb1e4917384843dbd989f9a481cda147",
+      "size": 8955
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085003.json",
+      "hash": "a26dba73dd61fa2073eb9d41b9992d4d0cbdb58cae446b4d6765897a0b4b4292",
+      "size": 7712
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085004.json",
+      "hash": "08ebe78829ef832332066ab39405cf695129b89ef08caa99acb677eccfc6be23",
+      "size": 6927
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085005.json",
+      "hash": "2d3f2476b38a1b7bb7810ac85ad4a64240cba91cae0dfeb663a1d610f0dce743",
+      "size": 6083
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085006.json",
+      "hash": "e6cfac5a74102e53fa3b4481a784dcdc91f741bc9ec10ea1c441ad94db1f5ed7",
+      "size": 7547
+    },
+    {
+      "path": "assets/story/data/04/1085/storytimeline_041085007.json",
+      "hash": "8933b80ffc58fd76e0653939a0dbe44a33e164d8b4ce056c08ee5c75f985def2",
+      "size": 6298
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086001.json",
+      "hash": "2c3438dbe05b1de29c2ba825c98ce222ef91c74315ce36bae1ed2f03220ecc9a",
+      "size": 8553
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086002.json",
+      "hash": "7e7457137e687b750dbaba227278b7e359bec7f8924e2fa63f1384f906d719a1",
+      "size": 9782
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086003.json",
+      "hash": "bbcf64b684049f160c764862bad4347bbd565e2e71f94518dbaac04734498a81",
+      "size": 8603
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086004.json",
+      "hash": "ed9b1764041b7ab37c8bc4169628d61c58b51d92cc2b2ceb2f938d3ea86f0f72",
+      "size": 10433
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086005.json",
+      "hash": "496965e337057481cb296e3646ed54702a0b4881bc5c6426110ff21b31f27a73",
+      "size": 6173
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086006.json",
+      "hash": "1ae64c1e56384ccfa761b30b1571ef56c97a1185b1a972fcb6ef897752c4f9bc",
+      "size": 8405
+    },
+    {
+      "path": "assets/story/data/04/1086/storytimeline_041086007.json",
+      "hash": "cc3eead711f135f3b7672c4d15790d97fb8d8aefefdb1af1c673b6fd02d1c4d3",
+      "size": 10232
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088001.json",
+      "hash": "16e8b59083fd4ecd9bdf02711b15613b8102b76a1d1238c019644b2e66517671",
+      "size": 11244
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088002.json",
+      "hash": "2744126e0c9d6efd2d28d365386b96379581706a54f93dad788316feed7f0297",
+      "size": 7628
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088003.json",
+      "hash": "82a493c454d7b5abdbe09ef891d20b2e32e78057f8466c7a2688b5541eba2d61",
+      "size": 9942
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088004.json",
+      "hash": "b4c0746266cbb410ca8f14827ca4b9da231f411fb51f5938d0f8833f9e2a1f8f",
+      "size": 8821
+    },
+    {
+      "path": "assets/story/data/04/1088/storytimeline_041088007.json",
+      "hash": "9d231576dbaadb4a83be9b37f22ec8414a0552f01b1a8c46bdc556325a0a70ad",
+      "size": 10029
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091001.json",
+      "hash": "8e361e92fb9309c96b51c6afbb6e02cd6a9e87879c86dd41be8d37d3b00c15f5",
+      "size": 10186
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091002.json",
+      "hash": "9dad2b0625c690f7fcad024a19ad80edb1efa62bb14e74d06b67eb671985ab8b",
+      "size": 9445
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091003.json",
+      "hash": "fa01de8066447b9dd396e36d6ccf46f3b432804fafc007a9e2c9086eb946f22e",
+      "size": 10812
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091004.json",
+      "hash": "b8aab607fbbea41914d98ee12a1e95fa360730bebacf6984b783c727f23194d2",
+      "size": 9797
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091005.json",
+      "hash": "756a416d35be3d85f3f474f283f2189fc02fa9cb17887bb352d26653d11e8393",
+      "size": 5746
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091006.json",
+      "hash": "01d992e90da96fe2ad6ca439b78ecf53bb43018bce0242d790e57f48580fe438",
+      "size": 9665
+    },
+    {
+      "path": "assets/story/data/04/1091/storytimeline_041091007.json",
+      "hash": "f645347354a4bb4a7dcf4e6559c75fb4dc8465678f1cff503f4018a971318a31",
+      "size": 10089
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098001.json",
+      "hash": "d2d02908b676dbd3d7cc7ca8bd6aa787a6945ce99309ec4dae0e2ccff250b781",
+      "size": 9137
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098002.json",
+      "hash": "9e80f7c1885878508635534e84cbb189431ca0fd69e5865bf1f2a65ba575561c",
+      "size": 10049
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098003.json",
+      "hash": "0c0f9e25fa404648648e8f523500c3754cc83f0f606aaca7a1433087925eb915",
+      "size": 11681
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098004.json",
+      "hash": "86d83afa3eaa32b7bf65259b75d240a2b0bf7b081bc6cb8869fde1ffd53d170c",
+      "size": 8583
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098005.json",
+      "hash": "92a625580ce66544a589f6204e6d3ac746843ec8a5205bce3e1f4a394149ef46",
+      "size": 6771
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098006.json",
+      "hash": "7216b6d278bdef4b3c1e24e31876443c91bd3336e5d75ffd57d76943ea246fdf",
+      "size": 10164
+    },
+    {
+      "path": "assets/story/data/04/1098/storytimeline_041098007.json",
+      "hash": "785e6dcfc36c6082865863bbb6b7104470d3d15f9c757de53de0405205e36b98",
+      "size": 10371
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099001.json",
+      "hash": "e954e420fd92c1e26d731716d862e6c014edf76ab0cad8afc788eae651dd992e",
+      "size": 8460
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099002.json",
+      "hash": "4ab41b5b70fee4075b2b0dcd6339ff47f8b4b64a411401bc9c0e36d038429be4",
+      "size": 6928
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099003.json",
+      "hash": "bed492282e8285ee858fdf2557ee13f8826e88bb4df4bd5e449ccc6a75d30122",
+      "size": 10482
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099004.json",
+      "hash": "b79786f2cf1ef1809b707355b6c71fe6ca89a881b7cd6e0590956c20a9388830",
+      "size": 6461
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099005.json",
+      "hash": "7f2c2a3c38f1be3956fbcd8d1cddfa2650c1e9e1ae189424f4e738b06c12115d",
+      "size": 6484
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099006.json",
+      "hash": "b19bc7baad9d8b91d231a7fec53cf0cecaccb0bce816dff64961951e20d6036a",
+      "size": 11242
+    },
+    {
+      "path": "assets/story/data/04/1099/storytimeline_041099007.json",
+      "hash": "d914fed0ea4afe6b2d6ab5f61f9db5551e2f1fad9ac71e00da8e178a6291cfe4",
+      "size": 10430
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104001.json",
+      "hash": "0776520c7eae54110fb3319a2c5647d9d92721374f4941c80a9ad2bba0de712a",
+      "size": 8852
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104002.json",
+      "hash": "cfb601d15568a134acf7f8f3d8307b3778a58f9be2beb47e4f64f19e93f1e380",
+      "size": 8684
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104003.json",
+      "hash": "2da5d694958cfd4d7ed85b65bc66135a2d5835def8dd0a8bfe6128a8ba970d08",
+      "size": 7861
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104004.json",
+      "hash": "2cd54f563ddc4b7eea82dcd1a0f5792b353c4e55b14cd32c71002a543b5ab68b",
+      "size": 9155
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104005.json",
+      "hash": "e9006833544c3f4abef7f24f3ea0852884b56deefc6f1f0fa7f97e58d53f987b",
+      "size": 7586
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104006.json",
+      "hash": "ad9eb7bd94ad912a6cfa2cdb59e62c91aeb15867b89f0bb79e6d5ba9031b5c47",
+      "size": 10614
+    },
+    {
+      "path": "assets/story/data/04/1104/storytimeline_041104007.json",
+      "hash": "adc247aaeffe1477e4404245acf434daa03ba4b5603b6ca58f380fefd0a1b422",
+      "size": 10011
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105001.json",
+      "hash": "6fb4b64881383704bef43abc64efb83f05dced5619a4b0d9828704e7d26d7a38",
+      "size": 6153
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105002.json",
+      "hash": "3235eaf520bd17a6fed539bba70b9629827fde7dd6aaaac6327c6ad9f83b87b3",
+      "size": 8578
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105003.json",
+      "hash": "a9e5a4874fbad66571bac2e7eb22453088d4b5b035ea0b2a97af0ad8bdbf1c2a",
+      "size": 10365
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105004.json",
+      "hash": "b8470e75b8ea09994edde43d81f37a89a4c644ad338c247e48f549809b7d6c00",
+      "size": 9228
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105005.json",
+      "hash": "8973f0a6ea167ae3a7f59ea87bb87d9b1118bef1726ab46ad56612de6d016d21",
+      "size": 4773
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105006.json",
+      "hash": "07200a251085e0a14e6944dcd818789b6830fec67eff90f96dc44c03f1f5a449",
+      "size": 9256
+    },
+    {
+      "path": "assets/story/data/04/1105/storytimeline_041105007.json",
+      "hash": "dbb1746eddda9d642fd21b1f2d90cbd9efe9b8ac5c691d371d570bcdecb2a7a8",
+      "size": 8787
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106001.json",
+      "hash": "f34df4db66c5f399be4760e1e06d520d1941179e9c3b5c13590afa566db3235a",
+      "size": 7765
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106002.json",
+      "hash": "3c7ed827b8d8b3883dcc7e9f9f7055cd43eb0c223f8d786a63e1c8b98fdfa130",
+      "size": 9078
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106003.json",
+      "hash": "deb4705cf69beaf6b95fba92e1ccef88697c863f037447a0694b813fdb1d24ba",
+      "size": 11185
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106004.json",
+      "hash": "5dd5e4108a80f3d8266e09544b6fa261adc4e60f1cfc2bb27047a408c2b7e3d4",
+      "size": 9275
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106005.json",
+      "hash": "d052eb2b17b2e39e64b51b7e4d7d8c7a8c3f924bb4d5532ec999b1c800442615",
+      "size": 6419
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106006.json",
+      "hash": "11bbe4eb30098e003a5e163bd5aca6f7ca5f7949c69f6166b87bd9fa5734b5f1",
+      "size": 10613
+    },
+    {
+      "path": "assets/story/data/04/1106/storytimeline_041106007.json",
+      "hash": "e59dac1b8957f15aaf9ea14d6e4cf9d9cd2863dd0adf7558a1024164a3ae7e6b",
+      "size": 11037
+    },
+    {
+      "path": "assets/story/data/04/1107/storytimeline_041107001.json",
+      "hash": "153c785a2f9623767a91414863a29410dd5a6995c47f845eb74d69d98a2c9976",
+      "size": 9519
+    },
+    {
+      "path": "assets/story/data/04/1107/storytimeline_041107002.json",
+      "hash": "cd22760047f9f7140507e74923826b700dc3adf34917ba8db3aec2d7b42f5f7f",
+      "size": 11497
+    },
+    {
+      "path": "assets/story/data/04/1107/storytimeline_041107003.json",
+      "hash": "c98d8d1a43a722f55b09b6a613d447ccdee143450cce6d422eebd59fd5446d95",
+      "size": 9088
+    },
+    {
+      "path": "assets/story/data/04/1107/storytimeline_041107004.json",
+      "hash": "3b5632bed95a8268c32b839e8c55f20489f1371a4408b9bd8dec019234e23a1d",
+      "size": 9656
+    },
+    {
+      "path": "assets/story/data/04/1107/storytimeline_041107005.json",
+      "hash": "4ce9f669c21e025e62ae2a1af694c2e0feed0beded80391de0a888b8faaac60e",
+      "size": 6524
+    },
+    {
+      "path": "assets/story/data/04/1107/storytimeline_041107006.json",
+      "hash": "c89c9b3eea7c4d82f711bd0bd461ed7b16c8b72b428b33c180812864b6d7e82c",
+      "size": 8399
+    },
+    {
+      "path": "assets/story/data/04/1107/storytimeline_041107007.json",
+      "hash": "7fd3a4ba64241810f29262dbd46f16ddb22c20934c6ce68a77d239a0ad815f26",
+      "size": 9207
+    },
+    {
+      "path": "assets/story/data/04/1109/storytimeline_041109001.json",
+      "hash": "573669f4e62f1dd10d8b92cef137b47dd841a7e30d7bc15a9fa30f0d9ca9b3e5",
+      "size": 10356
+    },
+    {
+      "path": "assets/story/data/04/1109/storytimeline_041109002.json",
+      "hash": "2e32ff40e8a4fc59be23b438db1dc2ab539e63a7cb486bc94fb73d2c677ac5ec",
+      "size": 8875
+    },
+    {
+      "path": "assets/story/data/04/1109/storytimeline_041109003.json",
+      "hash": "d71ae98d8f3411b8cdfcb9cb13d931c9b46f05d1bbe785ae2b7fdb3b48f842c3",
+      "size": 12074
+    },
+    {
+      "path": "assets/story/data/04/1109/storytimeline_041109004.json",
+      "hash": "6c35c72edac0826ad7f99b7556244b75c0c52436398e88fabee72ea11c2cfee5",
+      "size": 8581
+    },
+    {
+      "path": "assets/story/data/04/1109/storytimeline_041109005.json",
+      "hash": "2045437ba28732d93b5594bf8a0dee2181876102c2a5fd17b794494cbfee7031",
+      "size": 7121
+    },
+    {
+      "path": "assets/story/data/04/1109/storytimeline_041109006.json",
+      "hash": "a35de31c20181b6e38cd6b07b549b7d28de192f4295bd44b3c8ef21ebd5f52b5",
+      "size": 8982
+    },
+    {
+      "path": "assets/story/data/04/1109/storytimeline_041109007.json",
+      "hash": "4b01c9c33fc26fcd38a0ac64fe569135476ac56f1a9936f8e486524b0b74630e",
+      "size": 10322
+    },
+    {
+      "path": "assets/story/data/04/1110/storytimeline_041110001.json",
+      "hash": "a6a7007395afd4219b976c4ecf9940b82610a05fb59c162c464f4b641a4ddd14",
+      "size": 11231
+    },
+    {
+      "path": "assets/story/data/04/1110/storytimeline_041110002.json",
+      "hash": "580e1d379d1a4e1fdd41432faa65f329f81ddf050992c00e2458b571512e5ddf",
+      "size": 9481
+    },
+    {
+      "path": "assets/story/data/04/1110/storytimeline_041110003.json",
+      "hash": "0621aa8aba9471bba40caf224586ea609bf71e5cbc46bee5b01d0b71c039db2f",
+      "size": 9561
+    },
+    {
+      "path": "assets/story/data/04/1110/storytimeline_041110004.json",
+      "hash": "c1db60a559971cb88044797c9e79352fa656f6a824b77a7b2d296191b6268986",
+      "size": 11863
+    },
+    {
+      "path": "assets/story/data/04/1110/storytimeline_041110005.json",
+      "hash": "5ccf1115b99233b62355aadec8b414d6fa08def62a08ba67fe4a82a333d23a6e",
+      "size": 7479
+    },
+    {
+      "path": "assets/story/data/04/1110/storytimeline_041110006.json",
+      "hash": "3cb154868dcb2e189a482fc2a9d3ab61ace820967f558c32543a565ba1fef3dd",
+      "size": 9699
+    },
+    {
+      "path": "assets/story/data/04/1110/storytimeline_041110007.json",
+      "hash": "4b23f32ba80ff2d851b1e6b147d5878f2bd25dfa6742093d9a61f5884a60b0ee",
+      "size": 9303
+    },
+    {
+      "path": "assets/story/data/04/1116/storytimeline_041116001.json",
+      "hash": "8c6d2cf681044160ecf988dfec24d1a2ad7e34f6a0c184e53dc982afcd2b4294",
+      "size": 9792
+    },
+    {
+      "path": "assets/story/data/04/1116/storytimeline_041116002.json",
+      "hash": "4509c4e9ad052faf5fc6f787f1ec9dfc6e4c8379b41c55080d92946fb135355a",
+      "size": 8545
+    },
+    {
+      "path": "assets/story/data/04/1116/storytimeline_041116003.json",
+      "hash": "70e285ae4c1f1172cc486b7ac814c6ab955fed80c8bdc432d3121686c4f2206f",
+      "size": 8808
+    },
+    {
+      "path": "assets/story/data/04/1116/storytimeline_041116004.json",
+      "hash": "29bcaa27270e9be1f7b3915eb5ef8151ba99fdf455a32434bf9aba39151cfc09",
+      "size": 8672
+    },
+    {
+      "path": "assets/story/data/04/1116/storytimeline_041116005.json",
+      "hash": "6ff50797552b357e173b89ecf3c1c5be042b704d9d8061cb0b7e4abdaf287c6a",
+      "size": 7527
+    },
+    {
+      "path": "assets/story/data/04/1116/storytimeline_041116006.json",
+      "hash": "e2f7daaafcb2003fe2938a89c74f3b9f4dbc3b012a4236e5e459902bd3f5a11f",
+      "size": 10061
+    },
+    {
+      "path": "assets/story/data/04/1116/storytimeline_041116007.json",
+      "hash": "75a6e56ffc8c2f3ee1edd41ef877b49270ddc16346059167347a5b39f27c5f0a",
+      "size": 9917
+    },
+    {
+      "path": "assets/story/data/04/1119/storytimeline_041119001.json",
+      "hash": "ac71b065dd82981e0b668f6df581178cdc1dfe7c7b85120f9bb029addf4407c8",
+      "size": 13266
+    },
+    {
+      "path": "assets/story/data/04/1119/storytimeline_041119002.json",
+      "hash": "7d495c574ccf749bed14c330f655092ca49bdcc4df6260ff0c8eb4a7c6281b79",
+      "size": 10459
+    },
+    {
+      "path": "assets/story/data/04/1119/storytimeline_041119003.json",
+      "hash": "34f4e2727b8d9052bd91212cb16435bbc71743b171c082bd4ae8912d63515438",
+      "size": 10727
+    },
+    {
+      "path": "assets/story/data/04/1119/storytimeline_041119004.json",
+      "hash": "0441454cea435495cc855737d1c3d7a7bccb7e67552b7da186bf59a22b6ffa99",
+      "size": 10806
+    },
+    {
+      "path": "assets/story/data/04/1119/storytimeline_041119005.json",
+      "hash": "55005c41ed96b6e5eeaa6f96215fd73ebd415b6bf33d342bf4af4e5a7ebc8f67",
+      "size": 5597
+    },
+    {
+      "path": "assets/story/data/04/1119/storytimeline_041119006.json",
+      "hash": "62944293a00031c34712af95ee0cdbb6cb7e383a6dac6a0743d9a565fff2614d",
+      "size": 10080
+    },
+    {
+      "path": "assets/story/data/04/1119/storytimeline_041119007.json",
+      "hash": "55c866ac038ac4f7774c9e47de00fbcf9e218b6a0e5253b7b36d510168e78381",
+      "size": 10677
+    },
+    {
+      "path": "assets/story/data/04/1124/storytimeline_041124001.json",
+      "hash": "37e61962bea7e972358fb7a61165f5f89fad798a7dfeff9edb05cc0b187154d2",
+      "size": 9816
+    },
+    {
+      "path": "assets/story/data/04/1124/storytimeline_041124002.json",
+      "hash": "1d4304b33a787895f24412661e2206a603fcf1ec81fc2d2874823773efaa526e",
+      "size": 8832
+    },
+    {
+      "path": "assets/story/data/04/1124/storytimeline_041124003.json",
+      "hash": "40f743f269e34af7650d29de175b6fed248b4a31112816ad577e1e642f79c560",
+      "size": 10973
+    },
+    {
+      "path": "assets/story/data/04/1124/storytimeline_041124004.json",
+      "hash": "d0cb23b9e51096451d48ddb1137bf20f35784530b6f5f7ba5236911396693b4c",
+      "size": 10064
+    },
+    {
+      "path": "assets/story/data/04/1124/storytimeline_041124005.json",
+      "hash": "381588268e5eec190759f08d172dc293e6886dc8ae115440c575dd1cee76f6b4",
+      "size": 7473
+    },
+    {
+      "path": "assets/story/data/04/1124/storytimeline_041124006.json",
+      "hash": "234af58558c443bfd270e8a4fb476bca9c0438f873474d2667fc1c5358b85978",
+      "size": 10981
+    },
+    {
+      "path": "assets/story/data/04/1124/storytimeline_041124007.json",
+      "hash": "606a4100b058df8578828cd08d2e98a0223116b233a8496b1c35bf18f5f4ee4a",
+      "size": 9454
+    },
+    {
+      "path": "assets/story/data/04/1127/storytimeline_041127001.json",
+      "hash": "37813e1335bb64e803591514fd0c24bd643a1eb71e7269997a0c77c192d4aa05",
+      "size": 10254
+    },
+    {
+      "path": "assets/story/data/04/1127/storytimeline_041127002.json",
+      "hash": "da960820ff3405c4ed87674ddc43a2924b5ba6ceba4d58b54f39581d91b6cb82",
+      "size": 7858
+    },
+    {
+      "path": "assets/story/data/04/1127/storytimeline_041127003.json",
+      "hash": "e2a13cb52c4821215db0dae5f43e925ea451a776afcdf57e9113a9d501fa88b8",
+      "size": 8725
+    },
+    {
+      "path": "assets/story/data/04/1127/storytimeline_041127004.json",
+      "hash": "c350af77ec90850f16e114faef3cc78c950a5d557920bdb0297abd01db533774",
+      "size": 8764
+    },
+    {
+      "path": "assets/story/data/04/1127/storytimeline_041127005.json",
+      "hash": "35e23ae880d5308b68d61753553f2d0a9f4fe641bbc81fb1e776c23ab1a0ed2a",
+      "size": 6991
+    },
+    {
+      "path": "assets/story/data/04/1127/storytimeline_041127006.json",
+      "hash": "609ac09aa2f0fb8f703da9073bb496e0bd7a257952d35763c5edafe4e7476854",
+      "size": 10567
+    },
+    {
+      "path": "assets/story/data/04/1127/storytimeline_041127007.json",
+      "hash": "27cab865ed9172765a78f0799bdff6497e1873f67673a85d555a2d1994cf5c87",
+      "size": 10009
+    },
+    {
+      "path": "assets/story/data/08/0000/storytimeline_080000001.json",
+      "hash": "ce2d98f46423dc5483a064bd03a95c2dc534b0a137731877f8c762a8d2e6aed8",
+      "size": 3385
+    },
+    {
+      "path": "assets/story/data/08/0000/storytimeline_080000002.json",
+      "hash": "bf0899db918757cdb0f9d782c4e3676a7b83f328c0407b81b32f09395e1327fa",
+      "size": 2045
+    },
+    {
+      "path": "assets/story/data/08/0000/storytimeline_080000010.json",
+      "hash": "570b55d5998ebdf882f81e15b486dd97d3f3bb608dc42f74b0040c75dd8598a9",
+      "size": 2275
+    },
+    {
+      "path": "assets/story/data/08/0000/storytimeline_080000011.json",
+      "hash": "2917584c1bfd9ed9d8ecef69198bc1a9b1759f676e0790c7ae9bc6c2da748976",
+      "size": 1779
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002001.json",
+      "hash": "cbc64315916cd4dcbede3e493f2a05f407a4433835392eaf7fa5748f6b8f8ba9",
+      "size": 10022
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002002.json",
+      "hash": "0055b8e857a85c97799d0a098b366999bc430066518ced2b826cd08123ebd8f4",
+      "size": 7164
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002003.json",
+      "hash": "ccafb9886bfe18fa627bb140d537332796c58a29fdf5b485555a3d84ef2dbcde",
+      "size": 6491
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002004.json",
+      "hash": "7471d6fb9967c64ff366fdcabf0d7d4632c33ef22281097f4e69c89e2a220c38",
+      "size": 7013
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002005.json",
+      "hash": "b064e7a65ac3233c711839d83926edc69b4a8e104d66b21576ddc84c2a8ce3bd",
+      "size": 6881
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002006.json",
+      "hash": "140eced39114c3b895d743e14d6b21d51add146486d3952c14f1aefa330c3ab2",
+      "size": 5444
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002007.json",
+      "hash": "f974347a3aa23e15ea54c7a2ad06c28d69936f053854889ff9a114c61c98b779",
+      "size": 7667
+    },
+    {
+      "path": "assets/story/data/09/0002/storytimeline_090002008.json",
+      "hash": "7fcae757c64d5947ee2a96afd7abf6f7ad56e3c3b86f44ccc57482607bd7dd30",
+      "size": 6556
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006001.json",
+      "hash": "8b803cab7bec9115448064f2eb1f5408b0ef21714f40232a0c35c06e12112c5e",
+      "size": 7706
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006002.json",
+      "hash": "3cf7abaa8406bfc3881c973f4335a04e006a8a10c954b76b07e96c349aa38253",
+      "size": 6308
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006003.json",
+      "hash": "bdd6ce6fdcb5c7f7a204dd38ddcab82d919bb9c6f94cfa2a3d66da599b3fd451",
+      "size": 10664
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006004.json",
+      "hash": "fe23b3458168e752631912ad04ac3d61d9489c396018a3f176507232eed899de",
+      "size": 6472
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006005.json",
+      "hash": "69cf1fb2da98114b815835f2dba2835f4eb57db15c9d3916ce69016d37f29fc1",
+      "size": 8024
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006006.json",
+      "hash": "d654631b5af7ce54e16b0125b4450e9e40d4daa3c6f6a19be008899026c35a41",
+      "size": 6517
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006007.json",
+      "hash": "3fd07d3b0a898b077cb972bb4589d870530ee40c476f91aea32041b103cb9273",
+      "size": 5718
+    },
+    {
+      "path": "assets/story/data/09/0006/storytimeline_090006008.json",
+      "hash": "8de1b59e7f83dca04fdfcc567dfb96a2d33a9b25fd81a05f7cf4c17025382051",
+      "size": 10779
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007001.json",
+      "hash": "998e82a91991b9d45101d2723099f3e0846f9359a576afae3e595fa4bef25474",
+      "size": 7593
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007002.json",
+      "hash": "0701ae63702e28692637956322cceff38bae59a5786ab8a162f90ea66d4455c8",
+      "size": 9098
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007003.json",
+      "hash": "8b71a9124164f4b50fa8f9548aedbe963d7cbc614b82f4e2ba7fd743eb0e50c0",
+      "size": 10254
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007004.json",
+      "hash": "e03eb7295dfe5261412d7a4c8ad602090e739723b89199dbd6bff9317ec26f85",
+      "size": 8136
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007005.json",
+      "hash": "07b6969fc4c8d43b62dcbc9b847ca4d8ea15e000fe7633321c39f1dcca36fb9a",
+      "size": 7702
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007006.json",
+      "hash": "37016ed733650017f51558d5662e012ca58d2539d7e8fb53ff0bb23dd835b8a7",
+      "size": 6401
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007007.json",
+      "hash": "cc338065906f0c69f8d0eb169ea17397156f91a153e1604fadfab4c0682f2b69",
+      "size": 5981
+    },
+    {
+      "path": "assets/story/data/09/0007/storytimeline_090007008.json",
+      "hash": "9c05b91e3e8610a3f2e736a3d9382c8344a5881b4a6fcb43e2a43096c75c9871",
+      "size": 11124
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008001.json",
+      "hash": "80236af367bb6b38b074b819e08a7519f30876a7fce1268f05db66b86bf241be",
+      "size": 9426
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008002.json",
+      "hash": "17bd1f0a9e8bb99e44b4f6204bd661987668cbd579833fa3817715f905cc4a05",
+      "size": 8843
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008003.json",
+      "hash": "fd41d975e3cfd5c10aee16c818c88bb4f0483d2faf91926080455a3d3e7fa160",
+      "size": 7314
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008004.json",
+      "hash": "d107566431d5991ae4d3e9249dd48e84fc0a704cf46e20f9995693c3402404d3",
+      "size": 7681
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008005.json",
+      "hash": "664f2c40effa45c057a27a38e90e5f6455ba7bea75749bf21023c0a9e461e92c",
+      "size": 8481
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008006.json",
+      "hash": "93776b73f1d083e862e94277170fb4ebd99d4fbc6c18edc11b7cf538df15355c",
+      "size": 10721
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008007.json",
+      "hash": "d2ebd7e89cb2be47dd7616275f8a1e7fee6b755629bd38cb07d8320a80126ade",
+      "size": 7606
+    },
+    {
+      "path": "assets/story/data/09/0008/storytimeline_090008008.json",
+      "hash": "2d6903b4b1fae6c0a26df5a949db8976c3e99f16e20b7b38ffdcd936d18d467a",
+      "size": 7229
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010001.json",
+      "hash": "a9c9a3013babbcd2d9579de238a936960378a427e5ca7b626d96637059c92518",
+      "size": 10215
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010002.json",
+      "hash": "9be69e6c63eb0b2f0263b4aa20cf62620d4ea4fdcce383fda360024055c80a3e",
+      "size": 9678
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010003.json",
+      "hash": "68de43f0ca7170b49c5393fd5ab06ae790fc4027d4ca669eea85ef85425b829d",
+      "size": 8930
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010004.json",
+      "hash": "96302cb84b19bad0779da0420eb9764ca112bb663beadccfd13a233c76e5608b",
+      "size": 8917
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010005.json",
+      "hash": "15a45a966dc81d1e26e08c80ba8c0caca19c0e5fd24daa3f459f47d2076dc900",
+      "size": 6792
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010006.json",
+      "hash": "f455402fc0926a8cac9c75757593139834dffff5cc7946eecab31436932822fa",
+      "size": 5362
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010007.json",
+      "hash": "0782755a6aab4aa06c2b686fef7206fa31fef15fd75297f9d013933bf54c9fbb",
+      "size": 7213
+    },
+    {
+      "path": "assets/story/data/09/0010/storytimeline_090010008.json",
+      "hash": "e34990af8b43e5ae9fc8425118800a94ff228085d862eed792fbda737f26c7a6",
+      "size": 7630
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011001.json",
+      "hash": "347ed6f1c022c6963d972de2841a3dc03b2687fde8cf5389768d2fd0fe2c9a08",
+      "size": 6995
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011002.json",
+      "hash": "9b50c467c1e3308b8f4c3a548d100f5b944c2efaf20b844f948aeda5488cfd64",
+      "size": 7998
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011003.json",
+      "hash": "91428f8c10b809d10a47cb24215a6b049490ea6546c07120fe4984716f94e150",
+      "size": 10564
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011004.json",
+      "hash": "0f05e992d9359654654f424e3e9e9c6f40dd885a5ab8d9aa7a4ddb0a83c1b043",
+      "size": 5695
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011005.json",
+      "hash": "8b7690722dbcc273ec99d9d412aef227fce2d364735ed7236984fe5de2034554",
+      "size": 9102
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011006.json",
+      "hash": "e8aebfb914280cef9afb7a5f42751f70ed4531aa980ebbeca1bb0dd286de43e2",
+      "size": 7288
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011007.json",
+      "hash": "eb322205ca0b675b56c655a1dbf199ea16bcc0df777cecdbd2f4f1690e9d1444",
+      "size": 6083
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011008.json",
+      "hash": "30dfecc4db7c3713ae91541ef01d551fe83e81d934e0d9fbb9a1ad0709a82974",
+      "size": 6150
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011009.json",
+      "hash": "22b44b42926cc009e133ee5d7fa327bc6e1155bc588d7e431f25a0bbeb10c882",
+      "size": 9002
+    },
+    {
+      "path": "assets/story/data/09/0011/storytimeline_090011010.json",
+      "hash": "e0278a786c19ef564639030da198faef42024723a6734b292cef88564fce53a9",
+      "size": 10843
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012001.json",
+      "hash": "984263140ac1973058ad0d4988fe58cd97021d099b750f5139e61cecfd996b3f",
+      "size": 8763
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012002.json",
+      "hash": "a8c11361b2219279c1e1299818c6cda224e62fe82fb685a897826f64209713a4",
+      "size": 8647
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012003.json",
+      "hash": "05d23c11e82b74b4a00329eba3ccaabf5493b197ded5aaaf7821ed136fc7842c",
+      "size": 7796
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012004.json",
+      "hash": "677286648538f72f7030d44ab41556e9cceb0b03f2f13d060572e3241e17a046",
+      "size": 9109
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012005.json",
+      "hash": "6e3cec560504ae34782e49b04638e5954d4a1c16a0d4a9c937f64f842cf982bc",
+      "size": 9406
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012006.json",
+      "hash": "8cfed0a2771f3b596b698607da193c7d595362df5e3436ab49c3c4feb013d257",
+      "size": 7774
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012007.json",
+      "hash": "502bac5bd17885ce819c9e7d7d4c3609faf9a98055f855d4650a5d16eb280566",
+      "size": 9642
+    },
+    {
+      "path": "assets/story/data/09/0012/storytimeline_090012008.json",
+      "hash": "a3bd44d9b6a3bad0bf7966ab9f7f7c777922eaf0dfe9078ab533d80255d940bf",
+      "size": 6404
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013001.json",
+      "hash": "7ea89a9d8555e9acf43650b11ec64617fc19b5e38cef67331e9f0c021b467a80",
+      "size": 6951
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013002.json",
+      "hash": "04cbfa8eda28a8d8c9ba2836ec162056bdad9b5835d181b39dad6b55a8af7c09",
+      "size": 10308
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013003.json",
+      "hash": "4ae52a2530f669c41fe0063d4d3d373771e2ce99b1ed7ee1048474159baa420b",
+      "size": 12052
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013004.json",
+      "hash": "67e79819591b20938d6c41edde64c666ee2ae1a193ecd2d342289533cfbe5a46",
+      "size": 10248
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013005.json",
+      "hash": "4c54c8cff0563e1214d76119feec035be9451273f6e3816a9bcfc1cc01b393a3",
+      "size": 8500
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013006.json",
+      "hash": "b35b3ec31b6308ca9608c75bd6d0185c6c6c7b1be42d9d4c5f1b1648bd6d291b",
+      "size": 7900
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013007.json",
+      "hash": "e9b392b7ec123e56e04f4a1863651f28c4e5c39feb127efba61f38e909bff4b7",
+      "size": 9983
+    },
+    {
+      "path": "assets/story/data/09/0013/storytimeline_090013008.json",
+      "hash": "7a9765a77e717332eebc7f1df77dd7facfbd19e6a685ec8e76907f1d354518a4",
+      "size": 4249
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015001.json",
+      "hash": "d88cd64426a275e2d65b554f0e10d949c95e622bed784506695e1087fe320847",
+      "size": 7752
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015002.json",
+      "hash": "6fd5f16d94f9b7e1d902751770f919d853a2e6ba5e13a092ea35c5e5e38c962a",
+      "size": 8448
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015003.json",
+      "hash": "e58786c96ee4d0ab9ef03f6aa080301099909eeb8d19ea73e954f068fe091a1a",
+      "size": 7672
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015004.json",
+      "hash": "bc713e5a1f4ca2311bf452ee0d42ef75672f4c88035004c2f820f87f2d5a3e4a",
+      "size": 6493
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015005.json",
+      "hash": "eccf09b9db4a24bb3867de9149c7c2f0290416c12bbe15835bb2a07b97886f55",
+      "size": 7811
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015006.json",
+      "hash": "7389d3e2a6219670cf3c4cfb206fc9b2a6cf5ccdca9b58918b4a8ad903f74ade",
+      "size": 10075
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015007.json",
+      "hash": "4bd921417a520683b8f48c57f5be0867c5bc8701cfd3c073086fbf6ec1ed1166",
+      "size": 9624
+    },
+    {
+      "path": "assets/story/data/09/0015/storytimeline_090015008.json",
+      "hash": "c0a91af6c668a964df3cd0605a4307e187a5dcb816d53064796d95ff45a0da5a",
+      "size": 7801
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017001.json",
+      "hash": "c6aa55633fc7c21a58b036ca51f4df09a03f0743fcb2c66a4bdf1e3b0bf34c0b",
+      "size": 6718
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017002.json",
+      "hash": "307dc63dd7938cd72f7e711a660d2f4ebf7a1b219fc89a2ad0eae012e766bc2e",
+      "size": 8495
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017003.json",
+      "hash": "13b9ce0c2955c8447af76031fd8b136631e7776e23fde08748abd68b48b7f576",
+      "size": 10508
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017004.json",
+      "hash": "d43582f1f0ca1cf0b56b527234a6e1e6cb5d6cfc2853124c728884757f384ec5",
+      "size": 8085
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017005.json",
+      "hash": "245978e9b480107a104ca7a842f24a0e502867e81e49bdb70cd8e705aa390fee",
+      "size": 8166
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017006.json",
+      "hash": "a91af623f062fb10421b5f2ee452a0631f1d124aafed9b49caec0aa5c5a77e90",
+      "size": 8292
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017007.json",
+      "hash": "f0b5520fb951e58f0eee961c948097771821244eb0886c6a9a9cca28badf673d",
+      "size": 7990
+    },
+    {
+      "path": "assets/story/data/09/0017/storytimeline_090017008.json",
+      "hash": "168dd6815f023a776a6454b42eb2e6e16121e8123af31ffccface82d90ce78c8",
+      "size": 8538
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018001.json",
+      "hash": "fa85de3027f1a836bb1bcf00fb9c88e766bc523da1c8a756ef3687085764f591",
+      "size": 7587
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018002.json",
+      "hash": "c6e753045a08ec2250e4a4f90757d3c2c86da78a9b13e308725263f70bf9105f",
+      "size": 9298
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018003.json",
+      "hash": "800f2de315606e95e9da6c8e65b90eca6aab403ff685f9069d526294cf24283f",
+      "size": 7174
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018004.json",
+      "hash": "f3c78ce091a1b2d045b057390147022537d3e2c8094ddbcfa59fd788076dcaa2",
+      "size": 7426
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018005.json",
+      "hash": "98cfb4033b016141a551dbd51d3045f28469680645d851921aadc6f98dfbb2f6",
+      "size": 9447
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018006.json",
+      "hash": "619c8ef686b7c924c11c66b968cf150cd0eaa37bf07789145c0cdbb4859c1295",
+      "size": 9231
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018007.json",
+      "hash": "57b450f12aa841a92b3f6b9e2d98e7221fe25bafc401e15b3eb6456fd0b5d7a0",
+      "size": 7843
+    },
+    {
+      "path": "assets/story/data/09/0018/storytimeline_090018008.json",
+      "hash": "23c75565f935f03f2072064c5fca13fc0b1c6ee965b59dde43754d97e0f158a4",
+      "size": 6641
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019001.json",
+      "hash": "2fe1ad8a99c2b37e71bb4bc1f03177f3ceca65812199a8f90cc2e1898d936edb",
+      "size": 7875
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019002.json",
+      "hash": "290891f25b700217c75a6da9e9b9e4009dbc3513ea433e1165b30700c3bd6591",
+      "size": 8874
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019003.json",
+      "hash": "953afb8f4aae2467b98a38186a0a1b391e9576ca6f97acac3037d890be085679",
+      "size": 10157
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019004.json",
+      "hash": "90d14dc6c49739cadeabef8c33decae6df95b4b45cb19e49feb079a60e556861",
+      "size": 8002
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019005.json",
+      "hash": "1fbc68c50c5e8ec7b24c18006ac5f2a8104ef33822ca735441f22fcc6d90b165",
+      "size": 10229
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019006.json",
+      "hash": "55a88df6aeab1c2d6026c502ebcb3697d4490806a45ea2d32942428f4f830a0c",
+      "size": 11120
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019007.json",
+      "hash": "f1731b1995e783791843cc5dbf7619124df4f7866fd2317dacd075af40595eaa",
+      "size": 9691
+    },
+    {
+      "path": "assets/story/data/09/0019/storytimeline_090019008.json",
+      "hash": "efc1400a9cb62886b291f3f21c7fe04738a4135b5e8abae39f636dadedd5ba16",
+      "size": 7796
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020001.json",
+      "hash": "164b3a2de196f36ca74cf5aafd6164bba8e08bc419647cb4ab26e2a035af1c28",
+      "size": 7391
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020002.json",
+      "hash": "565f2cb41031afebd85116bd6ebf83f975bc56bd8121e85f46b060cda4f8008d",
+      "size": 7418
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020003.json",
+      "hash": "32cfdc5c259883f0a21e47cad3274e1e24cd486e7f05cb11d9f6097cd3767fc2",
+      "size": 7227
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020004.json",
+      "hash": "f2c92d1016278170a737e2f0b32aede10e07709db061de01ce2dba09ac0e1930",
+      "size": 7330
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020005.json",
+      "hash": "2ee2ac2188b876a2528f25322c3445047c48618b212745963a2e4d2abbf7576d",
+      "size": 8376
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020006.json",
+      "hash": "68582f286b259f1465d003025ccf15203529fec34ab127baae43194624e6d055",
+      "size": 7239
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020007.json",
+      "hash": "d61bb7c2ec58c012b986d0340b2cb658f930bbdf81231fe4379f26c19636867f",
+      "size": 6389
+    },
+    {
+      "path": "assets/story/data/09/0020/storytimeline_090020008.json",
+      "hash": "5c55646ce261f45381b220b7d7e3fa68b207c5f717e0339fd1a5024dbb7bc47a",
+      "size": 7356
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022001.json",
+      "hash": "4144f5db47b79663e788c64fb53dc7ee442989987dabf394f61e6b0c0a76f690",
+      "size": 8513
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022002.json",
+      "hash": "c50a129680de40855ae2eb4e9244321169a7a47840e57dc73fe10c2823db5454",
+      "size": 5844
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022003.json",
+      "hash": "8cf843d9f77bcb1a56e76e9cdeaa5dbc785f6ae38dddee09e07a0ae9e4192dee",
+      "size": 8378
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022004.json",
+      "hash": "1e6bf5a121e0e9ff2024b1726bbdd3f5f65c73af1131b1dd7784aec11ba47b7b",
+      "size": 4900
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022005.json",
+      "hash": "8d646e2ac9b2ea1ca78748e9fad124e892665b58fd47cfd38e66839f82906214",
+      "size": 7929
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022006.json",
+      "hash": "41b8c02316f8c9fd4bc20a28636ac91441192ce72762a0b6ba908213571918e1",
+      "size": 8275
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022007.json",
+      "hash": "952db26c0c4e9dbee9eade982ac4b175c79ca2372a11ed12c3c5307b6be3105c",
+      "size": 8552
+    },
+    {
+      "path": "assets/story/data/09/0022/storytimeline_090022008.json",
+      "hash": "777452afdb3f8ed51b0b8c8b599ccdf079dee76352b6133d39f1f8dded69789b",
+      "size": 4706
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023001.json",
+      "hash": "db30b6065c87aac3abec3e694e14c55d416b9ae774df649ae65ae22585772d7c",
+      "size": 5611
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023002.json",
+      "hash": "aeab10a97a2c223e426b1217ce4f75a63eacfbf16b939558df1dca44405ef502",
+      "size": 7239
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023003.json",
+      "hash": "935abbf9cee00c9ded00fb441a5bda9676f4834cc43b7507f11b936d941cd85f",
+      "size": 9250
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023004.json",
+      "hash": "29b404e42505686b0c97943def6af5a72f632d582f8f57e3b754cde7ea73d723",
+      "size": 7037
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023005.json",
+      "hash": "cb2d4d5d3f25361e0a77d81484f923a0f3fc0cfa7a9fb7f309f5b9f2900a92c7",
+      "size": 8312
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023006.json",
+      "hash": "4b694ab88c6088a295fa1777746da19be6478e286f40415850e544d572a429e7",
+      "size": 9482
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023007.json",
+      "hash": "75237b804477c1be129e7c277bba5c98b6a5738fdc1afe9a9f4725bdcff6d94c",
+      "size": 7486
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023008.json",
+      "hash": "4b8bb1eef32eea23a79635c5b56d72c053bf47884eacf7cddf8dbbaba63edbae",
+      "size": 8453
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023009.json",
+      "hash": "c27c6142a0eacd0d85d76eaed537577772a90bbb360cf6421b898ef498841fc1",
+      "size": 9648
+    },
+    {
+      "path": "assets/story/data/09/0023/storytimeline_090023010.json",
+      "hash": "3bcf6832bca12b41a8a5bfc854bf11b10e25ff0b12c26a9f3b8517c735b152b6",
+      "size": 7519
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029001.json",
+      "hash": "43ce8827aabb7b0be19977cd50881435612836d0155bc693eee46fdfd0e6bf7e",
+      "size": 8375
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029002.json",
+      "hash": "19f834a112c666e15634ffcc5a93552a77680b496786d445ae7863bccfbdf55a",
+      "size": 7456
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029003.json",
+      "hash": "0ee09770598f14e83ace5ffbc720b63b1b0bb227b91cb441fc8f5da9c4e17eb7",
+      "size": 9135
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029004.json",
+      "hash": "6807d733b5656de7a218cc70d8066a65e9ba26c51213366cf8dbc64388cbf169",
+      "size": 9572
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029005.json",
+      "hash": "042821578dfeb997e25c8903fa72104ccd08b23973b8e5c9dd9a45f5c95068f5",
+      "size": 9306
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029006.json",
+      "hash": "b6355f13353ce6f0d2ed6215e3616af7f3a3f04abc5da4570ba14b838a6b0a3b",
+      "size": 8486
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029007.json",
+      "hash": "91bdec7c7b2ef133be1c75882425426ef59b9096eefdc0ecb214f6e77d7ac7d3",
+      "size": 8191
+    },
+    {
+      "path": "assets/story/data/09/0029/storytimeline_090029008.json",
+      "hash": "4fbe51b2302ed1118fd61a1bbb106df6e72f51e3d7654b346581f39ca8be862f",
+      "size": 7657
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030001.json",
+      "hash": "83331546f509d0de9573fb599ecc9fc1d40e931ce1ceb28b40c88e2a10c1d572",
+      "size": 8557
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030002.json",
+      "hash": "5d2d6f3b2123ede9cff39eba2f2a2b67da4140ec0488a695c7b111041ff5c2c1",
+      "size": 11559
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030003.json",
+      "hash": "9427c9d4dcd503c3ac19954eedc67322b60eeba54c932bddfe827df7c937c5f5",
+      "size": 6635
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030004.json",
+      "hash": "28a68db6d5a6d360fb0b9f5b5114ee73765750a32d3ad631906e36b731505b26",
+      "size": 7675
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030005.json",
+      "hash": "1c62efd007049e969040b7e1a6569348e35481525fb8aad1a83c778ed2f6bd6b",
+      "size": 8020
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030006.json",
+      "hash": "237a1ba9de2340e1ddd943445842f9e090730cabce453606d6c0980bd41fbec9",
+      "size": 10067
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030007.json",
+      "hash": "f0fa3563eb7b8e814ba24daf84b146eec07ecbee2f3bcd3a087af7d6a94452d3",
+      "size": 6808
+    },
+    {
+      "path": "assets/story/data/09/0030/storytimeline_090030008.json",
+      "hash": "6669fb0314be0bc2158625cb25878e1bb48a7415a0687fb3ecf3d07aa53ccac4",
+      "size": 11065
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034001.json",
+      "hash": "cfc7a6a2216b5244a68e1cd845b4a6bd079ff4605e0ec78151981fcef48a81d2",
+      "size": 6906
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034002.json",
+      "hash": "cc3d3c57dc586911f8b7c5b8519ec95ba9fb260326043d614d8ab103bf9e6451",
+      "size": 9274
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034003.json",
+      "hash": "1a6042f75aa1eac6e236bcea11544f663d313506f22babae6beb5a086ebc61ad",
+      "size": 8568
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034004.json",
+      "hash": "2c5016753e526ab330e70c4704aa6719f257531b0444f120079ba5f828ed79a2",
+      "size": 8313
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034005.json",
+      "hash": "5a6f04e5884b0c9df5a55e07c9596edfbe04696532b67707118022ab3961a3d9",
+      "size": 6833
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034006.json",
+      "hash": "4b34926d385b83dab04ebb6d63443c63ad50f19335514f49638258594c3334a3",
+      "size": 6320
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034008.json",
+      "hash": "84fadebdd29abf50e4591f75344aa1cf0852547b707a950283eca7b35bc31d1a",
+      "size": 5197
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034071.json",
+      "hash": "5825e5baa1b7323b46c7dfad19af703f1e788694bbe716aa6f743ae644a9b6e7",
+      "size": 2606
+    },
+    {
+      "path": "assets/story/data/09/0034/storytimeline_090034073.json",
+      "hash": "c37b8da9f670f2d380d17fb06a9e1d723bdd2b0e1e313c81551535863d39d171",
+      "size": 3402
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035001.json",
+      "hash": "ace50dc7e623463ca91fcb36b5da8cc1186e7b39da82a0d68a77cab21f191a90",
+      "size": 9582
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035002.json",
+      "hash": "5d35f1e6178b4e663fc744dece2373bcc08fc84541be81c04510144c8d6db313",
+      "size": 10465
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035003.json",
+      "hash": "6c199dd3477c34362b92f3c31a38a4e781daec5dcdc2d32729210e4f00546270",
+      "size": 6420
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035004.json",
+      "hash": "ed22122d1d6a80368e8d0edc934c051b56837ae109a33bd598fc3ec2dc271038",
+      "size": 10198
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035005.json",
+      "hash": "173f1e2d7ab4daa3c70384e68550f765223b4e85570442d56436142540aa35e4",
+      "size": 6872
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035006.json",
+      "hash": "b65c695c9f2a1ae1ab46d37b04f225d10eb2f7e7c387f6ce6ab911c992641429",
+      "size": 8051
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035007.json",
+      "hash": "b3bbd41c585aabf7e7106f52d4b3d6a8a2181a2069a58d4fd68ee9b1172cab5a",
+      "size": 8624
+    },
+    {
+      "path": "assets/story/data/09/0035/storytimeline_090035008.json",
+      "hash": "c321c79f69c6bbf34f60625414d1cb3ef7657b99ebf6eadbad512f6ce8fdf7b7",
+      "size": 10399
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038001.json",
+      "hash": "214ef16f22664c504709fd4027ca2e45d694ae3e235cf68941f3c729fce9f2c8",
+      "size": 8252
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038002.json",
+      "hash": "69feff29875ac91fe974f153c0c36c4df2038f2cea62d622d060d5ef889b703d",
+      "size": 5717
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038003.json",
+      "hash": "b64f5c1da1ef6d29b3fcba2be8e6560e7a6fb69d5ee7997a260c6ccb9bcd198a",
+      "size": 5922
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038004.json",
+      "hash": "8520862a833b28eb4ffb4052a873414e04ccfccba78dba722ffb39f17f42c9a8",
+      "size": 10288
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038005.json",
+      "hash": "5f8352a7882d570f920e20687060e98912349783c0e61087a6ac646c20d6071b",
+      "size": 12399
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038006.json",
+      "hash": "f9998cf4eff3a9e55517695d292098e89e8f53fe3bff3cfbcae8e62e8c82f5b6",
+      "size": 7705
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038007.json",
+      "hash": "d022fb9fb62577c1cd5a0ef31aabff29c16be8cc8cc227d24c50a86627f78920",
+      "size": 7625
+    },
+    {
+      "path": "assets/story/data/09/0038/storytimeline_090038008.json",
+      "hash": "ec7df11551f3d664c7f59e8ef6336b4a962cfc9731d21b8c86dbc743f7539355",
+      "size": 5320
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040001.json",
+      "hash": "e9b87baa2d76c08cc51d6f24f81c8b5086ea34528ad0767018544ef7d65c4e1e",
+      "size": 8579
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040002.json",
+      "hash": "aac6ee4f8415e102fdb4c351d464bfcd8de86d64b2771ca8aa193b6baa5bdf59",
+      "size": 6142
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040003.json",
+      "hash": "288fd1e2f89fe40f168104150e1d59bc2ee84eb4440e97712baa5a1d1e268ab9",
+      "size": 9662
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040004.json",
+      "hash": "847b3a2abb90275d7e5435dd7e82c1adaf6193504fc5bd51a74f805a19804802",
+      "size": 8133
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040005.json",
+      "hash": "204367c76df5e68678cd17e9206185bddc5ffb509b2261ae9fdbd4e8b7cd080e",
+      "size": 9233
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040006.json",
+      "hash": "de19409140308f31969c01d403a63373c28b158df3da64c0439de4e215771bf1",
+      "size": 8234
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040007.json",
+      "hash": "678405edacec9fa35961b3d43aaeb69497c6ac8b552020f733474dce8d007513",
+      "size": 9851
+    },
+    {
+      "path": "assets/story/data/09/0040/storytimeline_090040008.json",
+      "hash": "e9d85bc201abfc9d9962d43ff8551f4e188339a20f974e8316e9bcb92c93b008",
+      "size": 7407
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000001.json",
+      "hash": "20f721ad763b6af1ff66c28e73896502744306a9872fb4ab04a505275b62f9df",
+      "size": 2088
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000002.json",
+      "hash": "f137bbde26d5bdaeab1542517775a4e30a039c87ffaeb30e95c33d4abef36257",
+      "size": 1602
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000004.json",
+      "hash": "a4117f64e3660a22872d9a57a8063961ac3216203f52379ae6cfaba34dfe8424",
+      "size": 1653
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000005.json",
+      "hash": "ea3da625a67654ea952b3e693f9313c8c5428ee76feb000304cd58c922b50287",
+      "size": 1966
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000006.json",
+      "hash": "9d69e0986e1a0ea67a450c3e7cd44dc8fd510942b177a1953ce7ec16b0a2206d",
+      "size": 1812
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000007.json",
+      "hash": "167bff73cae1619891b5f8312e970d4cd0eae5d42fa506568c1bdf01b10731c9",
+      "size": 3436
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000008.json",
+      "hash": "7c478f5f0b40444663212f44e953178e6627e71a1caf1c669e5f43adc19d8517",
+      "size": 3274
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000010.json",
+      "hash": "cef74773014d029eef83bcf8279f26cb86e056502d025592f7489fcd4070bb3c",
+      "size": 2765
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000011.json",
+      "hash": "ebd61477210c8edee6765687a5e34249da4351c7fc820c031f2be35a14dfab8c",
+      "size": 2896
+    },
+    {
+      "path": "assets/story/data/10/0000/storytimeline_100000012.json",
+      "hash": "df7b946b585370b71d75cc4e4ec7330b4699f764ba24f8da811eb3efd0c89e1d",
+      "size": 3874
+    },
+    {
+      "path": "assets/story/data/10/0001/storytimeline_100001001.json",
+      "hash": "e0db88f496f46578d3c8f547331aba0de2110e6939062560e053c10def295ca0",
+      "size": 7818
+    },
+    {
+      "path": "assets/story/data/10/0001/storytimeline_100001002.json",
+      "hash": "f54c5b59fee5f5569753b5be65fadb3d6d8dab3a960e137aa0ef3f4ec010a732",
+      "size": 8131
+    },
+    {
+      "path": "assets/story/data/10/0001/storytimeline_100001003.json",
+      "hash": "b6d4fcdb5ca33d9c7fa84129bed3e93b19f344cbe444235b49e001a4e85bcacc",
+      "size": 7758
+    },
+    {
+      "path": "assets/story/data/10/0002/storytimeline_100002001.json",
+      "hash": "4ca680f9e00544e7a799c414f1b78a29445d3a841aad51b33d96aefed78f4445",
+      "size": 8732
+    },
+    {
+      "path": "assets/story/data/10/0002/storytimeline_100002002.json",
+      "hash": "0c10da5da29dc12de8c04aef825081fd4350447e6942ae5ba170a765fc719c75",
+      "size": 8283
+    },
+    {
+      "path": "assets/story/data/10/0002/storytimeline_100002003.json",
+      "hash": "25b53b219c976420886f3e0d4ac0fb44752ce64ffcd3ff3b4463940bd6e50976",
+      "size": 8627
+    },
+    {
+      "path": "assets/story/data/10/0003/storytimeline_100003001.json",
+      "hash": "9093b4938ef3458b1b56fba8cac142e47aaaf3c435ff701ffbaaed6494461661",
+      "size": 7853
+    },
+    {
+      "path": "assets/story/data/10/0003/storytimeline_100003002.json",
+      "hash": "6faa047cbf380dc7ed299c0986b12e0eb46a396bca87821e8552ec0558a4bc08",
+      "size": 9087
+    },
+    {
+      "path": "assets/story/data/10/0003/storytimeline_100003003.json",
+      "hash": "14e0b9ad42efa184dc8113ff1bd47ca687347037d411e996c937a4ef7a932809",
+      "size": 8129
+    },
+    {
+      "path": "assets/story/data/10/0004/storytimeline_100004001.json",
+      "hash": "4adaab95d630a65411244d2cc8a2ba870cd0655efec8a54df21b8c6e8b1f1500",
+      "size": 2551
+    },
+    {
+      "path": "assets/story/data/10/0004/storytimeline_100004002.json",
+      "hash": "43aba5f4553ea7fcfcf1108d46736a1a4fd73512dc1cab48a9e031b57d069f71",
+      "size": 2305
+    },
+    {
+      "path": "assets/story/data/10/0005/storytimeline_100005001.json",
+      "hash": "793ad0d44ca58bc1786f537c5b7ef6eb57ddd24129b4fe275580a330fa691c64",
+      "size": 8328
+    },
+    {
+      "path": "assets/story/data/10/0005/storytimeline_100005002.json",
+      "hash": "630da64128bb1222b63f719518d673e4f3db0fdad17ae519601af052d5da72fa",
+      "size": 8933
+    },
+    {
+      "path": "assets/story/data/10/0005/storytimeline_100005003.json",
+      "hash": "46991c6a3f45276195d2fbb8a6b19d0aa4b38ca7545e326aed456fb14317718d",
+      "size": 7980
+    },
+    {
+      "path": "assets/story/data/11/1004/storytimeline_111004001.json",
+      "hash": "42403f06b1e13bb561ab40ba856077df736c3ce9a8aa3393c923b1719dff3641",
+      "size": 283
+    },
+    {
+      "path": "assets/story/data/11/1004/storytimeline_111004002.json",
+      "hash": "21c9a8fd96f43ab8d92048bbb98d85dfa6191d1a297651a0d30e0b343a3ae142",
+      "size": 264
+    },
+    {
+      "path": "assets/story/data/11/1011/storytimeline_111011001.json",
+      "hash": "66292f9fef01d29b55cf16e33fe691972423e30027d2530a7f5658582c07ad90",
+      "size": 265
+    },
+    {
+      "path": "assets/story/data/11/1011/storytimeline_111011002.json",
+      "hash": "fe8d0f6afa4803beacf640b9b811f5cafd19c2a78ab4be81f563a06c981a2428",
+      "size": 269
+    },
+    {
+      "path": "assets/story/data/11/1018/storytimeline_111018001.json",
+      "hash": "6f4e2a1dfcf5485eca05bf162dc6005987f18fc2717c3c9d99d587b3e0b3765b",
+      "size": 254
+    },
+    {
+      "path": "assets/story/data/11/1018/storytimeline_111018002.json",
+      "hash": "ea770bc2ada484c2c9cd95bfe842c186fbb95777d44ea2000c1443cf8ad48ebb",
+      "size": 264
+    },
+    {
+      "path": "assets/story/data/11/1025/storytimeline_111025001.json",
+      "hash": "5e83b926c19a4dbc5241a73f43807adde56c855c67e98ed86090e9efcec4fda9",
+      "size": 301
+    },
+    {
+      "path": "assets/story/data/11/1026/storytimeline_111026001.json",
+      "hash": "2c8e9d5ca50d59c5fcf539961c37de3f204648933ed61f2116e603acf8f8d6b3",
+      "size": 233
+    },
+    {
+      "path": "assets/story/data/11/1026/storytimeline_111026002.json",
+      "hash": "cd46a49737f6a490a047c4102bad24eb61b9a87adaaccfafd73875f15ad78726",
+      "size": 301
+    },
+    {
+      "path": "assets/story/data/11/1032/storytimeline_111032001.json",
+      "hash": "7706085d99fef6cf1be512172c57278ef3309615b398c3dba3f61b905dbaf709",
+      "size": 261
+    },
+    {
+      "path": "assets/story/data/11/1034/storytimeline_111034001.json",
+      "hash": "0ddc9fe0d445270357a39a6186702b61195127c206e97ab63c2ae9a7722c73c7",
+      "size": 215
+    },
+    {
+      "path": "assets/story/data/11/1034/storytimeline_111034002.json",
+      "hash": "21e695d6909c522a937622aded522e7bba575dfde8753295ddab53391e15d2dd",
+      "size": 223
+    },
+    {
+      "path": "assets/story/data/11/1041/storytimeline_111041001.json",
+      "hash": "06f43aff0361c78ed1139a7272c9b1c2b44e3f2ff0f43aac646fc02ff4d273c2",
+      "size": 319
+    },
+    {
+      "path": "assets/story/data/11/1060/storytimeline_111060001.json",
+      "hash": "a6d425a09bbaff58f7115eb6fd18f3f99c8d9c2e06bd617f25e4529588f63d26",
+      "size": 281
+    },
+    {
+      "path": "assets/story/data/11/1060/storytimeline_111060002.json",
+      "hash": "92ded4f3a6fc97df336b17866017bb7af37ab9a6499c85e0b5f590ab4189db01",
+      "size": 263
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251001.json",
+      "hash": "fb5562aa3d99f618cee75d768062ab8ed431be8d8eac5d15b6c8f8c4403ffe50",
+      "size": 397
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251002.json",
+      "hash": "d7c0756809a3aa74f7a9a649b10985a63226a65f78a64b53f6baa7667e829480",
+      "size": 756
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251003.json",
+      "hash": "ea2814fd47adfd15833f95c4eb802dab37dafe3265feb8671ec91de266161091",
+      "size": 647
+    },
+    {
+      "path": "assets/story/data/12/0251/storytimeline_120251004.json",
+      "hash": "7683bf86650b6418a81c08e71d3e91e1ef46265f3ce6e2853b9f9bf8a5cf3fcb",
+      "size": 580
+    },
+    {
+      "path": "assets/story/data/13/0001/storytimeline_130001001.json",
+      "hash": "da7875805c3dd2793888e901c51a7b717bfd92b13f884afb3937bee8155aeba9",
+      "size": 4035
+    },
+    {
+      "path": "assets/story/data/13/0001/storytimeline_130001002.json",
+      "hash": "a91ed18ddcfcac4808b1054aa2720889c525b37bb1496ab06c212cfc74b45b57",
+      "size": 3125
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000001.json",
+      "hash": "20ea1e4999ee57e20a7ccfdae6d33b5dbd5564bc3f07064697a808d2e6953184",
+      "size": 2572
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000005.json",
+      "hash": "56b8a1b6dbb5a550613f8cd7ad52b7adf440ed3b1b40e18f3fcbbff5d45a0565",
+      "size": 476
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000008.json",
+      "hash": "3cf313c1503d61cee5cbe668e743748c1555d60a685a52122b0b137f2cf2da0e",
+      "size": 383
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000009.json",
+      "hash": "ee7eb24bb855760deccac9c564ea21f30eedc568aea3a2bc895755cc8a47da54",
+      "size": 428
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000010.json",
+      "hash": "8dfbe16ba1a7aa300d109684133a07d66846a3513cf410ac170e410d7d22266b",
+      "size": 431
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000011.json",
+      "hash": "316052ae9fbaa9278b4442ad98c9dcf61ec39c38d725b18ca222feea99e7d5da",
+      "size": 458
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000012.json",
+      "hash": "362071e735b4e6214a41976bbb481383def5a938b477d94225353b227c44be1f",
+      "size": 448
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000031.json",
+      "hash": "7c2c2f047bb41b2bb510cac73329d5c3c997e799a99c46e5c1f821ae2ab0c573",
+      "size": 604
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000032.json",
+      "hash": "00b0a2a83ad477100a09050d2e9a3e1eca11272b452e0e773323c22876b62fe9",
+      "size": 510
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000033.json",
+      "hash": "152d5bb4cefe7b98a8f835d292c8ed53daa45593cc2ad37f246d3f5c90f83f38",
+      "size": 586
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000034.json",
+      "hash": "48446023665e2c54e851b25c963f9b343762b44058c7c6bbf39624e09da6a81e",
+      "size": 928
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000035.json",
+      "hash": "97a592c6f77027ae6d9c668dee90c1683de7e12ac7d9970067648bc2f541a20d",
+      "size": 649
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000036.json",
+      "hash": "d74ac28228c5917128e009a1b6b97cb209529647eb637dc291a777450d82b897",
+      "size": 3671
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000037.json",
+      "hash": "497c9fc751160a2a7999e283ebad63eacc1c757efe564512cf7cab6c317b3fd9",
+      "size": 257
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000038.json",
+      "hash": "c1ca24e4375878e7718b91d56b46f81faea003f994b7ef76c6651fc0dc868cba",
+      "size": 232
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000039.json",
+      "hash": "d903f4524fb8935ab675debd398280b11d775e851b3f5b93b63e25ffc8402234",
+      "size": 280
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000040.json",
+      "hash": "e297af8e0fb8c8934ff6f1ca82988a8f2a4e4985ca9f2c409c290925ba9b406a",
+      "size": 254
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000041.json",
+      "hash": "3e71f10ff459b500ea50b9e1d47f7ad0ac1e1bb2255062c8ca66457e9eadc2e6",
+      "size": 3221
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000042.json",
+      "hash": "9e9302e4a2610a3c7b4d03a1bda11164a349cbdd8067c3469dcc5b3efd5f9e5d",
+      "size": 336
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000043.json",
+      "hash": "a42223105f778d25c19f66d807f3dac1e88177df70856e4a4cf9c7720bb0c9fa",
+      "size": 960
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000044.json",
+      "hash": "b118f0776b37cd6d5b8b94be19ec2d8548eaabd1e37cbb616d262fc867f52b69",
+      "size": 922
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000045.json",
+      "hash": "f8603dbb9697394fc44ca02868f11dd3dcd0054619b9d98b2e84f96dc11d190f",
+      "size": 1112
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000090.json",
+      "hash": "a218a49810044d126b5ff7c98e77c36f09b6c8e1eda0cf4a23a346080ddf8f94",
+      "size": 336
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000091.json",
+      "hash": "a6572cb4307dc57fda61231fd0ed565cbecab0860713835343c84bdbee5a41e4",
+      "size": 8598
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000100.json",
+      "hash": "a412ecbe9e553613051d1becfb08407f06ef632cd3367838e4eddc3ef6b06e4a",
+      "size": 3200
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000101.json",
+      "hash": "fe33760b9c0f36291e3a778460c60c5ab180762f6eb70e5cc77016a9428185bb",
+      "size": 879
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000102.json",
+      "hash": "2742e8d3ceb2786515460fc881fdf7ee73084a5ec8a76cbb75768f9e87a841fa",
+      "size": 630
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000103.json",
+      "hash": "1369bf6748eaff338f021422893d463b6f2349f08f827196940688d1bf6ed056",
+      "size": 851
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000104.json",
+      "hash": "1349b206d806d68d4c60674efde3ad0af0ce67df0c5391e7c79ebb7c5240c699",
+      "size": 789
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000105.json",
+      "hash": "e414a24b7bdc10c4e84509c3c145aefb431dd55197477e7d1a6bf19453d13c04",
+      "size": 781
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000106.json",
+      "hash": "6faf5bfe5d579fb5ea8da92160e1e8527cac4d5677d4abe3c17b9d2d5abdc460",
+      "size": 806
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000107.json",
+      "hash": "4eb6c36e6f4835d62742c53510348d72d30d6d3f3e9e49232f1c5688d189b0ea",
+      "size": 1055
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000108.json",
+      "hash": "ce73ebcbad8ce7607aaddf9b00a03d368dfdeb38c6a6686a42caed0c2b3c8ea1",
+      "size": 948
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000109.json",
+      "hash": "03224d81f325945609460817d4ed793c20dfd62297ceead6eec419ebe39a3d88",
+      "size": 844
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000110.json",
+      "hash": "b63a175bc4295cb29ce466d6b7558e93099063991db12f95b3dcb4843281ce44",
+      "size": 1389
+    },
+    {
+      "path": "assets/story/data/40/0000/storytimeline_400000400.json",
+      "hash": "8b6a27765694c2290d33ee068d8b24251fb7ebc8aaf562371e13313312bb0968",
+      "size": 670
+    },
+    {
+      "path": "assets/story/data/40/0001/storytimeline_400001002.json",
+      "hash": "4a9082289cc4633b92747238adeeee72cb31c1167f7730ae990877f95b790d6a",
+      "size": 10582
+    },
+    {
+      "path": "assets/story/data/40/0004/storytimeline_400004249.json",
+      "hash": "6a7e0bea1a80eed6649f53241f5d31b7e8bff54d0db04af080d1b4e2c5e26d86",
+      "size": 2648
+    },
+    {
+      "path": "assets/story/data/50/1007/storytimeline_501007100.json",
+      "hash": "99c3b22995a1a946727a3e8db73b8f5999371c0548e7c3f6bc72074b462b7b0f",
+      "size": 4923
+    },
+    {
+      "path": "assets/story/data/50/1007/storytimeline_501007101.json",
+      "hash": "0788b54b71c8de135ebcf460c8eeb77601867357a196cd0455ce2f5d9dcda5cd",
+      "size": 4218
+    },
+    {
+      "path": "assets/story/data/50/1007/storytimeline_501007102.json",
+      "hash": "77be51d6d38af0a9262204a80a85eb5c9e88010bb035d7fdb765264329b014de",
+      "size": 4637
+    },
+    {
+      "path": "assets/story/data/50/1007/storytimeline_501007200.json",
+      "hash": "39e5a7e8b90e215f2383acbcf501e9e4538bde90f44a5e35fbd2c292de4d9e5d",
+      "size": 1970
+    },
+    {
+      "path": "assets/story/data/50/1007/storytimeline_501007201.json",
+      "hash": "fb1366b1262de50cf14bddbe83ecefaba25ce3b60271dc7b0257231e5861552c",
+      "size": 927
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041100.json",
+      "hash": "38aaf63376af6676e109b361b2ae086f8f9242f2258b829278dc85226fac5343",
+      "size": 11204
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041101.json",
+      "hash": "6d7a45e8c8841831f814da46fce636e0e5672af5ce2b372b3ffc5685bdd077d6",
+      "size": 7510
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041102.json",
+      "hash": "5fef6276dfc42dfa15048e03b33e85a9557b1af72f965dc46631d4db16220218",
+      "size": 6117
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041103.json",
+      "hash": "8afec29c2aaf9a8fe99e202c5cbb2cf39e4fe6d9ea2cceaaff9672be08da68a5",
+      "size": 3240
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041104.json",
+      "hash": "0af2fbbd0350395cc5b5f2c402881edc3b5e9fe5a58c4302ab76e34b331da389",
+      "size": 8321
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041105.json",
+      "hash": "437be2c9a1edfb42ea46cc74f2120da3c190e6e81f19c332a15d6552b7f137d3",
+      "size": 1041
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041107.json",
+      "hash": "302ab35c7ac37b0b8adc5d354b98efe5e4fcaa5fe43da86285f30518eaab3d5d",
+      "size": 7882
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041108.json",
+      "hash": "01ea312423dfd934ed3e9c8f2efa1be78975c6142df23a73adedcafbf3e84836",
+      "size": 8735
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041109.json",
+      "hash": "ee10ed807c97fde0ab6e65929dd3b925136aa75d0d91430f7a2a6a75b255eeb6",
+      "size": 11484
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041110.json",
+      "hash": "31eac39de39cabd8f67c3f7571f12fcf2310dcbfc94dbf1c0413dbc4f8fcc2fd",
+      "size": 3038
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041111.json",
+      "hash": "a164b94e0cfe268a5ed92f0e74e03258d3d2ac1ab40462896929d7d1571e2017",
+      "size": 6399
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041112.json",
+      "hash": "e0276516a284c157822cea93d3fcbc6dec90e65fd14692185d9f269001421944",
+      "size": 7503
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041113.json",
+      "hash": "66a2251c8142066ec0fb243f4ff852e8749af874f5b57b58a74d3377a6dc72cb",
+      "size": 8899
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041114.json",
+      "hash": "a7416c4e1b71b2374cba23ce063c2a1284b3be3caacd6f04679313ddf44e1183",
+      "size": 6512
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041115.json",
+      "hash": "cbd7c96d48ecf9170bac4b7de0afe4f49a28d354421ba5871fa6e670e11f0ab2",
+      "size": 8896
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041116.json",
+      "hash": "a8c41e5b12e370d50bf079be3d4b056e08950deba07da9da3629d73046c57cfb",
+      "size": 4132
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041117.json",
+      "hash": "c3caa3a3a2d84dfc12687557e06c08f096d20f36ac16208131c86ef37a80fdad",
+      "size": 8229
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041200.json",
+      "hash": "61775c78e5d713d17c55d719ff49fb9260279c491a1385b026c614c8716cbf13",
+      "size": 1425
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041201.json",
+      "hash": "ec1ecdfa73ee74a4912d4c3e7dff63d670f401fd5f37f9ef53823d594995285e",
+      "size": 1698
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041202.json",
+      "hash": "b5c891bf68e6ad0cbb3ce95d4c4b6d2ebf1936196db30f336c02810a5c31ee90",
+      "size": 1794
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041203.json",
+      "hash": "c64234cc53e68c4fdb2224277cf6dcefbcf2bf637f0059e6e9f7380b59401fba",
+      "size": 892
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041204.json",
+      "hash": "02237e2cfbd0d82065e2674eb0f8d95caddc026ac50466f441845ab9789f3649",
+      "size": 4340
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041205.json",
+      "hash": "056749537c030f02c34dd14268a59d152101573e5a74ac19434bc7e38a214a9f",
+      "size": 2672
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041206.json",
+      "hash": "c4236a0a8325ea3ad572814098868d5e932600e2ae80c4e3e8200873e9256190",
+      "size": 1041
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041207.json",
+      "hash": "85ec6d21d92b2c79f09de37ad665f25324325fecc1f8cb0c2d125568d8cf8eb7",
+      "size": 1228
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041208.json",
+      "hash": "3dafb1a826c4d66a9f0c38143c93372638ab49a8a01dbd67e6074e2b4047f629",
+      "size": 1417
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041209.json",
+      "hash": "4cf407a8ad07629809197b113a8ac1c10f801f2db961e395df9c06e5f6d91e7e",
+      "size": 3351
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041210.json",
+      "hash": "ca57cacdb54537ad875d6b454626e2a20031d425c976004d5af060e9b47b5680",
+      "size": 2206
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041300.json",
+      "hash": "3aa57f36c14db936284c82b4dda5538362a32deb40dae7d2fc4668a9a30273f6",
+      "size": 1735
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041301.json",
+      "hash": "4b5c59ba0bb57c99af8fe379bb7ac6f05e7f300361d3fdcf15c4ea696fd2894c",
+      "size": 2724
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041302.json",
+      "hash": "ff9a557d68e648d6ecbfd7379bf2c47f8a8580bb86cd958cf7f9472177007855",
+      "size": 14487
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041303.json",
+      "hash": "062250c8a46d5f656bd66bad2f9f874a72ddf1e7d0549e890220c9e0fa6461cf",
+      "size": 4027
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041304.json",
+      "hash": "c676fd23a1ebead047ec8d6094837cec71f88d52ce3d1e107433994b9f1ab165",
+      "size": 2455
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041305.json",
+      "hash": "9ec098e210793de6bf2597580a207b34e84d0181ed71802405e4e3e38c9015a2",
+      "size": 4025
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041306.json",
+      "hash": "73fcf304e60f4584eb06ac71f7c23a83159dc842a085f799a7adc81eb6363360",
+      "size": 5685
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041513.json",
+      "hash": "4ae6f01499d3a2624735beec6b9ae7e8708d994d796b42690eb850e90c724f80",
+      "size": 8901
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041514.json",
+      "hash": "e09d37b11eaa8eaede09c7b2a7c492c8650feca59b5be6ffdf0edd1d59f754be",
+      "size": 9654
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041515.json",
+      "hash": "3e402ef3dfd1a06085f320ce6d58b8df1d2572046940ef44da214eb1eae930d9",
+      "size": 9607
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041516.json",
+      "hash": "3bb9905c3ca0181507a1572622516b5367d4bca5546021be6eb4c3943bdb3dd8",
+      "size": 4514
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041517.json",
+      "hash": "e554261fa28867c2cae46c4daa7b2deacaacbface48034bf8801a7d432c39f27",
+      "size": 1446
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041518.json",
+      "hash": "3cc81d86e05f130d8fcce91d32b392aeb21586fd9ea457cfd19a963327f671e9",
+      "size": 1296
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041520.json",
+      "hash": "4a675ffae2c357753bd80b332e5264daedb2d25e876c7f7c558d5c3a4b588067",
+      "size": 10948
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041521.json",
+      "hash": "46d7e9915fb18eca96f52b88436115bd9582876bc0837a6e1b50415d597b4ade",
+      "size": 1037
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041522.json",
+      "hash": "083fac40b88dd0afb1eca24d47ffff2d9f274f6e948e5affd2627a7b560422c3",
+      "size": 1450
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041523.json",
+      "hash": "060c3d1207a87d99ed1a4cb9ef0cb7a6119d426feec8e2898192b80a52be9da6",
+      "size": 3815
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041524.json",
+      "hash": "10de0e9e27ebfc0ac02154df68309f85faa5b8f4b53997cf98418fd7d7ecd166",
+      "size": 5960
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041525.json",
+      "hash": "a19301e87efa9a6bed66ea4d5aedab1d830d174c2625a82d842e310db60e4906",
+      "size": 7694
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041600.json",
+      "hash": "4f3e40c54b32aa34fc9ff2a3988498013274519dfc2bbbfb3edb90c0c3ea7f4c",
+      "size": 997
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041601.json",
+      "hash": "19be25aa6b2bd3b690759a3d6944a3b67ab0fdbf2c9807dcdb53e5861bb63525",
+      "size": 866
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041700.json",
+      "hash": "5d21bacc367cf7c2741fd0b267a7b40c9688d491e50fdcbfa48ed375144e51dd",
+      "size": 1291
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041701.json",
+      "hash": "665464ca03673b43143327d5a5ba6e1cfd784c4caa75c9a7eb17026547785a39",
+      "size": 991
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041702.json",
+      "hash": "115d6b97f1ffa7d12147408a6280e7dee9ed0f417a47eaafdbe8c754eb882d72",
+      "size": 8527
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041703.json",
+      "hash": "8b2c4fbf61be474e8a8a5d390664de79a1d6c445c519884f9c3cc3921afe862d",
+      "size": 8670
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041704.json",
+      "hash": "20ab045c4db61a39318ca08057672f2dbfb8a59bc7ac84e5e60faa9db6f23b87",
+      "size": 14695
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041705.json",
+      "hash": "43d8f1a40d650538b621c6dc2eab7c327884369b6517284dee7a9d69ef4d24b6",
+      "size": 8285
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041706.json",
+      "hash": "91b34ba645738508a4c604224ffcd8e65d806d07375d111a78be35e4b3087960",
+      "size": 7412
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041707.json",
+      "hash": "62e2e7db40f450247d1cc57f50b9e61fb79a65bab5f0706d508f221646b6c554",
+      "size": 4685
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041708.json",
+      "hash": "a04b5b0f564b4a15548182d3bc98e2325571f3d236c6530069a7a4b4465c1213",
+      "size": 2232
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041709.json",
+      "hash": "5fe069a15af02c34cb6f4110b8af84f24d21ed6fa4b4ace4b7b684d9360b0475",
+      "size": 2318
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041710.json",
+      "hash": "0f77ac40e5d029445c72b5625bc1e1b4b0a44fa552a006d572f18e34213916d9",
+      "size": 2393
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041711.json",
+      "hash": "574d5c6d4f018bf0a6ac19e0ab5c685ca188ab32d478d43bf8259c272057372b",
+      "size": 3091
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041712.json",
+      "hash": "6edcf7c36794c26a02f6fac04b5e5e3d185139c4f63a76cce8a8bbdb3cc76d25",
+      "size": 1854
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041713.json",
+      "hash": "923df845537be621d68f3644befb63ce3884575db4c7950e09e3b26bbe3e80fc",
+      "size": 3485
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041714.json",
+      "hash": "8c7527842dd04ca859ad962fa8327be83e0de92dde7a13ce44bba05ac16df0e0",
+      "size": 5413
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041715.json",
+      "hash": "6908675c5420f09a3bb791eb2a8ea4bb08da8506a1c786ec35db12f01efede0d",
+      "size": 2299
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041716.json",
+      "hash": "4c61f58568d6049c14db4ecc0fa90bcf80b46fc693499f57133d4aafab70e8f2",
+      "size": 2579
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041717.json",
+      "hash": "2fe2a2ca00486dbf2f54c656360d2ef8680bf7c44aa6a5ecf04106ca3b779796",
+      "size": 3673
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041718.json",
+      "hash": "af39175ea496c53fbea5e05ddc8f81779ba3a350557bb3ddd637d679f2823832",
+      "size": 812
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041719.json",
+      "hash": "aa7fe6dd9232f902637f1394ade3a2e06cae9f0df310790ca5c23190800481f2",
+      "size": 1192
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041720.json",
+      "hash": "e1a70a5bee51b8fa583568db1ece3628004ad84e907630c554dbaf34c1654cf8",
+      "size": 18789
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041722.json",
+      "hash": "0eaca813037509f787cf1b3e8aeebc332a25c140d612cedfa50f15cd1607b208",
+      "size": 1617
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041726.json",
+      "hash": "a6f8313cbe191bdecd4e4ffe766010f440a1713f03ad4b79c4a34060aa7b4d90",
+      "size": 1878
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041727.json",
+      "hash": "ad756921ea21e2ae7022184b38ca75b50e43d51f0ddca16367c6c1974190c4d8",
+      "size": 921
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041728.json",
+      "hash": "b39ebea6d32129f8f0f078a7e37ea50b927b47e69e1cda63fed5e363e4d63c0d",
+      "size": 674
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041729.json",
+      "hash": "cae3123bca3054122ef12ab1e344e9017f4373197f8b90f9048bfd404f0ddcd6",
+      "size": 842
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041730.json",
+      "hash": "ad756921ea21e2ae7022184b38ca75b50e43d51f0ddca16367c6c1974190c4d8",
+      "size": 921
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041731.json",
+      "hash": "b39ebea6d32129f8f0f078a7e37ea50b927b47e69e1cda63fed5e363e4d63c0d",
+      "size": 674
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041732.json",
+      "hash": "0ac70c7c941e421152da5ba33f2a094c60ad1deaba9e1377520f81a364342a6b",
+      "size": 590
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041733.json",
+      "hash": "75cfde9ed155e1b4e696f6c2be46dc77434098259fcda4b03ae2d20630141238",
+      "size": 443
+    },
+    {
+      "path": "assets/story/data/50/1041/storytimeline_501041900.json",
+      "hash": "a7ed18f64bda3d03365324e67a81a0a4b4a0e95927e0d168da7ce96afe217a7f",
+      "size": 1122
+    },
+    {
+      "path": "assets/story/data/50/1052/storytimeline_501052100.json",
+      "hash": "00094dc16a7304135ecb690f512e6c235e3f744091676d02e3fb231e532bfbbf",
+      "size": 5974
+    },
+    {
+      "path": "assets/story/data/50/1052/storytimeline_501052103.json",
+      "hash": "c4c97759cf624c47c2522514c79301c29f9c06f62b265ff952b0909a424a99cb",
+      "size": 779
+    },
+    {
+      "path": "assets/story/data/50/1052/storytimeline_501052200.json",
+      "hash": "43fb0447b34ae89a5c51d6f63e5d59a9e0dbfdf3119e6f2b29787d31e30ae6d6",
+      "size": 1677
+    },
+    {
+      "path": "assets/story/data/80/1008/storytimeline_801008001.json",
+      "hash": "d19abda154e56347b898ce3f4bb461e0bbaf0723986ef9d0767891874c3599d4",
+      "size": 2886
+    },
+    {
+      "path": "assets/story/data/80/1008/storytimeline_801008002.json",
+      "hash": "68b4a254c851b9cc2854268cebf44e80698d2baaae2ec02f24c60598fa7b3a36",
+      "size": 2044
+    },
+    {
+      "path": "assets/story/data/80/1008/storytimeline_801008003.json",
+      "hash": "5965eb2d27dc2fe4d381a2c5e4aabde1e3c9115739e8199922fde11d4d22a42d",
+      "size": 146
+    },
+    {
+      "path": "assets/story/data/82/0039/storytimeline_820039001.json",
+      "hash": "50b72e0388a41ac3b937e0a9b14dce25f638366240e0e704229230d90a753993",
+      "size": 7458
+    },
+    {
+      "path": "assets/story/data/82/0039/storytimeline_820039002.json",
+      "hash": "ccec5d724eddc826dc996a83801b808018182d162d8414fc4f3ea9b9d8f06c9c",
+      "size": 3708
+    },
+    {
+      "path": "assets/story/data/83/0005/storytimeline_830005001.json",
+      "hash": "b0492960a0fd65764289010b8c6ec9212bc66f6835ddd9f9a80b1f6f61ede7c8",
+      "size": 2938
+    },
+    {
+      "path": "assets/story/data/83/0005/storytimeline_830005002.json",
+      "hash": "487c38f9d79324f432da03671268354c129454176e5db8c4c8fa94e76333b9f6",
+      "size": 3427
+    },
+    {
+      "path": "assets/story/data/83/0005/storytimeline_830005003.json",
+      "hash": "b4fb0741feabc4daf82997dabcb16f9e42418a85649b23d6f2d97862259390b6",
+      "size": 4142
+    },
+    {
+      "path": "assets/textures/chara/_chr/petit/petit_chr_0070.diff.png",
+      "hash": "8ceea30c07c495e4064ac06689472df14d3b47772dd76773f1807e40ed522487",
+      "size": 16858
+    },
+    {
+      "path": "assets/textures/chara/_chr/petit/petit_chr_0071.diff.png",
+      "hash": "305fc0f664f66808c06ec4c656fcd6c4934f2dd5a6ffadb7dd83ef131983371a",
+      "size": 17739
+    },
+    {
+      "path": "assets/textures/chara/chr1009/petit/petit_chr_1009_000101_0070.diff.png",
+      "hash": "cb7336cc85dedb47738cd0b1598d33c73f244f3a0e4513c2b5686ac7527174ae",
+      "size": 15841
+    },
+    {
+      "path": "assets/textures/chara/chr1009/petit/petit_chr_1009_100901_0070.diff.png",
+      "hash": "8ab24190c52452007c9172b2aa7d0e57ea5e18d8c043fcbddc8ce88f7f7163db",
+      "size": 15835
+    },
+    {
+      "path": "assets/textures/chara/chr1012/petit/petit_chr_1012_101201_0071.diff.png",
+      "hash": "842072117ec64dd4296a186a0c6f96618738af155d2fd1712b1e03dcdf641da4",
+      "size": 15445
+    },
+    {
+      "path": "assets/textures/chara/chr1023/petit/petit_chr_1023_102301_0071.diff.png",
+      "hash": "8be7604c3524412baa472057262d2399671e94e700cab830e97865956998c527",
+      "size": 15281
+    },
+    {
+      "path": "assets/textures/chara/chr1023/petit/petit_chr_1023_102346_0071.diff.png",
+      "hash": "d4c61eb65da6d63c34829a1d770192d6276330948c57bb0edf2b67ff10795cd1",
+      "size": 15324
+    },
+    {
+      "path": "assets/textures/chara/chr1044/petit/petit_chr_1044_104401_0071.diff.png",
+      "hash": "d7858a346d27cf3caf81771a38d8edf3fa0d2e738d441f8ff826fe97d2fd28a9",
+      "size": 15451
+    },
+    {
+      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_000101_0070.diff.png",
+      "hash": "46a978dec2e08b6f8cf68c0e89765298b62c4d587eed1394081c794b1e8283ef",
+      "size": 15858
+    },
+    {
+      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_000101_0071.diff.png",
+      "hash": "f7f8decdd6c0e4e0508d5def74624d99a7f9c90868608fc37fcffc58cec994ed",
+      "size": 15320
+    },
+    {
+      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_106601_0070.diff.png",
+      "hash": "295a5acbc3516b63b9af9e06eaf4ac0c13ffb81537a687cc1b95f5222c760423",
+      "size": 15854
+    },
+    {
+      "path": "assets/textures/chara/chr1066/petit/petit_chr_1066_106601_0071.diff.png",
+      "hash": "6ed8efa43178e19aed10fce3f82a557a3f20c251b533e82d003f162b0fb2c06f",
+      "size": 15341
+    },
+    {
+      "path": "assets/textures/chara/chr1091/petit/petit_chr_1091_109101_0070.diff.png",
+      "hash": "03366514c3237df7638a54bdd2eb814f81851b777f809875a421e2e317833578",
+      "size": 16910
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1001_01.png",
+      "hash": "fb7785191f4a00201bcdd3746be9083386440c15c8eb6b89c37f42a487beb504",
+      "size": 250439
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1002_01.png",
+      "hash": "f24df3cf15d1e158c43c0e08588b0cf5330e43240bf4f35187a8e7318f39bcef",
+      "size": 230088
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1003_01.png",
+      "hash": "b2a1b57d9ccca21f2f25784bb0c3eff2ae8ddf10f9ef8698b341b5658afe0ec9",
+      "size": 178401
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1004_01.png",
+      "hash": "5e931edcae295b31ed0ced299082becbe8ff913b3ff51d52d5fe3e235d71f7b1",
+      "size": 214358
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1005_01.png",
+      "hash": "b42b97fd93233bbfdd660a36113f4e53ab637fe27d26c60a8d5cec8200970a16",
+      "size": 210185
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1006_01.png",
+      "hash": "c78b0df62f9c8cb0469418ff64f5f4c60b7e9f0bdcc48ee2998b53dd4d820186",
+      "size": 209188
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1007_01.png",
+      "hash": "259e585d46d48999aecf0221bacc8ed1a99450eb78a6a656bd5376bfe0cdea5f",
+      "size": 210579
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1008_01.png",
+      "hash": "f6750c1f950b666bc7dd7a6922c274f996649a4789639eacf187b07ff61a1911",
+      "size": 140619
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1009_01.png",
+      "hash": "856cfd6cd82f0dd4dce0cdf8b2d396712393f1f6ed9778c30ab9c2303fc58913",
+      "size": 246510
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1010_01.png",
+      "hash": "f8cfec84252945e84208756d926e8ee02e352310fe73b2738414319d3aefd4bb",
+      "size": 235057
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1011_01.png",
+      "hash": "c575e8bf0539d06b925ff7c2cfcb82940eec3f8f585525c11f1e95414197bea9",
+      "size": 247475
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1012_01.png",
+      "hash": "3fac73fd1bb48de92af14a2e7719ea78eadb5d379e72a2e3f7065717b87b5126",
+      "size": 233917
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1013_01.png",
+      "hash": "65fa445b50b7d3ae6e170c071c4fbb8b73c406174a190621b9748c0ab6fd7481",
+      "size": 245809
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1014_01.png",
+      "hash": "f540f2a5901c8f5317d67df958e0f46f72c4d0776174b73f2de6ef2e00d83f7f",
+      "size": 251602
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1015_01.png",
+      "hash": "ac6c32b89f45a32e5b8892618bb49ff4400a81ce8ec44f57f86f9c7417c16b2b",
+      "size": 242190
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1016_01.png",
+      "hash": "262e5c5b1ff5e7e2246c8e3effd097036cd2e0e7445d69b0b17041ecb949ac1e",
+      "size": 182019
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1017_01.png",
+      "hash": "5b5200a95fd01308b76bb33f6ba0bfafbed70b329f2050cf90452d6e9c8afe78",
+      "size": 268124
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1018_01.png",
+      "hash": "5818db7c3d5ea800e2e92d325ec0b629781827134f9c4a221b5dc39931cfb000",
+      "size": 205286
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1019_01.png",
+      "hash": "e4ed3140eb330b64574a67607c31030735453143fd476eb53f4a3c2a0c2cdc6a",
+      "size": 254396
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1020_01.png",
+      "hash": "78447697f25ee3c08a70640b092f32177bf73724bcde661ac646c0d09e56ba7f",
+      "size": 191505
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1021_01.png",
+      "hash": "7a6aa44383bd3fafb88981ce3b337537dc9cada027c83fcf92014e2568056296",
+      "size": 215916
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1022_01.png",
+      "hash": "487a4774bdebde2bdc15578df3c019c8a9fd0eca25aa0f5c41731e756f76ba08",
+      "size": 200733
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1023_01.png",
+      "hash": "def76d2b8be1735988f355e3578d3c01485c3cea6e1d7fd5ccb850f4a31eb542",
+      "size": 249439
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1024_01.png",
+      "hash": "7ebc44ccd6405ae44d1fb70c64d689a9be150f6db46638c7e35d1e996a15676b",
+      "size": 254725
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1025_01.png",
+      "hash": "6a49610ec8c680d93a708d0a164d67006cd13f0a3d14ec980a08459008da4d63",
+      "size": 231569
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1026_01.png",
+      "hash": "97cf1fc35d5ce1dd73c8ebf8f8d6a95366dd57db4c4b5595e95f9468e86e50f4",
+      "size": 203056
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1027_01.png",
+      "hash": "6332ad231a287648a18746daffc27e0d81af6e38b7f533675d5353e3224786bc",
+      "size": 226464
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1028_01.png",
+      "hash": "0687783b36bc5c8d58867d03e7e0c660ab4625b32cb7066332bb9acd51c2950d",
+      "size": 253928
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1029_01.png",
+      "hash": "487bbd1d8b4c9a52a3f52f26dbb39d10552eb71df14f437f1724c5763b735940",
+      "size": 212270
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1030_01.png",
+      "hash": "f8867da0d92025688884f2ce2caba171245d8fce0433843b26726f5126cc97e2",
+      "size": 228234
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1031_01.png",
+      "hash": "156e27047eff5f3e01b5e3999fbf533be12cabc10485b3cbeb68a06807cd66bf",
+      "size": 188245
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1032_01.png",
+      "hash": "645cead3f58b83edc16625000fe28fa7bf3c5e8d50e0764f3e74c226ac70375b",
+      "size": 271508
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1033_01.png",
+      "hash": "adc8db9d76822087c56041ee9736032a525af30a09661e2c501997cdadc72a6f",
+      "size": 239514
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1034_01.png",
+      "hash": "33a4ee14f0590e045690bffbf9c8fc3a0e837b825ea56f8f4b26296f40a6ef4f",
+      "size": 177877
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1035_01.png",
+      "hash": "40f24f9ca33eb54a87b95879758d92b2841d07845b89e0d5383f53bfc7873f5c",
+      "size": 242820
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1036_01.png",
+      "hash": "6f68dfa42b161409aaa91656b40615a3d7569defb91242f5941eed146212db0c",
+      "size": 197386
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1037_01.png",
+      "hash": "9724800d8cf03c00a746f349afd08d64323889950fd0021a7ed78ca732b2f078",
+      "size": 179650
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1038_01.png",
+      "hash": "13f6fd787419453d23cdd421e1db22e42f92a10c0e16d4fe6033fc290661338f",
+      "size": 181195
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1039_01.png",
+      "hash": "b68729a12bb1c267c7ea137e992415afd4093ea18e03d2f59e600c63be50d02b",
+      "size": 226029
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1040_01.png",
+      "hash": "394e0b43bba17cc4b781ed92ba5b84d210a54fd57fbbded23865859de843dd28",
+      "size": 207525
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1041_01.png",
+      "hash": "77a754d5c01fe98d6f7a17d96be8b44e976c944c797996d3c9d03647ce414f8c",
+      "size": 218829
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1042_01.png",
+      "hash": "0e5f984d675f52f8232aeeb7e4a521d8d70bdd1f33ace76bc0ebffa6f9e3619d",
+      "size": 265826
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1043_01.png",
+      "hash": "a2fbc878f4561b09df21f4b631ac2b503efda3d91b66d02aa5adf2251ef6334d",
+      "size": 240390
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1044_01.png",
+      "hash": "5553559a1960ad4586db0158dab1fae6dbc91c6603e17aff459a61711d0b7ed0",
+      "size": 245518
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1045_01.png",
+      "hash": "c69cbf659cbec45d6b3a802073a7d3413f28aaac22681b30e2561deba582dba3",
+      "size": 230623
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1046_01.png",
+      "hash": "d971b77a6e644697ef3fa45893b41fad04edc15c02512a98745c40125bf18124",
+      "size": 234343
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1047_01.png",
+      "hash": "992cfb6afc613e6cfe8bda78520e8686f83c8269446ab5ad4f597eb0354e9a23",
+      "size": 226442
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1048_01.png",
+      "hash": "d041183d2b281bf8b63401f3afe1af728f90af1286dfcbb4c1b2214b77f6a552",
+      "size": 219581
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1049_01.png",
+      "hash": "148bdab6b277376344494dbbbc7f32eca516229601a4d234ef645977bf77816c",
+      "size": 234651
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1050_01.png",
+      "hash": "7856cd3b289979e187fa7affe31678f5e8a4127552b2062a1a4f5521a3d02835",
+      "size": 225439
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1051_01.png",
+      "hash": "998dedd3b727b94059efc2307ed049783fceb6b25cb6af9ae8f229fa842821f8",
+      "size": 240609
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1052_01.png",
+      "hash": "cf859f1044e3550b5ff2f6c95435e7bad2c218671eda86039e01a8fbb16af549",
+      "size": 163016
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1053_01.png",
+      "hash": "ad41234b4b92c3abaf6241eed6610cbbeb5bd04a0993054575e05a8dd6772782",
+      "size": 232143
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1054_01.png",
+      "hash": "1385d02994c06a11b200cfe6d2a76c581effc89bfef67aa5d2eacdd586fa0cbf",
+      "size": 240189
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1055_01.png",
+      "hash": "df4249ecda6c78f886714ea4b1361dfc431dec62a53e570a8fefeb8ef5c2425c",
+      "size": 251207
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1056_01.png",
+      "hash": "f0b417230ef236975f3a1cb6a4362a30b0375bab56756b069bb7779cb9547149",
+      "size": 205377
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1057_01.png",
+      "hash": "893d7940d83806af54a7ba2728e0a3271123bc1942f8da96f8a651b8f2d9c30a",
+      "size": 167133
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1058_01.png",
+      "hash": "215c14feff4960d7777440aeb892005393e8181a52eadb8b4745f79099547b69",
+      "size": 217361
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1059_01.png",
+      "hash": "5fc32886a27f482269af8ffe6e778ad7e21243152ce86fa1718f560662a2e6c7",
+      "size": 232878
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1060_01.png",
+      "hash": "b20308d61c27b3d0516e35c4ce688014767fe44798eb616fefa58a8ed20116c4",
+      "size": 189207
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1061_01.png",
+      "hash": "27ad230a348e59069bc47671681b03680c8af7a5a7f3b407ee0e18afeb7562d0",
+      "size": 194903
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1062_01.png",
+      "hash": "3253ca3903d510ee79f1b44f952b14f759d5d861f632596a6326a3d9afb90302",
+      "size": 194080
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1063_01.png",
+      "hash": "3cc324c6b31ddb32dc1a28ac21db9873ae4ef838c983c47921d96925120472df",
+      "size": 217899
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1064_01.png",
+      "hash": "a55d5939f24e5083bd548e5247097b8a72e3a6165c8b9459036dde49439c8a85",
+      "size": 242227
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1065_01.png",
+      "hash": "89ef932aa6e8844d60b09d48e04063c8d4772c8ed7b544260efc9f12ffa84175",
+      "size": 244634
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1066_01.png",
+      "hash": "117f43715705b21a3c177553250324f7aebeaa9de1cb39c71374f29aa925ee78",
+      "size": 188619
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1067_01.png",
+      "hash": "0f86f1a7606bfeca5d13b55729e22bc357e9d1808046121b451de17ba07a581d",
+      "size": 231003
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1068_01.png",
+      "hash": "19e7e9611da5332cf5658cabeeb12672066310340125f1ea4ff32f3795cea609",
+      "size": 227495
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1069_01.png",
+      "hash": "d75e7d2ede6fc523e24b3960a379cac263192eca53ebb8461e412c06b8661cb6",
+      "size": 255063
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1070_01.png",
+      "hash": "da4ccf580e191bc9cc0b97e848db997bb657466ebf9a1e81ca0b1e64f8cd60b7",
+      "size": 247590
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1071_01.png",
+      "hash": "60263cd223228d2f41b73bff21c67bba0c275a88be7cc563813d53c0a65f214d",
+      "size": 243487
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1072_01.png",
+      "hash": "77c12701ecc09e7a72b20956a7f7db7ed862f58f119cf6d5c390a8691651b666",
+      "size": 249726
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1073_01.png",
+      "hash": "c92cf5918f354b030b1c5948f04a70717eceb9f9148d5983e0f6154005a07705",
+      "size": 187178
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1074_01.png",
+      "hash": "f88aa8c28a2685588ca694c38207caebb9c73bc21fe1bcf4f663f5c19a80cf18",
+      "size": 251295
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1075_01.png",
+      "hash": "67122a3edc586ba51981226910db4d28c5bad9659793f67873aea880dc5f1b15",
+      "size": 220218
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1076_01.png",
+      "hash": "d6a15ea66c221e0a6704382ea22b9a54f7481b8a6e1f0088f97b5604109e2179",
+      "size": 225527
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1077_01.png",
+      "hash": "28cab496164424f267bd56f8f6768b0682e634ade237f9518907cf86d71b8c61",
+      "size": 258676
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1078_01.png",
+      "hash": "384fb85b56d3c5ab4e07d4a8a29c80a98ae32eb7b44ccf15bbeb01e85fe7a323",
+      "size": 239901
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1080_01.png",
+      "hash": "1a4c0e9ce66a4b875b89db3535d97e96b9cbbd95f0e9724d527f05f0e182fd07",
+      "size": 181464
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1081_01.png",
+      "hash": "6fa11c0350790e29607715623b3df3988d3b544f2107eada6db4da5eba1182df",
+      "size": 228763
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1082_01.png",
+      "hash": "e5ec58edaccd127dcdb560254d3ca4ab7c1fea640a9d131b9105d7cc9b70801f",
+      "size": 227754
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1083_01.png",
+      "hash": "71535bb6a850e843ec046b9bdc6f289d68c09bab7a591df6cd2fcebc4db4b237",
+      "size": 264108
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1084_01.png",
+      "hash": "1b51e5cbc7dfbeee63d032482b9fbaae0db68f85076fdb180d25b7fb8856ce2f",
+      "size": 234741
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1085_01.png",
+      "hash": "12a6e2c5b70275f5590d2c54d290658ee44a4d2fa340275de17459d803fd3244",
+      "size": 230074
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1086_01.png",
+      "hash": "406acea8c2b52a16c3bfd720a762b3814b263fe4a9391c92f8be7e102cf6772e",
+      "size": 250515
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1087_01.png",
+      "hash": "fb94f68b23cec4b82367c03fedfc8f9d2565678849e9428d66e6158ebba53497",
+      "size": 234924
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1089_01.png",
+      "hash": "577218322cd86a10c5adf94a66d50c2d9fcb1adfeddefbf500661b100eb9e725",
+      "size": 236799
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1090_01.png",
+      "hash": "54719d53a220e7b672bf64caa4ba6b358d4d407b090242fa8ae35f575cd83bb0",
+      "size": 151608
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1091_01.png",
+      "hash": "47a2aeea50b7d38322972900b7ba48deaf9457a0852bc3527efab5c5a0a45baf",
+      "size": 137904
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1092_01.png",
+      "hash": "442448ea9cd6f04a82d0ac1db7a419d43888d15233b8858f4c4c94bb110ae145",
+      "size": 219244
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1093_01.png",
+      "hash": "906220a372b025435349aa51f10493e02a87cfda4c7941ba6b6d15b81fa77a71",
+      "size": 231860
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1094_01.png",
+      "hash": "359a46becae30c66dd91fc77552642d165360dfdb3137d396600cb2fc6578e2b",
+      "size": 265162
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1096_01.png",
+      "hash": "82096fb87121feb3742a8a185446f07d34490d3cb5b633c678a56ce41b78ee76",
+      "size": 192260
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1097_01.png",
+      "hash": "17ab13e1f95f5613efcca2c4b836a19714c30344c1a92fac13a1f2bb3766275e",
+      "size": 224304
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1098_01.png",
+      "hash": "772beba0b0543fb0ab7dcea9bd80664d550f0d38cc4acbfb6b9e77bcdc0c1e18",
+      "size": 275188
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1099_01.png",
+      "hash": "f0665df0959d045f4429dcc47503e3c75a988eb1acd695039fa18b5db1dc5aa1",
+      "size": 234766
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1100_01.png",
+      "hash": "6577a34c8f2759e5a9ff38053191aedea1aa4ef287ab29f818cc4cb490c88e26",
+      "size": 250427
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1102_01.png",
+      "hash": "adbc94484ebea67b68c23e72c1cf71b68ae11bd6ed02b7879be146b82d3d54f4",
+      "size": 258169
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1103_01.png",
+      "hash": "f2d6a05b8cb1cc684197bf858c2fe16113d4a97d48d926f249e7f2dc840e3d21",
+      "size": 199765
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1104_01.png",
+      "hash": "df64d0da8f59185b003d888602e9e9ea76df328361c2a3d287eaebd5dd429835",
+      "size": 264875
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1105_01.png",
+      "hash": "812ade20746bb860ad17fad6ab52dde0726bdbcd89ff9aa98faa725c9d65af60",
+      "size": 229452
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1106_01.png",
+      "hash": "362be75546f3371092638935b67603d783af0b7716b354d8040d9f82a3a42b48",
+      "size": 227233
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1107_01.png",
+      "hash": "f8ce29ead72034aa818561ff72ac0354191d83cbd37c17f5da67dbdc2b67c138",
+      "size": 278917
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1108_01.png",
+      "hash": "0f3a9d3402ab571bdb6bf9f464f3c87066c631b50ab2d86955d6df68272a1aae",
+      "size": 182783
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1109_01.png",
+      "hash": "a53746b33f35cb718903f15e10c6445b074d0c054b7be29fb2954c8dd411c701",
+      "size": 208704
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1110_01.png",
+      "hash": "f46df6de858ca0be300bd1a9214d4aebce327df1ba0f763bf617c6141a2c565f",
+      "size": 160526
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1111_01.png",
+      "hash": "3f2ad58c55c2873f5056d191a19dbc7f8d9e6a1d4e687cbba29dec133c253480",
+      "size": 216282
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1112_01.png",
+      "hash": "b12d48ca30a7132b5a38bc00ee1972e03e97815e5e7b819786a861bedf71e620",
+      "size": 228552
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1113_01.png",
+      "hash": "d3205ca1ec746fd798858f04e3ec5a0b09dc909842fcd8c862ad77a600c8d2e5",
+      "size": 237071
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1114_01.png",
+      "hash": "309ee665d3c18636a5806490d3c3fd92429b9071bc958de6cccf1a9bea721973",
+      "size": 210151
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1115_01.png",
+      "hash": "82ee7f566034e8babc750a6219668ab360e6a2b0d394532f8270ca0f8db7203a",
+      "size": 149662
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1116_01.png",
+      "hash": "5bab5699c7eeaff47b1eb32b14d8174ddf26d1e420b9142606c84673b354ad76",
+      "size": 199258
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1117_01.png",
+      "hash": "72966ce806a2e07c0bd3ee2ddc798793f4764cdab6d686f80d0777db1f266e92",
+      "size": 211644
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1118_01.png",
+      "hash": "298eae309aa046aa9acde0e0e80c6ce36c1512348523435ed73ea7bf0de2c01e",
+      "size": 238752
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1119_01.png",
+      "hash": "1c2471898b41f98cc4f5195891dbf40503d5675c3335e70dcbb30187fbb22233",
+      "size": 250591
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1120_01.png",
+      "hash": "da618c97f20ad927437fc6c4d48b8da8a5981f923b3213ecdcf95b6b1818c990",
+      "size": 282855
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1121_01.png",
+      "hash": "bfe6c27c6fa0a81f16cbea648b0bff36b5fd44242e9f8acbfba3f5d287eff7f4",
+      "size": 169269
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1124_01.png",
+      "hash": "5e21847942b58528a5be11638cade4264f39a5214961f4b2955c69ab26ecaf57",
+      "size": 229984
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1128_01.png",
+      "hash": "fb487c9237c2b0f757728322ce21f7749e52b8f35be3113732e73928bba781f0",
+      "size": 269853
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1129_01.png",
+      "hash": "4bb881617ba444a8bf474054e31c129ef7230c51e448be26faa265f6f5b812bd",
+      "size": 226255
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1130_01.png",
+      "hash": "6c44bc7659411d3f3844659a078e70954166944997ee18ce105802667db871fa",
+      "size": 208390
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1131_01.png",
+      "hash": "d01088b2f5d8f1da0aa58e1b3d250435c454d7e8aa704143965a13e5c78952c3",
+      "size": 229927
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1133_01.png",
+      "hash": "c05a6657a6dd6e6e7187d28c1f01352f5a91c3a3490e4dc86972264d79844902",
+      "size": 230733
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1134_01.png",
+      "hash": "d5653856219c0ff4b7a2582fff01a0abe91cd5d96852db5fc031cef1529906f9",
+      "size": 225012
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_1135_01.png",
+      "hash": "0e5628adf354879893ec810dfade1ab68ffb9e4a5e2302abebfa7d9eb5d16d4d",
+      "size": 220584
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9001_01.png",
+      "hash": "676a2ea96f0652fa06ab74080f8708bff40fc8079885f8a6dca4648cd714d693",
+      "size": 211151
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9002_01.png",
+      "hash": "0d7a4a0c90d30808e01965ddb569e57cc5cfb61f5b4ba256bb47c01efcb2ee6d",
+      "size": 247891
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9004_01.png",
+      "hash": "07b92ff555ce5c8c2f36aba59333eb94a22b591314c3ff82e1e2c7a0f3a91834",
+      "size": 210642
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9005_01.png",
+      "hash": "47a24ac6e5ceba2b580b0c03cf14df1ba40068f0e05dc62171c77238cda4d02f",
+      "size": 208850
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9006_01.png",
+      "hash": "6a97335fb500c74864f62e3a2dc66ca0ad01c7de7c6d444f0ac97687ecbc98f0",
+      "size": 240831
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9008_01.png",
+      "hash": "9e225b82c18f006e846c6c693d0244462517deec6e2205afe4834f906fee1d38",
+      "size": 220155
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9043_01.png",
+      "hash": "7b4f5788ad4f6fc555ea373fc0a122646c9cc3cc2d43d0c009e3f7af318ec858",
+      "size": 213183
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9044_01.png",
+      "hash": "0af844a7025cc341996e85e14970f5b2e2fa04268b04866771731184a80f0e1f",
+      "size": 261846
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_1/gacha_chrname_9049_01.png",
+      "hash": "998cedf25a8ec77f3adc525a407433d040ea8eee3a7462f259c6167e85cad9b0",
+      "size": 254070
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1001_02.png",
+      "hash": "43227d353f6444523176f80bc1066278765f1202d607b53c95880735c01e053f",
+      "size": 245339
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1002_02.png",
+      "hash": "b98e3f249ef09ce63d70aa27a74baec3b47ae57ed5218527d7680a529601a32f",
+      "size": 226568
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1003_02.png",
+      "hash": "7ac9e09bf95abc7ad26aad76f50e73197c5b76b900068b8a11e2da9b7b3a1ffa",
+      "size": 174399
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1004_02.png",
+      "hash": "a3320e43a6509a210c64d75d748dbd900157d961188bcbf3cc0e65ce00c44ba5",
+      "size": 213050
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1005_02.png",
+      "hash": "d39ac769834217383e08cfa69718fba13b9552ed1903b0154121e9d211dce22f",
+      "size": 203009
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1006_02.png",
+      "hash": "cb9463315bab777bf582344f4d21f839c39f869bc7b9b7e5525a28fa9fcd6a23",
+      "size": 204996
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1007_02.png",
+      "hash": "893c83c39e4ebe7c09a09ecf84b7c6fda951a028e8dda7bce882b52f9dc6c152",
+      "size": 207982
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1008_02.png",
+      "hash": "7914102abe080dd71c13dd740121f7e8701e4c4439b72448176f3d96873394fa",
+      "size": 138444
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1009_02.png",
+      "hash": "027956ba6fbc73763c72abf86d50f10310f85c5ce5e0a689d4ea7520174460ce",
+      "size": 239714
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1010_02.png",
+      "hash": "d7b329bedead79f403213d45cea349ca3bd02219c0bda9c093a3fed0675d1ca6",
+      "size": 227875
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1011_02.png",
+      "hash": "92eb36c195a2ca25ae917ec9a91ecd5c675b28abdbc28de091c6dfeb55d9c8fe",
+      "size": 242017
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1012_02.png",
+      "hash": "7bc41bb59b86fe645d8f095b6ec6bd11554bdb297780e360e87602dd84fddab8",
+      "size": 226860
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1013_02.png",
+      "hash": "b153131be27d90425a6d90238b60a28cf271066b59dd71c84d827bd1ec28ffb7",
+      "size": 238680
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1014_02.png",
+      "hash": "bdd0080436cecccbfc99e5b5c9860939ca461cee508ecb88383bf890e54b64b0",
+      "size": 245056
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1015_02.png",
+      "hash": "853eec3fdf62363d6f1e29e9faceed705d3feae82b49cdfb5818cd5333564b1a",
+      "size": 234255
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1017_02.png",
+      "hash": "f624d486c0fe59926d546fdbf560e9f88ee21a327e13474c3c1c0f3e9aa5644b",
+      "size": 262586
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1018_02.png",
+      "hash": "aeee5cac2828b7bb00a90212881b7590dd6a4fae7615125f69b0c1864759f4fa",
+      "size": 198903
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1019_02.png",
+      "hash": "b8dbfcf142ddd734f70ed98c92a3535b5b9e8e424ca8d0245b0516efcd2286d4",
+      "size": 249562
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1020_02.png",
+      "hash": "2c973dffe04b230d7a4288b62e8a0971ff1f39bad363755cdfdfeead499df302",
+      "size": 186703
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1021_02.png",
+      "hash": "d2e5f3b8e1f39b7302d9429efeaedf2e1c46c33fd4b64783a7d4586829dfa456",
+      "size": 211103
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1022_02.png",
+      "hash": "03fd2841fb1273183df2f6da202b7dabe932326b9794bd25f00b3d45d2529a5e",
+      "size": 192530
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1023_02.png",
+      "hash": "dacd193f8f835809513922ef35fda1e43e2ccdaac6058a63a150e01b8c46059b",
+      "size": 243012
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1024_02.png",
+      "hash": "d69b9b952414c897d167c9af9b4ec0aed4c451da4a44d626e3fd2dcd8be87351",
+      "size": 247926
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1025_02.png",
+      "hash": "bea539bf259bc74b628863724d3d0825f926a19070ccdb1736a5ff9d502e1abf",
+      "size": 227388
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1026_02.png",
+      "hash": "6cea9dbb0a2015ca88f8c8ec5fe42bcd27d9378a165057ecedf1973f95c25ea9",
+      "size": 195777
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1027_02.png",
+      "hash": "bc13ec29fc52a5e24e9e79eda29c36cad990732d64b11420f2df81848f0e94d6",
+      "size": 222652
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1028_02.png",
+      "hash": "8fe5754fd4ed37ff9912cda4609256e586fd4459ede17298ea2e1fb35accff77",
+      "size": 244661
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1029_02.png",
+      "hash": "666af3df1978db2bd81950c9100bc35af7ef00568c25507208308c8c91869583",
+      "size": 207144
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1030_02.png",
+      "hash": "56b1e194ff28bfe019c8bfb90dc6658a9536bc59ffddba75d8961304913a8d34",
+      "size": 222963
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1031_02.png",
+      "hash": "a125104c7af9c28d692f9191e066ec34a6a1c2becb69418e140ef0d5c295ad4a",
+      "size": 184098
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1032_02.png",
+      "hash": "f53db7b6886b426047681f2d66f62b22904f7d9d7af0a6db0bd83c7391f90493",
+      "size": 265470
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1033_02.png",
+      "hash": "c9df7639d1bd682fd34917c18c5c0d80c321d3d6786792a5c5bd97845d82a5ce",
+      "size": 234799
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1034_02.png",
+      "hash": "86094a35a95467ba4ad0e76af352a4ccc72307aac195f76536c92b3764e2ddd6",
+      "size": 173557
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1036_02.png",
+      "hash": "7493494c3f11d8c2570b80875a5bb4ff089cc4cfcbf88369a9bebbd18a02fa15",
+      "size": 192535
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1037_02.png",
+      "hash": "842a118d6e531cf4c1efbf0ef5df6676755404905f5b10aaffb6d47d1b6ea84a",
+      "size": 174572
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1038_02.png",
+      "hash": "e728a6f112e81315da360fb1d5e00562789828650a2f77cee8798b94f60c513d",
+      "size": 175650
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1039_02.png",
+      "hash": "8832c41051e057f27e925956722234dcae5dc27025aa21cc25c0269a78c8d2f7",
+      "size": 223680
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1040_02.png",
+      "hash": "ecaf1ff237de0ad52ca7b9d39924e31e64e32f8d0c9035d46244277d1d3426f0",
+      "size": 202498
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1041_02.png",
+      "hash": "6f4284eace396a43fe2ee14169d5fc044845974cacadbc5f0eb78e431343aa70",
+      "size": 216325
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1042_02.png",
+      "hash": "4c9325b5ada67180d4b9c052239de49198877cc37005e18ba79ae581ec8a74d6",
+      "size": 260633
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1043_02.png",
+      "hash": "583c3c5452a26724b05e164224bf1721d92d1532c9e3c5a290ea4ee123cd7846",
+      "size": 235406
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1044_02.png",
+      "hash": "20d61bf3af5720117a49f1749d4b08eccb7dad8b1d1a4c476e42ff6efb515b13",
+      "size": 239671
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1045_02.png",
+      "hash": "d3b027f2bd0f181c72e5120591b043ab8b7a1a47a2ce9fa2b2031c386dbe6011",
+      "size": 224863
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1046_02.png",
+      "hash": "e096a48b1a1be6296e4923f655264364216b9876444985ca412c87308fb9657e",
+      "size": 228611
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1047_02.png",
+      "hash": "858643f0893fc230542a2522e0032a0f0a95d7a21ff693e12a69999d265de175",
+      "size": 221703
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1048_02.png",
+      "hash": "f6083eb317db8b4105e61628191d689bd06525156d542c7b37108fa2164763dd",
+      "size": 214960
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1050_02.png",
+      "hash": "139c876de2c77ea8ec2c3be7c3658c850591d2ddfe11f5be5b268fb05f29ce03",
+      "size": 219413
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1051_02.png",
+      "hash": "9665b10e24419fec14b7c54b7c8491f29fa973000674efbf401859ddaa5985a2",
+      "size": 233464
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1054_02.png",
+      "hash": "40747f7c37b8f33754a44a12bbe4cae4bfc5798bd4708b159bb4e1fef358ba3e",
+      "size": 234362
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1055_02.png",
+      "hash": "123991723bf03fc9dcc94546127c5d9787f000759c91ec346659eafffb80aa0f",
+      "size": 247040
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1056_02.png",
+      "hash": "8a874ff2795f44de984481e2636fc404b09bec4e72446cf7294e2e50dc879d28",
+      "size": 197925
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1058_02.png",
+      "hash": "a93207d23f3db619f7d948488fc16a664933682ac454a077183f27304c347288",
+      "size": 212719
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1059_02.png",
+      "hash": "778a583ee743261e0fd0447874a9f94a6b5347a635879bf082fe6de5d9d6ea1d",
+      "size": 227537
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1060_02.png",
+      "hash": "c595966cf469bc7ba8ba54d597093ccfd131e84670d21901acb09e89cea144dc",
+      "size": 185225
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1061_02.png",
+      "hash": "ebaaba5c06d529e985bb327f68b18b16675a9c1db8cd09c629e8a176d7fe37da",
+      "size": 188437
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1062_02.png",
+      "hash": "e8466ffdbc5c92f6f6528e104aa8a0fbcf87219f973ee16f407e13b61ee2cbb7",
+      "size": 190546
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1063_02.png",
+      "hash": "5385e4c3ecac64b71af76bbadcdd5d7ee12c89ebf0ceb6b9f8810dd4457f75c5",
+      "size": 213018
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1064_02.png",
+      "hash": "3504318aedf44e0579c27fbe1732c96086f31721b9736f8f855d96786fe22d78",
+      "size": 236200
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1065_02.png",
+      "hash": "7bbfb7f85c7a83ddf6af4fe139d40ed98e70358bc26e5a737db5d78afce500a2",
+      "size": 236976
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1068_02.png",
+      "hash": "365bbdc89245f5f23a68044282b791fc108e560bd6ce6c38825333b29d2b4ef9",
+      "size": 223979
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1070_02.png",
+      "hash": "d04fc234bce0ce9e5eff21687f694a34f3f628fb4af4e90145565ce2cd6c3257",
+      "size": 240872
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1071_02.png",
+      "hash": "1b500e721031971e16c3abfded2db86c5928b9a6e988ad4ff694f4d990186182",
+      "size": 238011
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1072_02.png",
+      "hash": "7831a7b9a0e6265e63dc6865e01e3b83141452f6ace71cdef1616d2a4b879fbe",
+      "size": 242683
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1073_02.png",
+      "hash": "4284fd0eb364fbabdde8449cc7eda4526a5d649bef2d9ce0d1e8a8cff3d9fc78",
+      "size": 183169
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1076_02.png",
+      "hash": "e7bdf3328785f0abf5558bf390f4366a92cbe829bb853c15a7307b58937e12b7",
+      "size": 219340
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1077_02.png",
+      "hash": "a54415de87a8598eb3adb1abd0c65f322e94f2206ac212b22e256ffa2b30e18a",
+      "size": 251837
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1082_02.png",
+      "hash": "daffcc15546181fc32a2840bfecb11396d6455bb83ae114ae1f4fe47465d7fc6",
+      "size": 221067
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1084_02.png",
+      "hash": "6da0b9659bdd74a94c1ae97f9793540af4015fb4552735fbca5c79c477465fb2",
+      "size": 228310
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1086_02.png",
+      "hash": "1b94289b13caaed97b76633c7c30f5af85753cd0d9536210fb102ddd5a7fb482",
+      "size": 244323
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1087_02.png",
+      "hash": "9ab65355bcd4258742ae7b6accfdbe81c47165430f4bd5b8f7451e714a1c1df2",
+      "size": 229117
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1090_02.png",
+      "hash": "c04fa9208ce236c0a4b77de3ed8cede72281fe8d67605aea989e12d5d251ae14",
+      "size": 147777
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1092_02.png",
+      "hash": "fd4ecedf8e0aca388041f17284ac3fd723584976b56c3c1e524077db7f0f2dd5",
+      "size": 215487
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1093_02.png",
+      "hash": "86c7d4faf4501385caecd9fd37e914158dd0453f395671e6e0485a98fd2d293e",
+      "size": 226027
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1094_02.png",
+      "hash": "bc4e3870fa242421a8f18d6bbdb9f5531456e5302edc4f20dde34e8a5c134af5",
+      "size": 260601
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1098_02.png",
+      "hash": "351f4e0d96787673d86dced08d7a5c30eab651170273a33f2479b5fd41296977",
+      "size": 270472
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1103_02.png",
+      "hash": "134a2534cfdb5bcc7cce72cd8d60e798995302500e8845d9e52e21cdf6797d4d",
+      "size": 193696
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1107_02.png",
+      "hash": "9cc35e937b6707fa6fdbd81bce5a6c78614ac06aa982a2bd666d602181e6bd98",
+      "size": 272267
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1112_02.png",
+      "hash": "29859a5910b65ccd7717b6e57617db2224c582ed117f3872c7ed32ff4360a47b",
+      "size": 222592
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1124_02.png",
+      "hash": "c9169698994ce33b6f6852c7d4660b9e51770912e5ac97b2c77af2f1dddfc5e6",
+      "size": 225688
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1130_02.png",
+      "hash": "6185d6484d7cb384ac7a15c7c09ad24208a24e1216907530304d47843d6ed101",
+      "size": 201475
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_1134_02.png",
+      "hash": "81a574c35635d117b22c919f0245be534c4814d844c753f10e927b546e908f0d",
+      "size": 221722
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_2/gacha_chrname_9004_02.png",
+      "hash": "5d856f70577c785661bff575364d0e6779402717689b743d88f050834134fb6c",
+      "size": 205719
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1001_03.png",
+      "hash": "d29893441473eb83ea81b8f4e5fc7044a66ba810ef8a75160fbca27537768e68",
+      "size": 322457
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1002_03.png",
+      "hash": "bc911f9f4b87f4513877ff42685e9188851d6da82f2ce17d6648a564cf9d7340",
+      "size": 323302
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1003_03.png",
+      "hash": "b41c2431bd231868234b5fce5179a17a984a03ff657ad36d5a5de6dd9673d4ce",
+      "size": 251958
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1004_03.png",
+      "hash": "8a5136cd4fc3ea143658106772728a7b8916e15cc29ca83d612079a43d3811ef",
+      "size": 262165
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1005_03.png",
+      "hash": "47cb281ca432696becd197c543d8a7aad39c7e22d6e816705be9bfa7b422549d",
+      "size": 270097
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1006_03.png",
+      "hash": "6e02fc2ec21884ff675de617df3caf582b6a421ba3180172d879bf5cea246150",
+      "size": 254253
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1007_03.png",
+      "hash": "19e62f46779e905a138058988a91ce4202d64bddf11e1e86f1c41220060edf7c",
+      "size": 259333
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1008_03.png",
+      "hash": "48be979f8a7ebdcf006ab7c5b80c67a8b415fe92e3243db287484d353c1186b9",
+      "size": 166623
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1009_03.png",
+      "hash": "4bab045e7a44900390f9c47e177416b950bd0e48691c6645bc0ff2b95a0d18ef",
+      "size": 315069
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1010_03.png",
+      "hash": "2b4617f79fe3afbd136d5803d7c5a9c1cb9f82ebce572c14965e21b3ea18b86a",
+      "size": 291070
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1011_03.png",
+      "hash": "72a9a9f84beb2f56718bade33271655e4a78bc636fd09b2147d79cd30246b30a",
+      "size": 312110
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1012_03.png",
+      "hash": "68c96ee87384ab27c8447dabc4850edcef275d214162c9fb39647c6ad66cff3b",
+      "size": 293498
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1013_03.png",
+      "hash": "4ccd793f2f306eda17d5c5d3698efb2a4eb86f5eb762a93476b92fcff6df1877",
+      "size": 340048
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1014_03.png",
+      "hash": "4af012d0d2d5300daa122a3d4b5efddf26aaf163ba00425921f744d6a3b99cb7",
+      "size": 337360
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1015_03.png",
+      "hash": "282991f0234d0467005e9ef28092c23e832c1813b2525260322ef78546092acc",
+      "size": 309970
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1016_03.png",
+      "hash": "c0761913d9628eb9691d0a5157ce179c09ce69654252358a38cb8356b2cda981",
+      "size": 273630
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1017_03.png",
+      "hash": "c65e826c37ba7278950ded73b3c2aa40be3b9a5bf4e529ce07228a2822f33be4",
+      "size": 349797
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1018_03.png",
+      "hash": "195027dede35074d0ebd4be123cef632f42d39c35fdad1f108cdcf7cc7ead332",
+      "size": 255811
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1019_03.png",
+      "hash": "5996fa3edff592e649e5d07749370173233b1c69752736d8ac7ee4d6bd3cf5f2",
+      "size": 326962
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1020_03.png",
+      "hash": "d0f53bae26627d14093b459777d5c40c5c197d92015efa6d07f8d812341c9244",
+      "size": 255916
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1021_03.png",
+      "hash": "894dd5e722f18ae5954fd3fa168c0e203592b26d5a25354fba89d30a5d7432e0",
+      "size": 310553
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1022_03.png",
+      "hash": "8fc6464cdba0da38ef40891e4609c09be93d345b51fc3a6cc98d3e812ee3734b",
+      "size": 273378
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1023_03.png",
+      "hash": "1b1fd304bc0d0217ceb5ba6c8569d59dbf99094c422ffc4fb3ba5567eeb6cc93",
+      "size": 329807
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1024_03.png",
+      "hash": "cd2e316cd08affae457a4e3cacc569536e7821d08dfbb84a4cfda30f14f541f5",
+      "size": 329432
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1025_03.png",
+      "hash": "06e9200d9c42e228a200e23c9a8e0771d0591858bce3af8039321cca8cf5a369",
+      "size": 327337
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1026_03.png",
+      "hash": "24ae60e447f684dc0854722b24d0831b96afdd7b7288fc3dadb90f5a77ba6088",
+      "size": 310509
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1027_03.png",
+      "hash": "7dd18a5981e91e3a47c7ad6ed1fcdebcac6f45a81139de50c8a604ba27da4ac0",
+      "size": 285810
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1028_03.png",
+      "hash": "e77a66db974e6ec337fa40566d6f0ade5cb8f59f81361be89834c0c1315f28b5",
+      "size": 328802
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1029_03.png",
+      "hash": "43bd159f3c9072a99975be73ccb002d2154656b3056f918ad8d565006c0676aa",
+      "size": 281977
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1030_03.png",
+      "hash": "f6baa1a5612a0e62c525f93a320a993c57abd52d2c78d1fe38b56444d1a56de7",
+      "size": 281804
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1031_03.png",
+      "hash": "8233e93dc60580df7fe6dd899ad227b108dd5d33bad641d59f80c3062fb3fed1",
+      "size": 244269
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1032_03.png",
+      "hash": "f56d483656372ef38b37668d336ebdd96beddd9e9c6ebd4a92de9a5d9b394e75",
+      "size": 343543
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1033_03.png",
+      "hash": "58a57882d59dbd85abf4d4e01eb1fdac1a0b51e26281b5ce5dfc4baeba76a095",
+      "size": 302575
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1034_03.png",
+      "hash": "b1ed2c9d4173bb8694349ffa7b0f2611138bf4dcf749757b5b3d0f6c1f601f40",
+      "size": 226265
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1035_03.png",
+      "hash": "b330035def2e665a292600ead3c652e8c94d56da0f5ebe140f07ad7a44ce61c5",
+      "size": 326547
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1036_03.png",
+      "hash": "42fd8ff64da6f7e088ab8c7bb63689d7dfadda6ad6cbdd51377e1f1fd1c802ac",
+      "size": 251355
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1037_03.png",
+      "hash": "6f680fd91ed2dbafbba39009739c8db8a4a16da0ff4b64e1e07dc71f77525c54",
+      "size": 276727
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1038_03.png",
+      "hash": "6a05394a59d0fdd20cd192535ccf88f14753f4350bfcd75d2d31927cd51f72f1",
+      "size": 277330
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1039_03.png",
+      "hash": "7e5293e6985e2b7bbd8e924a5774ed5285a3a34abb0842748d38aff9aca34777",
+      "size": 303378
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1040_03.png",
+      "hash": "155348fa56c82921921d77d58de9d6fccbd88f117c7d475928141fc1eb54a572",
+      "size": 248075
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1041_03.png",
+      "hash": "fa6ddc7327dcfa0537d9495e212c087a3d88cc758a7c5913475b3a8fd5fc8d48",
+      "size": 315466
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1042_03.png",
+      "hash": "698aa1c0a10d1d50c08e0816e83bf4b67d2c503d84825af92fde91114ad45d21",
+      "size": 345591
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1043_03.png",
+      "hash": "d901702458ab2dfc54a082853a067b166ced7b08fa20059e83e1f793f4136096",
+      "size": 315511
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1044_03.png",
+      "hash": "c7d18b3628a0d1e03b29385efc796459e9775d9e2d1cefbf6129747787612274",
+      "size": 308376
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1045_03.png",
+      "hash": "1f1e50c879e255f1e5045033e00f68577384d610c1dcf89735b9c207e12f7b2b",
+      "size": 299859
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1046_03.png",
+      "hash": "5a8eddd80e3cb95f9c23021fbd33ca3cb76c503081f03272c3cc84e376778909",
+      "size": 295735
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1047_03.png",
+      "hash": "1b949e39c60d827e16b50d3db06481fd13f2e3d6c5a235753dc32f24d1994889",
+      "size": 338774
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1048_03.png",
+      "hash": "256b2f943fae0e9c38240de889e80371d676df556e6d12bbf5dc45e59df88b46",
+      "size": 298315
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1049_03.png",
+      "hash": "1ad40ab35fe8b71313006d7277c9c94c1f6b8eb88789a500d28cbb4e36fbea77",
+      "size": 325463
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1050_03.png",
+      "hash": "092c847dd1139f6abb642b7d9c47f72b6f0f492414b45af527d08192ac84ed80",
+      "size": 314502
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1051_03.png",
+      "hash": "e2b5e976e42785d2ea240d813dcefe8587b1faca38b5e1c322d6e35004f75813",
+      "size": 321905
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1052_03.png",
+      "hash": "cdeb53b3439ba6965df7e6c517cec2785eb45430dbf9ce1d8e6ddadf870be687",
+      "size": 245332
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1053_03.png",
+      "hash": "90d1ac7e9fdc0ddcf8b37ba8a489028b6e55150180379c4f5eae3333ed7c2f8f",
+      "size": 316855
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1054_03.png",
+      "hash": "7384114628c383d4a3c7b04ed5697d4bba25fca3be41307d30183753ca82ed92",
+      "size": 303048
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1055_03.png",
+      "hash": "2b912c201c9445c41b13131e5944dc0fed3f2af68fdf13c4cf883e12b2f760b8",
+      "size": 316825
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1056_03.png",
+      "hash": "2571a415f4ddf7f158b71f461ab6585d956a0916b7939a868daaccc7f6d6f1aa",
+      "size": 302407
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1057_03.png",
+      "hash": "df7be894b140eaefbe052ca80133fb0f13a9c8b998c543a638636535b03c79a3",
+      "size": 203624
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1058_03.png",
+      "hash": "04866e4a8c2e13f32f79e9c6b77c4dfa37f5d6bd33a1b8aeab3d2f839eaf3e7b",
+      "size": 301051
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1059_03.png",
+      "hash": "11a73f1053fb14f28e31ed9a5d1435c86fea0395c7f842800a2a1b8ad8ea8b33",
+      "size": 308490
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1060_03.png",
+      "hash": "13f569f06b848dedb04cbec9f3a1b0d843cfe5a6d41731c36858f163c93a3e1f",
+      "size": 270596
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1061_03.png",
+      "hash": "1656717e120ca0a9cbaffc2b75707c5b23da244ef536b81b3231b21b6c54bb10",
+      "size": 238482
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1062_03.png",
+      "hash": "2f2e432974fe6984c2c064685f752a92fffc6e79b512f03e4f416fbcc1caff7f",
+      "size": 282697
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1063_03.png",
+      "hash": "5121309fd001cf188e589e759caf56ace1595182ab75cb61f45d2c8310423d25",
+      "size": 280402
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1064_03.png",
+      "hash": "b822fdba3db347a00f0b85730f9a955ed44e7241ce1e1d2263fc1cf3ed3adf7b",
+      "size": 315333
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1065_03.png",
+      "hash": "5868869b9dadc59c57a7f5ac092a68c94d8409a4cc5848cce34f3afdf9a786a3",
+      "size": 321584
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1066_03.png",
+      "hash": "5f0e9d12845df482a6a7b33fdc550d9f386d037d06e921d5c94bca495e53643c",
+      "size": 254158
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1067_03.png",
+      "hash": "dcf8cd0f401dc3a5aac3ed801f76cef6f4120b921598e0d366548a1d5251a69d",
+      "size": 320690
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1068_03.png",
+      "hash": "24d337c19a8ecba7f712a03992045f6c3651c026eff78859cd50190807b1775c",
+      "size": 302620
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1069_03.png",
+      "hash": "a7684a2b35616b3cfcead31f15c9b96d6e85b9f6467e3de539ed42472cfcc9ef",
+      "size": 329748
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1070_03.png",
+      "hash": "0759acb2f7508f67fc564da363410de11615a328975e2e042480cf22de9597d9",
+      "size": 338260
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1071_03.png",
+      "hash": "0bdb2a4be241bae371534656c2308c7441637563dc75a9ff23c55ac6375a99f3",
+      "size": 302823
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1072_03.png",
+      "hash": "44ef6d00526bdc9e95b9d1fa63c89eac717bd4e31e177eaac07c9542a68ff59e",
+      "size": 313212
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1073_03.png",
+      "hash": "30b3953191268d3912aa9c32359799f1cc6bf1b482e9fe0731af3d6d94c441a4",
+      "size": 293524
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1074_03.png",
+      "hash": "0b3ed51df7e8fc6b7b4c3cc3ac0500733a31cd35905b1ea42d0b61d1faf0511e",
+      "size": 323799
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1075_03.png",
+      "hash": "50312b1030bfd6126fdbecd288177cfdc49c4baab57fd5b9be7adb65e64b7c43",
+      "size": 278041
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1076_03.png",
+      "hash": "8d10531276c841ebf7de2e41ef0449496ab8e9efd157fe87a2fced746d028907",
+      "size": 305065
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1077_03.png",
+      "hash": "25f4674c950c25853cc555297d082f210f3c8bc514950be32f4ef92654361f7b",
+      "size": 343763
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1078_03.png",
+      "hash": "95fa0e82dc16022b19d4e0b0b937c6f80f1837a788d55b20cbbcc2e43e321185",
+      "size": 323671
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1079_03.png",
+      "hash": "ec5eb6146617a2099748a204c43e34057fa4355ab4024e3da5a36de0d9898c72",
+      "size": 191414
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1080_03.png",
+      "hash": "cb6537b8774964610a136b0c0d17c4c2b496aaf102499383cc83d0e774035927",
+      "size": 238317
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1081_03.png",
+      "hash": "171afc4b8dbf1978c44dd62518f9059f40bc34fe06597336ff7ed3e39175a6f0",
+      "size": 273490
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1082_03.png",
+      "hash": "595bb14d3516775dc1c07b3490c725796e5ea23c3b460db433e8fbb28499be0c",
+      "size": 295101
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1083_03.png",
+      "hash": "e4c0282f51e1a690c81da193bf3ae6d0ef0a49bc17a63f254a0de4bba1c2c49e",
+      "size": 347033
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1084_03.png",
+      "hash": "7b77b1d3bdcc8381bfbeb11c88234126e443caee4ea13e9160a28412a6d78044",
+      "size": 307374
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1085_03.png",
+      "hash": "9020dcc46b7f0c74ca7f5f484b9ba2bb762c5f2445bd2ecd68c9684c0b7286d6",
+      "size": 297930
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1086_03.png",
+      "hash": "95adf176ea4cbfafec1f52e04eb616c2c86857efe7bd2673678a36b0b00ff8a8",
+      "size": 322439
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1087_03.png",
+      "hash": "170cd7aba2007f0960801fea8b72c31506119a02e768671750a6bbcb2b59b23d",
+      "size": 313907
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1088_03.png",
+      "hash": "f97222da4c58eff142d533808e107db677ef3a18634da0d52da695183f000806",
+      "size": 310259
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1089_03.png",
+      "hash": "08fd4c1da0292dde7e8d41f351a4b72f910f3b700b1fb73298c37a3ecc76200a",
+      "size": 308284
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1090_03.png",
+      "hash": "53befdf19d710b0e6be177e47e52d0904474ced3ebc35e453ba8da351efd1aea",
+      "size": 185693
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1091_03.png",
+      "hash": "29630cbfa3739bedad2fca5c6594e888bacdc8cba386dfcfedec85cfd271fa15",
+      "size": 168854
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1092_03.png",
+      "hash": "cfea740c74642bb6d715da49ba629c950f0b50ce4c8d2894e333c9d8de9e3091",
+      "size": 291600
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1093_03.png",
+      "hash": "863006d527d92d959db22807999fc96c616269ae98aba4fe0edc97f32abc878e",
+      "size": 287146
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1094_03.png",
+      "hash": "4f5c88a2d78f64787c3350058815bd1ef3e89c9b72d89ced6310ef7b20f46929",
+      "size": 330502
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1095_03.png",
+      "hash": "8d22cefdb9e0699f543b0641d1cdc55992bfc15ccd5237f1a08a8c6e6d63b2a6",
+      "size": 186788
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1096_03.png",
+      "hash": "92571e0cee500ecb16ef7eb615f303b25ec30a6601220324e9c8576afc9f1584",
+      "size": 248617
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1097_03.png",
+      "hash": "1e46cdbf3d0317154b89433db728ef9b01adfdc900f8680a088ce31b3e5b648f",
+      "size": 280433
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1098_03.png",
+      "hash": "3fc2f761a46e9f29bfb36394381d2c656f49dfe13487e279c398059d1a47fed6",
+      "size": 337486
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1099_03.png",
+      "hash": "6be4f49d613a01ad4ef0e546ee441d6e527816de468a94f7f1bfe4b1e533b520",
+      "size": 317814
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1100_03.png",
+      "hash": "8a951981a3296a4c5ed976adf322e03a1439929d8ad235eb559859f0628ed036",
+      "size": 312089
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1102_03.png",
+      "hash": "faafe495b14fb2371eb2ebebcce906443b82780b242d57a4ac46e3d43afcce74",
+      "size": 329448
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1104_03.png",
+      "hash": "c5ecdf2a9dff7664a53ed7520b1979f48057da5e01fa8ec3fa39c462e5b6d6b7",
+      "size": 322738
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1105_03.png",
+      "hash": "98741e76d7558d2ff3bbb3bce908bd055f33c557412fb9d63ca9eb824c23af68",
+      "size": 303599
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1106_03.png",
+      "hash": "71b77fe6aeab90151614c5b6eadf3f8aac269c14eb476224a9168356bd35ba92",
+      "size": 297283
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1107_03.png",
+      "hash": "97362d1cb438519a9e4c65fa61acaa513f799f867a0e72e0461005fd0a4c58ac",
+      "size": 345920
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1108_03.png",
+      "hash": "8ee3b31be48461b2098ac405ad6b4a5a624c875762340c6ffb30b53a4564ba1b",
+      "size": 237699
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1109_03.png",
+      "hash": "00ee41fcba5e99eb272ad32072487ec974044410ccd3d544f8936fea5946df4b",
+      "size": 270323
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1110_03.png",
+      "hash": "bba20eab4b7141c449acbaf72d4196828c27464fb153efeabbee7c1030471095",
+      "size": 194792
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1111_03.png",
+      "hash": "214b3adc7e812dc0ee5862d28cadc51a45a5057e5e662b95b98f0d1cbe7afbae",
+      "size": 280064
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1112_03.png",
+      "hash": "8c3d537f1ab25329c6c7ef2f73a5a7ea29bad762fdd0e0692d256bc0f4dd79b7",
+      "size": 299886
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1113_03.png",
+      "hash": "b789182745ebe6a3115a3f142cbe87736246620a244944cc91a165475a963876",
+      "size": 320831
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1114_03.png",
+      "hash": "0caf22a7d2ddbca3e32bd4b5474bfadb10837adeebb187a5fe3ec4ac969e2347",
+      "size": 273635
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1115_03.png",
+      "hash": "19585a471f5bd8ab10866b1a8abd89f5e8c6fc3517d2ea59d931508218265ff9",
+      "size": 192444
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1116_03.png",
+      "hash": "9d4a5609e1984d38f1709e4783a6735e3233117757e97fc1177fa80a025abc18",
+      "size": 265986
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1117_03.png",
+      "hash": "6cfef9d17b5135508d3778282fd9165e6f962b6580bcce8b5cab19c61b936035",
+      "size": 296950
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1118_03.png",
+      "hash": "9472297796cdec9dbad5f397648085fe0775a7ed1b4944bb924169b24ae60a1c",
+      "size": 331654
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1119_03.png",
+      "hash": "815f5fbeb17cbf2fbe33dd187a25d6de3433adbe512b5dc4d68bb3bf9ea0c1e1",
+      "size": 317794
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1120_03.png",
+      "hash": "1f7f3c04e26ee5a6649842fdbc93bf0c91baedc5312f109dbc46ea9e1e4e2df1",
+      "size": 353144
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1121_03.png",
+      "hash": "3a2586e0846d6516140de114487e6d06ed7c0df755ee0945e27ee9dca0fbba49",
+      "size": 215355
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1124_03.png",
+      "hash": "ac0987243b81d8aa1c20d402b196985b69d583196fd3bdd95be03864d1d345b4",
+      "size": 318256
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1127_03.png",
+      "hash": "63828fad92d4adccf27f1a86f6f09aa4606e884c614841a84912e0ff17c4fbf9",
+      "size": 229153
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1128_03.png",
+      "hash": "31e19affe68ae469f0a68b9a1fb120857760e088253b6813fa8a9663d4db2b79",
+      "size": 342359
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1129_03.png",
+      "hash": "a15c75ff446cbe1efbde58b7371a7af5d3b0b92b53fdfd79eda16202eaa25e59",
+      "size": 276698
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1131_03.png",
+      "hash": "412298076c93ce57c0cbd401e53fc4a3398e1fc122f2501f30797a309880873f",
+      "size": 290519
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1132_03.png",
+      "hash": "f3360d733b562d7940c337770ac3f2b3548f1fe6bc26a2d28a645e435897b524",
+      "size": 351606
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1133_03.png",
+      "hash": "fcfd270696670952c6cd662542ee4cb8b7f2cbe32b44329600cc891e70a865da",
+      "size": 330723
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_1135_03.png",
+      "hash": "3b7a505ce6cee9e67d4ca67e91b93853a30776cb3c73930d747c70ee6dec549b",
+      "size": 260764
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9001_03.png",
+      "hash": "0c70c33b50c51108c6a912240f34d2f5ee8bcabb31f537f8288c274f5abe8838",
+      "size": 294045
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9002_03.png",
+      "hash": "8fcf92207d352c582d26d109a62343f47c1d1a47cb5b11dc30a8e93f03b9fec6",
+      "size": 317631
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9005_03.png",
+      "hash": "a189a74ebb3830c4e69a7f26b0777f2bb72a6dc3853f3719cd0a56a0bd4e6ac5",
+      "size": 288080
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9006_03.png",
+      "hash": "462b6fc1c40155ad42b8974dd55b6a17afa12e660d62d0865ab308636871966e",
+      "size": 325431
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9008_03.png",
+      "hash": "e253d60c43cd62fad67abd5ec46dba94757c21348309e1b92b528beebe3c3f3c",
+      "size": 274279
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9043_03.png",
+      "hash": "d0adc1847777962ffbe2880dcfc92c6901830907cf32835d9fab903a42500793",
+      "size": 270603
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9044_03.png",
+      "hash": "3c5dff45f9e56b4df29931e066ae2a5d58c1de5c8ef9539e89d6e28a3c635e11",
+      "size": 328066
+    },
+    {
+      "path": "assets/textures/gacha/charaname/rarity_3/gacha_chrname_9049_03.png",
+      "hash": "725962300aaa93f32a70ad2f678385291eccef4f9f30dced7c77421f5cba2b16",
+      "size": 315801
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100101.png",
+      "hash": "8cdd69d3c937d23a3fca7b026f5bd37f76737672152455dc511bd46589c2e42a",
+      "size": 467906
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100102.png",
+      "hash": "5a76923cd38cde82720a08f9a035273ae1ba86dbaf6893dbbefcc1987dc44bdf",
+      "size": 505368
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100103.png",
+      "hash": "9b52db46766b85d60e8aa6a6d68e2480500c292d010984e7d34d2e52686a1cff",
+      "size": 506812
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100201.png",
+      "hash": "6ab8306b2939b8eef48c3d69b73eee3d5b8cffe8c6d4580861e91eeb1c2175e6",
+      "size": 520421
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100202.png",
+      "hash": "9ba74c293b28f657de9d80236b8ec857a5a3d698ecd350980052238a6987a5ac",
+      "size": 500558
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100301.png",
+      "hash": "f6ee5375f6ea0c42ebd58f4034832f9b1137544b6af756df6cc239a360bd2dab",
+      "size": 472468
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100302.png",
+      "hash": "b28c3f914fa59e93ff8b98be617fea739586896bb107a90026abc20bd6dc07cf",
+      "size": 528955
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100401.png",
+      "hash": "99d51452b023a05a023764eef58ac663d6241b4c059b8704028551daec1dc6a5",
+      "size": 508147
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100403.png",
+      "hash": "75390f75c5528ce91d6e5761c2122450e550f9ad37cd499a4d90b7ffc3484c53",
+      "size": 477101
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100602.png",
+      "hash": "4ee1fa96894c59a7191d09ba42bc71bc859b4275ef89d708cda9159ab21beda9",
+      "size": 491209
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100702.png",
+      "hash": "99187899ceaa2ec630c5d113a18ef915458a5f07daa9c67b4d140cd137b92318",
+      "size": 549206
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100802.png",
+      "hash": "768bc4270e653bc1f7b447a41bacb3baddca329768e37a1fe02bf63e3223ed66",
+      "size": 529212
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_100902.png",
+      "hash": "0c6e460115a91dcf446665b9031e590175899e2754a73139bbb8b255b3119be0",
+      "size": 538053
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_101001.png",
+      "hash": "7bb9dfe5f5108af7e672fef531f1febde22f5a22780ef23453b05f493e455ce8",
+      "size": 435724
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_101002.png",
+      "hash": "41fc81d697dafbc25eaa2c4765a8451673d5ef99613caee7af6aa7d3e83d6855",
+      "size": 481824
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_101103.png",
+      "hash": "b1d787862721475bd2caa112f90e76fbeed170617bf6ae0891df6e231034790f",
+      "size": 522364
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_101201.png",
+      "hash": "34d0b7d3fd39b164059686f3c4fa914036873c177d321dad53fb798a88bc9ca5",
+      "size": 557398
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_101901.png",
+      "hash": "a713026f0fe1bde55bcfc0cab97d6c0647c20dd2fba966395fd137dadcbca8aa",
+      "size": 437184
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_102303.png",
+      "hash": "97cd64dcb1942f284f0601ab94797bf82f35f905d6ec17bcb59c67b94e192feb",
+      "size": 509004
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_102403.png",
+      "hash": "a8f0655c708fcf0f3a815c64b9c41f12dab17607f24cf9d6cbe82ed1572fa655",
+      "size": 524569
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_102601.png",
+      "hash": "f608ac6457a62d597faa76c51f11f97570eeb32c727a8756651047eb2a07f006",
+      "size": 569666
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_102801.png",
+      "hash": "34bd7ae1936c852747a1f6adaff5753eb74fcdf09d8e8970bfeccfcbf5cad99a",
+      "size": 505340
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_103001.png",
+      "hash": "84e9a2c4daf33076964867d84185e42f1b3550a5284911d188787bf721d0ae0f",
+      "size": 545513
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_103302.png",
+      "hash": "30711f7ae9757e53ee1ab47bbaaeda5a14086554f9ceeb92b10701a3ed05cc9d",
+      "size": 490949
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_103701.png",
+      "hash": "caf428f9168d56626a15e7c1392997f54a5dddaa07bdd1510fba1ae53857fcb2",
+      "size": 473157
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_103703.png",
+      "hash": "b3edea03bd8757c697fd3d119f85e6b41769d03f67bec031143f77618301d3ca",
+      "size": 513473
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_103801.png",
+      "hash": "cd03a867fb70a5d54bac713addc88a48d9fa71579ea96c0d3b7a9d8cad50346e",
+      "size": 482498
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_103802.png",
+      "hash": "8146323550db600750161d9f2f37d47ab3ee957481502b7f36555b06f28d0122",
+      "size": 507119
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_104202.png",
+      "hash": "1a4a7a63268762130ff080a0a57039dca34387d63d2864b10f7550c7930e4780",
+      "size": 419715
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_104401.png",
+      "hash": "a0c71175da2c0f9e2d75432ceaf62538c0ca92a63cfb7f5bbb0f7b19a29d9abd",
+      "size": 608499
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_104402.png",
+      "hash": "0d005a218a899a472b5974c49c45f4cd61cbed8d20f371e5ba8d03a13af50628",
+      "size": 553023
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_104502.png",
+      "hash": "031a459ea8e2a083d52c8e79e11f2b825d59776e8de379fa5dc7a1573bfbf370",
+      "size": 491051
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_104503.png",
+      "hash": "ff5087e2d579ec05b641aa422fafbfaa2de5e224fb99f991d0d8111d96480153",
+      "size": 385673
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_105003.png",
+      "hash": "eee665d32226f6cef7382a4d7a3127b4b33800effdd152dc11e14a4969f73d66",
+      "size": 497960
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_105501.png",
+      "hash": "99f6aaae0b78ba39f1d9c112040bfe3a54ab9eeb4324f4e1b4f2aa5eb47b2a76",
+      "size": 516175
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_105702.png",
+      "hash": "493034c564b160e9b06da5c41a995680441d2ec4199596b8c2340abe81047ccc",
+      "size": 532331
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_105801.png",
+      "hash": "cd4cecc532d472588888fa58e3326ec81b93aa55b07e93dfb0105fca62b01cc3",
+      "size": 548733
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_106002.png",
+      "hash": "8212b76f243beb3001d39a5850a39af0b5da52fd225a3a4136cfb8d99567ba0e",
+      "size": 522695
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_106401.png",
+      "hash": "7c113cbf7bc99e3d9d7beac467cbd8a6ce04e029d887d56fc023ce255df9fb4a",
+      "size": 557390
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_107702.png",
+      "hash": "ca52e077a282102559fb966f14c333460907fc78d9b0090c5d8e9ecdc0726de5",
+      "size": 483698
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_107802.png",
+      "hash": "4fa4ee11ab99087a8bca3fcef76b440c7da3857990be8d321a25d533abecd7fd",
+      "size": 514808
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_107901.png",
+      "hash": "c1591ca00e04098862f2e4295eff88f40479a4c6904d3f3d71ac1315d4f87f0d",
+      "size": 514998
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_108001.png",
+      "hash": "1754031ac49c8cb1e81952b84f774a4942efdc18e5a44b867dd92a8a4eade186",
+      "size": 489884
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_108301.png",
+      "hash": "06a2f0f464b8091854ff2587f87a2ef53261d8395f8291d7dcd859bd06c742c7",
+      "size": 452721
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_108701.png",
+      "hash": "a63e27eee6b99195aaf5dca3c9dda806b30d4c689a15151521cf53796a4f2d51",
+      "size": 491819
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_108702.png",
+      "hash": "da4a121334eea989be81763f50adf033f6f9df8517ba28123e8c603e589d2651",
+      "size": 516954
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_110402.png",
+      "hash": "fb1887f7bc322f04e69a1ceb801194335cddb0a13da48a332ba5b4e20e685af5",
+      "size": 512495
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_110501.png",
+      "hash": "17aee0b0af0ad22f32ac554eb68004215e03889183c61efce470f54a84584d96",
+      "size": 406830
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_110601.png",
+      "hash": "2f593db9e22a45af650ef7c60bc8f383b86b7dd4664ded68b586aa2c3a9ee468",
+      "size": 579184
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_111001.png",
+      "hash": "20bba1465cd9e34a9442470ee65d2526576db592a5226df44f4a65f29fbf301e",
+      "size": 546861
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_111101.png",
+      "hash": "238775039156255a1c8b2a5759678521f8ac83d63fdbf239e48cb1ede29df52d",
+      "size": 507309
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_111501.png",
+      "hash": "f882f507c6860b6b3b5346a20ed976cfc9537153f49ca3bd49366e9137848ba0",
+      "size": 473649
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_111601.png",
+      "hash": "cd8ff29c04cbf116b5a7b2534bfc349b7b72557d54fc2ec484e092d769aeb9b6",
+      "size": 539012
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_111701.png",
+      "hash": "ea1c6a3bed42fe3d8b63d575cfd931bc242c39074838bb00bb4fb2c1f87ab128",
+      "size": 529234
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_112001.png",
+      "hash": "93ba0b71906e61bcf6657d2a78b030c1db98c6a81106e383717da0250976a97a",
+      "size": 517085
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_112101.png",
+      "hash": "192a87657f7b0c1cdfb62f5befba3e51fa63c9be733179d3243a0113d036a585",
+      "size": 495511
+    },
+    {
+      "path": "assets/textures/gacha/comment/gacha_comment_112401.png",
+      "hash": "451daa5f6b161f0a2ce2dfb13b7635c6dfe5c1694ab6be719e4fb2e8d1a4ddd9",
+      "size": 535771
+    },
+    {
+      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30067_03.png",
+      "hash": "57d3419ae5750042fd174ef9fa672f04bac8df4e2765de1c9693c6ec3020b884",
+      "size": 284258
+    },
+    {
+      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30081_03.png",
+      "hash": "56043cd6a01f0138cfd8e53b79a4413ee17bd1061cab98e40c6af828853fe50b",
+      "size": 269278
+    },
+    {
+      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30137_03.png",
+      "hash": "74a972a9de8a9002523fe817495cef51ac4a6347a5bbee2321963428309df083",
+      "size": 323877
+    },
+    {
+      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30180_03.png",
+      "hash": "5c8bf0c742d0c2237a5d3e6639dcd0ba0e783eff0ec4bc136c9f194a47835f6f",
+      "size": 321224
+    },
+    {
+      "path": "assets/textures/gacha/supportname/rarity_3/gacha_supportname_30241_03.png",
+      "hash": "5184ed44217ae98dbd1dd1704484d59e14e94e7328118791db6f238b71724ab5",
+      "size": 287426
+    },
+    {
+      "path": "assets/textures/heroes/utx_txt_hero_skill_name_00.png",
+      "hash": "2982d4d6b382caed1078a7e1078fd35c67bca5e20f26b50363e04ca7c2785dbe",
+      "size": 206318
+    },
+    {
+      "path": "assets/textures/heroes/utx_txt_hero_skill_name_01.png",
+      "hash": "35ad207d41251bfa8047fc78c81c2587c5ee641ff6b460280e698f86f9d0f8b3",
+      "size": 202783
+    },
+    {
+      "path": "assets/textures/heroes/utx_txt_hero_skill_name_02.png",
+      "hash": "0b79cff589a7f42193feb874fbd13f364f22ada173ba87ef8c99eb016af43fec",
+      "size": 189795
+    },
+    {
+      "path": "assets/textures/heroes/utx_txt_hero_skill_name_03.png",
+      "hash": "0027bd3cd65d1021162b6e86a4f2c943c449528cb2e35db5e3c7f303d68e8905",
+      "size": 181419
+    },
+    {
+      "path": "assets/textures/heroes/utx_txt_hero_skill_name_04.png",
+      "hash": "8f9ce5cd2b607ef6f7c1cca8fe7f95b8f148bbb9ecbba5d1f555c69df89a601f",
+      "size": 219896
+    },
+    {
+      "path": "assets/textures/heroes/utx_txt_hero_skill_name_05.png",
+      "hash": "1163494438bbcc76dbb72e3f31bbb1bfb04a7627a0a874700a8d2f769d39f982",
+      "size": 201279
+    },
+    {
+      "path": "assets/textures/heroes/utx_txt_hero_skill_name_06.png",
+      "hash": "f42ce6ba3ef520ae791a62f994b7fc7d83fba8d64b32983ce8a480d9d61ee23b",
+      "size": 196541
+    },
+    {
+      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_00.png",
+      "hash": "f353516ed575d64758826fcd0427f3f08346316503672bec5cd74c16c6a19e6b",
+      "size": 48423
+    },
+    {
+      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_01.png",
+      "hash": "b75ddc8e7ae46b89a0072e3bbbd99dc39b7950071bea21feb64e8740f8910719",
+      "size": 48798
+    },
+    {
+      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_02.png",
+      "hash": "55a63c23d4d8f84999bae178239a42f6e077707e976472c9deab5722c0aad338",
+      "size": 60762
+    },
+    {
+      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_03.png",
+      "hash": "6a29cfcfe11f1c18c733ee0a2e1499713b248140010937dc974760f0edd6b4e8",
+      "size": 63108
+    },
+    {
+      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_04.png",
+      "hash": "1354b0c9ef4fc9545f59456f1973291896fa114cc25d9f3e241c8d99464a02c9",
+      "size": 53251
+    },
+    {
+      "path": "assets/textures/home/ui/texture/champions/utx_txt_home_race_round_05.png",
+      "hash": "e12a0d854b60dae8dc51470261552ae8dd7763ff43be084ddd735e4bf646b017",
+      "size": 61359
+    },
+    {
+      "path": "assets/textures/home/ui/texture/utx_btn_home_race_aggregate_01.png",
+      "hash": "693adee11ef35a818f13486f19a2588f8822e315b73173da8a5999d8adaf5492",
+      "size": 255219
+    },
+    {
+      "path": "assets/textures/home/ui/texture/utx_btn_home_race_down_01.png",
+      "hash": "3a5c3c28abba3810bcd92a87d2f706bbf8b949860fbdf8f5a757a672effc1028",
+      "size": 161291
+    },
+    {
+      "path": "assets/textures/home/ui/texture/utx_btn_home_race_keep_01.png",
+      "hash": "ccee2aa23bdd7fb029db9ff4343288b4717dba552273e727f5e75019997d2180",
+      "size": 154881
+    },
+    {
+      "path": "assets/textures/home/ui/texture/utx_btn_home_race_up_01.png",
+      "hash": "1edaf15fda1c8122e7e68c72f2dab17fc1dd322e5b1f33ac03d8c93edfb2bc11",
+      "size": 163663
+    },
+    {
+      "path": "assets/textures/item/item_icon_00234.png",
+      "hash": "18a8d54370bde96aee45f4678098ea50cc705b7ab466f6fb0687fc2cb0441616",
+      "size": 60223
+    },
+    {
+      "path": "assets/textures/item/item_icon_00235.png",
+      "hash": "38b1a8b6cfbfcb54235fec22a03109b102a17a0f45ceb8135ef23a142ef6ac5a",
+      "size": 58698
+    },
+    {
+      "path": "assets/textures/jobs/utx_txt_job_limited_00.diff.png",
+      "hash": "44a13c8293c5506130ea06b9207f083bc96d4fa7023f25fe80b80a788d5c6b51",
+      "size": 7195
+    },
+    {
+      "path": "assets/textures/outgame/campaign/campaign_icon_l_0007.png",
+      "hash": "0c9198497d93b5be7cc66aa83c3ef7a8c27bd7e8429f0dc56c062e04fcef33f3",
+      "size": 26193
+    },
+    {
+      "path": "assets/textures/outgame/campaign/campaign_icon_l_0014.png",
+      "hash": "6767d50137c6694dd4226323fe1cf0b65174d3bd07bd9a51fcea057d4d596090",
+      "size": 45420
+    },
+    {
+      "path": "assets/textures/outgame/campaign/campaign_icon_s_0007.png",
+      "hash": "0f06e28aeaff5a895f894ff8492fbeda13468827927ab9dab6093706a1d9f673",
+      "size": 14680
+    },
+    {
+      "path": "assets/textures/outgame/campaign/campaign_icon_s_0014.png",
+      "hash": "63eb96dedf9be0682b111cc8fa8f6cbf44b9ac8738ce4b4760da08c7e2dbc9f0",
+      "size": 18858
+    },
+    {
+      "path": "assets/textures/outgame/campaign/tex_txt_campaign_allget_00.png",
+      "hash": "ea6efa868982d37716502e6f223d412f526f68ab6469023fa54e8e07c544a5cc",
+      "size": 135542
+    },
+    {
+      "path": "assets/textures/outgame/campaign/walking/utx_txt_campaign_stroll_03.png",
+      "hash": "bd258681658b3c2917fa7f3eafb7b45018fc14b832a49c3d6d8d5e3468cfb6aa",
+      "size": 15844
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1001_01.diff.png",
+      "hash": "a3a54234867e93d7ebe904cd7b7730c9f6e0f1887d1e696172f409b695ff7116",
+      "size": 1053524
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1001_02.diff.png",
+      "hash": "e4fa030b9e7fff1a54cd12ff15e98b437525e5bb4c1b7bb7f61fe6558838e831",
+      "size": 924932
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1002_01.diff.png",
+      "hash": "9942eb02167dd93c6c750ede20d4ad73b64288036bf25c69016558453d5df727",
+      "size": 992012
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1002_02.diff.png",
+      "hash": "631e5f2a8b7cd6a4a8c533d2cd00a8b956104af086cad53c28d805b3f8d7326c",
+      "size": 1188440
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1003_01.diff.png",
+      "hash": "1765f293ea4219713ec58a98dbfa3bd4b94266bac024810e6174e4fa78166165",
+      "size": 1166429
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1003_02.diff.png",
+      "hash": "7f269df077eaeb84f1c696980349b7c3d29f067bada5b048b1d9e59d4fe84c4f",
+      "size": 1290182
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1004_01.diff.png",
+      "hash": "2b57f561f6c6deeee9e73d99f32e89b4a363193120db24b9c7d63d9d8209badc",
+      "size": 1119230
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1005_01.diff.png",
+      "hash": "7b77b75e398794b5b71aa2e8946672fa9b5adf1c96811c801495ffbc8943744d",
+      "size": 1381343
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1006_01.diff.png",
+      "hash": "85b0e01653621ef788167ab0855d8a3a3a4f4e5f0188ad512d448ef86601c6fb",
+      "size": 1130294
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1007_01.diff.png",
+      "hash": "ce5d8350a482bd48a7e2c3aa2c91bf8d7bf6bf2ca80b57719e112cce8e9676af",
+      "size": 1240231
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1007_02.diff.png",
+      "hash": "37254d57b62ec9837381768c3863928681d2c6d43e7f4cf47c64e9fb8de3fd8e",
+      "size": 1009794
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1008_01.diff.png",
+      "hash": "8499e469409b6145cb101f2b553704b4210f3748bb94eba14fa2f74a3c277a47",
+      "size": 1110940
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1009_01.diff.png",
+      "hash": "fc378d5018a922423bcc6fa869e4b95702320f64c1e9e9b4d950e589e3710917",
+      "size": 1120889
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1010_01.diff.png",
+      "hash": "5317281c25db4df72dba08e1c2a30b0e58965d7ab11f90335fcd7927f1e097a5",
+      "size": 1058960
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1011_01.diff.png",
+      "hash": "dad370cec4eb0545aeff059b788751b6522857f5cbfdf5018556add1ea6c4a3b",
+      "size": 1320694
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1012_01.diff.png",
+      "hash": "b15496f7444e0ef60f11db6f6ee916253e6d149a500007f64fdf86200b200ed1",
+      "size": 1374435
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1013_01.diff.png",
+      "hash": "3f397d534e74c1df4b90027c7c93994dab03108f7e035155cf5931c9ba8dfa01",
+      "size": 981184
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1013_02.diff.png",
+      "hash": "6f9aaadfea34e3e55667bcf36b38c28320fab63f33b1b59e842657f3944a015d",
+      "size": 962308
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1014_01.diff.png",
+      "hash": "ca46f922045bae398af0616b93185995e887651fe6205cf44bccd434ecd6237c",
+      "size": 1366931
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1014_02.diff.png",
+      "hash": "83b1f17c7c182af2e67440acd7aeaf8d2993ea2f21c7f5e5df03d7f356958111",
+      "size": 1119337
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1015_01.diff.png",
+      "hash": "b496905632e5df83f775ba914956113df215040da72b7b4720a18ee7f024c761",
+      "size": 1072280
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1016_01.diff.png",
+      "hash": "70b553901d550ebb2581e0163b9dbfdad9d4f9b64d5166586d815d0214c627da",
+      "size": 1006985
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1017_01.diff.png",
+      "hash": "0f1a769cc8b7de9a2a524c2d949b0cd5c82f48ab25c23d363ba2294c578bd7c8",
+      "size": 1190385
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1018_01.diff.png",
+      "hash": "fde201eb249b29368349d1251a9c28fff7118f26daffffe1b0b6228d47a0eb24",
+      "size": 1257853
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1019_01.diff.png",
+      "hash": "a2f35ea1eed7ca1f1696e8953976da4f8eea6105d8219333d8a4926155ad720b",
+      "size": 1000628
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1020_01.diff.png",
+      "hash": "658ac190eef724d008eddf4d1ca317587b3a5d720b02dabc3931c4947e67f032",
+      "size": 1220677
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1021_01.diff.png",
+      "hash": "b7482824c0eb9b0ce80736578dcb9a4518df10ec04e817e95b33597dd80f757a",
+      "size": 1255976
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1022_01.diff.png",
+      "hash": "19f567b556eb5ac4405e6373ca0ee9fb7ef19ca2c57bfe906ba22d24e4ef3994",
+      "size": 983823
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1023_01.diff.png",
+      "hash": "2df46e3edba86af1b24607733c872481fa0a8c6fed166ad7d89e476f3683739b",
+      "size": 897280
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1024_01.diff.png",
+      "hash": "fbedf1895b05aa14c2258cabf81ba044e6f5e1c8736c676ffea4c517a6898f6f",
+      "size": 950831
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1025_01.diff.png",
+      "hash": "4d3a1791241f2f663b05632fccd4ad5251169cb9d5632557069dbb9768268414",
+      "size": 955651
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1026_01.diff.png",
+      "hash": "671221f65f0324520c01c54b7b8da3dbee931ed6fed32d663ae83ef557908cc4",
+      "size": 1249543
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1027_01.diff.png",
+      "hash": "70096c2a7a6ac16b7ac485af7ae879e8e45f09d07522db8eb8416fd4c556e9c2",
+      "size": 958328
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1028_01.diff.png",
+      "hash": "8c9a65aef546c2e179543783a0870ac96ad02d8a9857d31fe3db871da858d049",
+      "size": 1089172
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1029_01.diff.png",
+      "hash": "ceb312032f6cb3d66abf491d4219f32aea32c935c8b3ba0ae869edfb94093b83",
+      "size": 1073126
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1030_01.diff.png",
+      "hash": "6087fd4d5f3c4df7cc99ce16676bd54ba27392df2efbece0d539e6c120fadee6",
+      "size": 1222285
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1031_01.diff.png",
+      "hash": "d80ac706393a009aae49a2a5283817d2a6cf396937165de87ed2d1c477aadf0e",
+      "size": 996135
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1032_01.diff.png",
+      "hash": "cac34e196043b7337f579fbffe7f705ee8409e3ba88753a1f8e245232d8c4ecc",
+      "size": 1101049
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1033_01.diff.png",
+      "hash": "a917e3b66c53f4636b73927f42c20f564915f9c3b594f8094311b9fd93a50d2e",
+      "size": 1266740
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1034_01.diff.png",
+      "hash": "a208e43119022aa4ef59d56c1226c7574657323a27dd7a27b45a507706242f9f",
+      "size": 1204216
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1035_01.diff.png",
+      "hash": "0d8ae9fe8277610d548cf7242a01a3b69a431f1ce97d8429fdc41fb0ff260c1c",
+      "size": 1208314
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1036_01.diff.png",
+      "hash": "86df5bfd7d32a711f4d1cf0192d38bed617b6b99b71988335bfe7006ff5281cb",
+      "size": 1055307
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1037_01.diff.png",
+      "hash": "57c281f13da442ee21f758df137d42f14b79392a3d99ff5653628e38f4ffb27c",
+      "size": 961350
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1038_01.diff.png",
+      "hash": "ca6b19627a6631a9a1f4973b2eaad3eec5a7b0fa4c521ae165548b999f97008a",
+      "size": 983097
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1039_01.diff.png",
+      "hash": "7453c806eaf6a3e6f94510693a2f3f6314bfd1eccea698671ec11f444676467b",
+      "size": 1268495
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1040_01.diff.png",
+      "hash": "e124b93bb15e448f060156671c174c9fe60e471081237c5e1a93f29e304521f6",
+      "size": 1187818
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1041_01.diff.png",
+      "hash": "00f79df75be3b360cbac4bd382356b2d0bab4b0b6ec0372aed4400eb79c07d0b",
+      "size": 1091463
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1042_01.diff.png",
+      "hash": "d4b2b425ed04e21972aa06bf86e70c51328d50fb16c4ae174cabff8b4dbfcc00",
+      "size": 1162649
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1043_01.diff.png",
+      "hash": "7293ae32d688fce56e31e472bd397609eb469671a9cf77f9c9da053fae6baba6",
+      "size": 1169658
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1044_01.diff.png",
+      "hash": "85b139fbe2bbab9e3f8ebf241a640e74c94bd7bafafc928eb5fac906d332d163",
+      "size": 1122883
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1045_01.diff.png",
+      "hash": "b7353e31c4a764d34134b9b6fdcd1dd9df5ef1c739dee723e065dd7d5b298500",
+      "size": 956809
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1046_01.diff.png",
+      "hash": "cc15504ae5e36fb1871e7da7b9d9db0cd5870cead0d00029da4389de1dd6f206",
+      "size": 1127738
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1047_01.diff.png",
+      "hash": "27f9724c3d7d5f6f97de444e30e94e7f4f56efcfb5b5696af5ea8af782e8e552",
+      "size": 1270965
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1048_01.diff.png",
+      "hash": "96294556d666800e687d861eb4d343c5fcbb06b96b6ba5d506482c96687d042f",
+      "size": 1108434
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1049_01.diff.png",
+      "hash": "c8f52e8e55b64b16b2ec575fe48e291fdb3291a2b64044cece47b3829d856814",
+      "size": 1270035
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1050_01.diff.png",
+      "hash": "6034f95418e2b0813e6b037963dbf5b3f433ee8fd92d9b490ef289e471ffd59f",
+      "size": 996371
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1051_01.diff.png",
+      "hash": "760d543849e30934450fc8af6ec6dd2df2143b70f47750275eaf0ca84bcdc1f9",
+      "size": 913372
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1052_01.diff.png",
+      "hash": "dcd14e5a2ee3bb91bdcd327d32f90ab6adc56738eb1949a8114e09fa7c5adf1f",
+      "size": 925408
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1053_01.diff.png",
+      "hash": "d88a2e1fdc071ea200da5182124b5e812be993f1774165b229aaca335325b801",
+      "size": 1183203
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1054_01.diff.png",
+      "hash": "4ca5c37eab2d1465c6ca526c4f63cfc1343788c0498a32e53eee41ad06686574",
+      "size": 1059977
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1055_01.diff.png",
+      "hash": "14ef741d09b13821ecd3c85224b884fbb5713506eaa7d7ab3969010d44d66242",
+      "size": 1210192
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1056_01.diff.png",
+      "hash": "1e0fb55a767ab955f80dc14b99876d842c62b06788e9aed5e5fcee0ce8dec6ff",
+      "size": 1234999
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1057_01.diff.png",
+      "hash": "0f4e23b4ebc4d068e10d1d7737f0222b6665a447a4b0a62b38a4f70e42b061dc",
+      "size": 1163102
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1058_01.diff.png",
+      "hash": "463d6d00ee81eb06624349da1755c4afa9ae7ee176248df7c25c91ad35f92998",
+      "size": 1222660
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1059_01.diff.png",
+      "hash": "15ce12740da0c6d9728eb6a7416c99c71616dddaf5f709e3105c2ea49cf0ca2c",
+      "size": 1120339
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1060_01.diff.png",
+      "hash": "fc81504be1eb08ace8081acc1873b10f91c895736703edf1415cf86afedd803f",
+      "size": 1116357
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1061_01.diff.png",
+      "hash": "45e4f9222c36d1f206c4a261e92917ebc62d19e4f396f6aba265c7f3768b0589",
+      "size": 1120825
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1062_01.diff.png",
+      "hash": "3ba32053eda833898bc5523d425ce7e706e5d254b1a53e6585646c3719dc39af",
+      "size": 993163
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1063_01.diff.png",
+      "hash": "5e130603f095ac5a5a0a50f493873763463feb8c2273f618f9c7b31af9059d3a",
+      "size": 988935
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1064_01.diff.png",
+      "hash": "da9908fddb6f752db568540c0ff24c79a0edcc0b0fa62d080012e48e2d7aaf9a",
+      "size": 1092120
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1065_01.diff.png",
+      "hash": "b47a36a8779fbc9e56d8a0edf7d931dbbe169e2c20aabfc07d20dab0d3f34478",
+      "size": 1077816
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1066_01.diff.png",
+      "hash": "534eafee1e93eeae12f15faed42cf0c6d0ca6a5217d706997d9016bca0490dff",
+      "size": 1182413
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1067_01.diff.png",
+      "hash": "acd2058ca075857fbe794ba1f0a2bfe116878ca71b0123830620f048d86da7d5",
+      "size": 1141112
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1068_01.diff.png",
+      "hash": "b2bb6c10eebd35412910675438c579c601d3eb9be3779099e7b9c778ee037c7f",
+      "size": 1355347
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1069_01.diff.png",
+      "hash": "f653ebb885fee64074da385e57a605b27140ce7cc6deb6b36c38a2441368bc53",
+      "size": 948826
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1070_01.diff.png",
+      "hash": "44c3120427b82a640154b9b70474995dfc65320e798af2b5982c0b7d02955f6a",
+      "size": 1202212
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1071_01.diff.png",
+      "hash": "2fa7ce72c0d12d9cf24589ff69f23c27d27632ec29b7c2abd81ee3552c29bee8",
+      "size": 965657
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_1072_01.diff.png",
+      "hash": "ccc6bad73d2d7286be45077a3cb5c1a89ed0c2429440bd3c88c9684ea4cf8d4a",
+      "size": 990607
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1001_01.diff.png",
+      "hash": "63cdb75014882cf7baeebc22d46a86fadb12f2d45b0800c57d06b1bbadd1a404",
+      "size": 191514
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1001_02.diff.png",
+      "hash": "8c860b2660394438661ee0d7bb7427b89585c1ae10dc92c6b03dc955de918fc6",
+      "size": 177429
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1002_01.diff.png",
+      "hash": "81a1e03cb5fdfa6a9bbb6c4587fc348ebcbbae187cb104c278083daed82093dc",
+      "size": 187910
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1002_02.diff.png",
+      "hash": "7239454fc1595077cf69130cf4aa30392e1919b58a13150cb258a4d8f8d716c4",
+      "size": 225548
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1003_01.diff.png",
+      "hash": "3b6384e3ff1ba1ab818a9f0a08b1dd5af3eb9165adf7fddf37cafbb2fa30da68",
+      "size": 215951
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1003_02.diff.png",
+      "hash": "f239e5d7731ad62eb549ccca56f2e29e8a28d60c39e488949ed7510b855d1442",
+      "size": 230766
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1004_01.diff.png",
+      "hash": "471313cc61a02e998eaeeb18b38ae80e11e72c45a3134522c62957c508455ae7",
+      "size": 222649
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1005_01.diff.png",
+      "hash": "a6eb76e3487d7e7dfd23781748fe48cdd96c486e4ef4f674f4607272d66ad780",
+      "size": 237341
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1006_01.diff.png",
+      "hash": "f15502195e54b3d86720bc0532bb32ab1202e871b49680cdffaaea8469fa65b8",
+      "size": 207104
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1007_01.diff.png",
+      "hash": "680d1ea2753d1cfb73bc2a328e6f1b601ecddec8377a08fc6d838a35cc31e62d",
+      "size": 218185
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1007_02.diff.png",
+      "hash": "3dfe52a51c0e3a3ac2f8deee970dabab84128363b6de0fe606375b68e61b6648",
+      "size": 187746
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1008_01.diff.png",
+      "hash": "f9df8c5b2094fa51d3227634873038f4c6a8ba83d07711a98ea7a9b0226950b0",
+      "size": 199545
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1009_01.diff.png",
+      "hash": "1a36bfefa2855efbb84c157330965405688b19493ec56c06fbd57dd825d87ec9",
+      "size": 207316
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1010_01.diff.png",
+      "hash": "eafd9d92fd33fcdc18f4f3e9264f521819a22cdb3a4002f1fae76c291ffdc5b8",
+      "size": 200798
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1011_01.diff.png",
+      "hash": "017b43391ec344f7b787a0252122a9d79dd0fa05c9011b7e8a8ab590f1aa04b9",
+      "size": 231334
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1012_01.diff.png",
+      "hash": "f0a03f67441399346f8913e81c113cecd47a60f57763ced70435f52930b331cb",
+      "size": 232338
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1013_01.diff.png",
+      "hash": "9f78c70896ee751bcd6f6e942a4ab365c9f8ca7d1b2eee4e2e4b5d2f97961216",
+      "size": 188837
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1013_02.diff.png",
+      "hash": "0db511643168b026529c2548aa1751e149a397d8702ac76a92d4580db91968fa",
+      "size": 187032
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1014_01.diff.png",
+      "hash": "fa0656d02d8bfd05847d16c9ef9dd40b5cf3414d8297482786af706b81d39f0e",
+      "size": 236367
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1014_02.diff.png",
+      "hash": "dbb29b1c9feb3673222dda5224d051e717ac21e195bbb14390559890118354ab",
+      "size": 208577
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1015_01.diff.png",
+      "hash": "d453bc9453a4811307548a87657578681c5304180e90581fcf55ce908c1d9448",
+      "size": 210515
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1016_01.diff.png",
+      "hash": "262182773e97faaa09f00b2bf8689d3776d965bc4bd624bcc4437c9e6666da38",
+      "size": 189891
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1017_01.diff.png",
+      "hash": "13bef7e8b4461d87c933b2016bfef33f7f5bd8a525e6e094dd92adb7b0994aeb",
+      "size": 220791
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1018_01.diff.png",
+      "hash": "3a44e848461d72962248a4524f2dcb0bd4505035971e60af480a8438b8a3214f",
+      "size": 219033
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1019_01.diff.png",
+      "hash": "73ae89a6b837ceb574da503409438de7f7424d8b654cf3bf855be4e93fa812fd",
+      "size": 201199
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1020_01.diff.png",
+      "hash": "f9aaf17e1f37c233d1bf12d0207a844ff2cc7e993e67745f7af650556694352e",
+      "size": 228621
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1021_01.diff.png",
+      "hash": "c23ef1ae5029934c4b5b640a563569800a20792a5173855b98cf2b95197b7c1d",
+      "size": 231369
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1022_01.diff.png",
+      "hash": "74b991e58ccde4b91402650988c4e1fd71bfd4258ab277286995a7b8bee96ad7",
+      "size": 195968
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1023_01.diff.png",
+      "hash": "69d9437811a8ecab942fdce6b70cefe3223d15b7770c95f59b7c282f358870f6",
+      "size": 176462
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1024_01.diff.png",
+      "hash": "d245b90ad8fe09bf65f3d87115e3f6966f88e64898c05c5d85e1ae63b8776354",
+      "size": 180985
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1025_01.diff.png",
+      "hash": "ce66b3354646924fb80b2ef2dcdaf6e3291260e5f95a60bdc9a8aca47f06b66f",
+      "size": 187498
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1026_01.diff.png",
+      "hash": "3654021b89d7c388fcde48af9f86a606456b12b4fb8bc05db775b7e836df8092",
+      "size": 235452
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1027_01.diff.png",
+      "hash": "96b143a7abc4804277670293f67a8f198338718ce6607efd72b23f99a3c25c94",
+      "size": 186047
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1028_01.diff.png",
+      "hash": "d7f670c0842dee89a7fb4c60f57b7e721dbbcd23aa81fa7144733e36b062397a",
+      "size": 197023
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1029_01.diff.png",
+      "hash": "c37ae7ae3da6e790a1198e7aa8f66eca986ea507f3081b135939499c83b053aa",
+      "size": 210014
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1030_01.diff.png",
+      "hash": "9aa6db972c9431a18b86ed89b5b2f9f6b33fd86ec9dd1783f34159edac61dc08",
+      "size": 228340
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1031_01.diff.png",
+      "hash": "dcb362becb0dd2c7d6c775c001e4c30d53472ddb2db9baa66ab6492681f1ec09",
+      "size": 184222
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1032_01.diff.png",
+      "hash": "da32d3b64fe8b828280c080d6499f8eed84426a616e52ea34530b6191ca82fd9",
+      "size": 200058
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1033_01.diff.png",
+      "hash": "a0d0784c4407547d6df92a80c9041ff14a43747e5cab8575cea971da4d9655b5",
+      "size": 220211
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1034_01.diff.png",
+      "hash": "e0e1e36bd672ab27c6eea8767219472c88e11ce22f011bcf4ef2b03ccc5a3d76",
+      "size": 220863
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1035_01.diff.png",
+      "hash": "7659894f0ee15761b149dfc28a66607029853e029fb7048429b24a6d285041cf",
+      "size": 226292
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1036_01.diff.png",
+      "hash": "07be626864ababee736b221a4080c4992a4de1047289f7332c03ee08530ad88a",
+      "size": 200582
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1037_01.diff.png",
+      "hash": "bfca611127a4fbaeedcaff9da153f9b12a4b1ce7fababf64acca2f4e6fd5ce03",
+      "size": 183748
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1038_01.diff.png",
+      "hash": "c2ec3e4118a8566e0ad28e6f0f9fe8df2607a09582412279d4407747bc62f15f",
+      "size": 183079
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1039_01.diff.png",
+      "hash": "d932147214a09882544c98f3279d4a642042dc62ec4c37b29787eb31c73b0c83",
+      "size": 222228
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1040_01.diff.png",
+      "hash": "1bce559fbc5ad477f616bc9bd98ea7bfbc2ef2a20092bfd8d085ba5f832d3b60",
+      "size": 214854
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1041_01.diff.png",
+      "hash": "4d4f4645f77b3949ca4d0e24af48468a592298d0d2d12c8b708a080c2d949556",
+      "size": 203802
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1042_01.diff.png",
+      "hash": "f2d32987761fadfc54fb16dac3d728366ac4174bda98e1abd5b511729cb7f196",
+      "size": 208751
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1043_01.diff.png",
+      "hash": "829c032da9eaa4789269d6847377205ea2803a0209a164ef6a9d2d86ad83358a",
+      "size": 206490
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1044_01.diff.png",
+      "hash": "5175f777c775eb89b678a1e574a9b843dc55de00e4f9471c0a15c0e2b7cfa8f5",
+      "size": 203848
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1045_01.diff.png",
+      "hash": "f9f0dae9825cf382b0d9a56a9ab1661b388b2e3b17fec926ae8f6f8f2226a259",
+      "size": 185664
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1046_01.diff.png",
+      "hash": "8b3c72ec4a2d4388e559ec4cc20d7a61a5325ac6dee25e5159fa0094476132c7",
+      "size": 213949
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1047_01.diff.png",
+      "hash": "4a3f8f1a21f5fd9b3ab77dd4c247fe2a72c61b2e93638b2b52fedb56041ceeb7",
+      "size": 229804
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1048_01.diff.png",
+      "hash": "ca25e15e74132c893491363d4ccf53b8fcad8af6222465e827831cad7ab8fdc2",
+      "size": 206588
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1049_01.diff.png",
+      "hash": "1daaaef379bb8f2535da3026d7be4592f7ffca1db89c20e70756b3d6d7090af3",
+      "size": 226314
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1050_01.diff.png",
+      "hash": "00cb711a4a10faa554b8e29747d1598ae2b87993de690f6a3dc15eb953ed5fab",
+      "size": 189509
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1051_01.diff.png",
+      "hash": "6250c2bf8c94c289fe6362f43753e82d5c48b7c21c0007c74b363b42cfe1889e",
+      "size": 175200
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1052_01.diff.png",
+      "hash": "d88cf0f1cf910e381ae617480c792f9e48d6881a238dd8908cfb8d4f2afcbacb",
+      "size": 171838
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1053_01.diff.png",
+      "hash": "bf0378ff88df1ff35e2bcc44bcac0d3d7fbad4d7ca2a5266e300181bc5717a05",
+      "size": 216427
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1054_01.diff.png",
+      "hash": "2d0a547d99e0ff70233bb4140dadd6033b6ed6fd3328bb798c9c8d8dc814b10e",
+      "size": 197664
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1055_01.diff.png",
+      "hash": "2225e90c40c4c4562bd1cdf67951bf140f031a31ef576f00e30a797b96d0466f",
+      "size": 215856
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1056_01.diff.png",
+      "hash": "c2019463bba46f999d8f5a9fc672050a41295d128c508077fe9998043af6c7b2",
+      "size": 228296
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1057_01.diff.png",
+      "hash": "cb619307d89c26cc0f003e0e5b96a35aac97c01a77bf46c34b2e6e9dc7e378ab",
+      "size": 203629
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1058_01.diff.png",
+      "hash": "ec4dd4e5037e198896658461dcde845297f5db92b2b005dedde3bc96894b636e",
+      "size": 245120
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1059_01.diff.png",
+      "hash": "3c3b09b737a3a58686e6ca63409c48f8fa030c4b816392eaf5fa1dd42420d179",
+      "size": 217901
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1060_01.diff.png",
+      "hash": "8cde66bb68c01f540f4aed043637765894c4115ac7d1af1eb031f5001a98eb14",
+      "size": 209408
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1061_01.diff.png",
+      "hash": "1f09929679b32d0f64a8e7778c5524049845769da70ae63c85023ac0d55d8f68",
+      "size": 208278
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1062_01.diff.png",
+      "hash": "0a54efe491bfb62360fe24a14b42a761bd4413f12abfc5766df1330d8357028a",
+      "size": 186712
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1063_01.diff.png",
+      "hash": "13a1d319918f762d2d8f9f0775b8a76588308d3c02aec7ff86ffa055b34acb30",
+      "size": 191145
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1064_01.diff.png",
+      "hash": "309497ddfcee64c0d4a9ce3d4721953a238c1b0dc714c67344030fc63549e5ff",
+      "size": 200489
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1065_01.diff.png",
+      "hash": "87b93abe2f805b0237ba37b978dad45d2405ce746c60aa1e3921683bf2423368",
+      "size": 197085
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1066_01.diff.png",
+      "hash": "dbeb2b7e1bec52f61f4801555567d973c042219f587b39f81efe636cd9dbcba7",
+      "size": 211595
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1067_01.diff.png",
+      "hash": "37a627e5126f698270b0d712006eda261e055ee75a4c3b297a06fedb9a829af1",
+      "size": 205867
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1068_01.diff.png",
+      "hash": "b12eb07d2313e5e75d607f460ad183dd8643702430a8a5fc4b670b4f3708ffbb",
+      "size": 239936
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1069_01.diff.png",
+      "hash": "c83c2978464e795aff139301998e4fe57c292371f2499cd24b77de3b35ce52f4",
+      "size": 183016
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1070_01.diff.png",
+      "hash": "85b3ce16018e1a8bd9f6b627506540d14b3490cb9a72befa80389e7af216a2ae",
+      "size": 213658
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1071_01.diff.png",
+      "hash": "176caead0493826ae5907969e5b3a0ebb174b7ffb745b9030e405d9a05564eef",
+      "size": 184622
+    },
+    {
+      "path": "assets/textures/outgame/comic/tex_comic_thumb_1072_01.diff.png",
+      "hash": "dd027b79f9f84a8363ffc198e00182ae119749929c84e3cbcce69a0572efcb43",
+      "size": 186442
+    },
+    {
+      "path": "assets/textures/outgame/shop/jewel/img_shopitem_jewel_0092.png",
+      "hash": "f53ee904d2637067541f862039f83f2d813aadf5504325751e78c7c4d986a78c",
+      "size": 194537
+    },
+    {
+      "path": "assets/textures/outgame/shop/shopbanner/shop_banner_000001.png",
+      "hash": "94b81135f6ed8864dbfc1399cbefa37181013d332d33125a45e2d9ff993e7605",
+      "size": 437194
+    },
+    {
+      "path": "assets/textures/outgame/trainingchallenge/tex_trainingchallenge_logo_00000.png",
+      "hash": "21c33a12148ef22e8fbdd47b5e5cb0dc8c3bafaa941ea65076e99efa79cca59b",
+      "size": 166303
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_13.png",
+      "hash": "82ca6d29a3ca17a4f7aab6305255b70086fe2f4802f8042035de923b87abac09",
+      "size": 160284
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_14.png",
+      "hash": "4fc68fdad1eef9bd86a921e835f6b7133d6b93a144490976e7da4c0e98ee5561",
+      "size": 154946
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_15.png",
+      "hash": "2cae91d4279858d13faf7318e775d842f7b3395981c85b809009bdfd2bd91dbc",
+      "size": 162278
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_16.png",
+      "hash": "24151f4fdbb08c3bf21e772dcbaca0aef22622ed540148d7c237146b330a3a93",
+      "size": 158295
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_logo_17.png",
+      "hash": "6c0f7a84c05ec9919382ab34e9a55a8fb8f1d6d1f332caf7ca3c307404020985",
+      "size": 155309
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_00.png",
+      "hash": "1310189b277b0efabae1de9d643e91a4b72c462f736dd00adc9ea4ae7c8413a4",
+      "size": 57926
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_01.png",
+      "hash": "6e573490ba17792bc2e9bd20f707f17ec4669bea7cf33832256da00b48c54427",
+      "size": 58488
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_02.png",
+      "hash": "a98306e48b91384b45147c220a344e70101edf3045b2ffc277ce1820bb4a61f3",
+      "size": 72612
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_03.png",
+      "hash": "697b0617a52baa3316c04b1db2ebb46127146358e222947ae6b6e925f5bcb254",
+      "size": 75091
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_04.png",
+      "hash": "e0e3c3a89093ba76490c3b2fd93093b0efbbcf4287d7bc9948dcb929d983cbc6",
+      "size": 68012
+    },
+    {
+      "path": "assets/textures/race/champions/texture/banner/banner_champions_text_05.png",
+      "hash": "d76d5cf94b8c5d3c868348a5a115fac668abfea7763384c1c51bcf725ac1343b",
+      "size": 73173
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_13_01.png",
+      "hash": "918cf2262f8dee7c169eeea8bde4a40ea1f527ae13486bcc121e013d32651ed8",
+      "size": 568864
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_13_01_s.png",
+      "hash": "d047da0bcefc6908691b25b0eff821b67a5e8213bf2194798ee0dd3171a94666",
+      "size": 192423
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_14_01.png",
+      "hash": "305ccf22386d56322c5a7317b90591066366bc0ebc22152ced2488a54b32246f",
+      "size": 421632
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_14_01_s.png",
+      "hash": "027c12085e6ff7c0389b98325b2f52377d1533e009f4f9a5bbd9ef918f60d252",
+      "size": 142736
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_15_01.png",
+      "hash": "c054767643cb1d579f0b861500c43f59d14bb2a032b56633e34b04c0e40dfb7d",
+      "size": 570996
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_15_01_s.png",
+      "hash": "865a3ed38d68314fe315eb9b9c075f8bbe0159227ad81d1672e0730ac8c8a81f",
+      "size": 194026
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_16_01.png",
+      "hash": "e16c3445a477a4e8e0a8fa1089760333039ed22ab8093d954d6d0eacad51687c",
+      "size": 470095
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_16_01_s.png",
+      "hash": "b6d5c560f6731b2e957c6820a3f0767ffc972b2dc31551c99297bce781fa781d",
+      "size": 158930
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_17_01.png",
+      "hash": "ecdb7990fd393a5fd7f5149aa88f32284b79de41e25d6590027e5430bb13e8b6",
+      "size": 473396
+    },
+    {
+      "path": "assets/textures/race/champions/texture/logo/tex_champions_logo_17_01_s.png",
+      "hash": "e65c2fd124f10dfb0c2d8798b8e7ac99b3ab1acba3b9e2a8b7319ce91bf45736",
+      "size": 161660
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10001.png",
+      "hash": "21b3f2859025fd0b3f5f4385466b0987265fa97e85025bbfb6471e299bb1d94c",
+      "size": 11864
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10002.png",
+      "hash": "f15e4533771c5cd51aeba1b43d1a99267c018915611e6651818b5c63e96e3761",
+      "size": 12074
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10003.png",
+      "hash": "863b497bbc449093eddef67caccdc0929edb3fb92ce0f59786d65e9ea7323ace",
+      "size": 11196
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10004.png",
+      "hash": "1c46c243db65e76945782574db314cef8d2e1ecc91b46599ed89b17be7d222f6",
+      "size": 11690
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10005.png",
+      "hash": "5ccd7b789a1d01cd41a04affab2ace8daea961b085e55033d5fb7871b981964b",
+      "size": 12531
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10006.png",
+      "hash": "e31759ba52ef712ee0a347e07a9af89d0900964932f9a943ef47089529bdc67c",
+      "size": 11571
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10007.png",
+      "hash": "185926fead280ad212c4e56bcd1e78f00b63a7c716308f6756f75065e4879c3e",
+      "size": 11745
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10008.png",
+      "hash": "52593dd5e4cd9f81d73270effd69892651730902943be3e4c7e185187a24b92d",
+      "size": 12816
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10009.png",
+      "hash": "e1cc46677c00546c80e6b1cb1fe706be502c9c4438c4b192233fa6702d5b843a",
+      "size": 11639
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10010.png",
+      "hash": "9b1eb38385bbf50c45d9e5171e03ea985e0b5d6496a0ed21fe28b476591a804e",
+      "size": 12871
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10101.png",
+      "hash": "e8a12c5322a63e1bb5bbc4718e02fe5c0f73f0ee4cc44d5319dff753f40856c4",
+      "size": 11293
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10103.png",
+      "hash": "523472fe747338d7a973829ff4f5352693bee00cb491bb939bcbcfc965aba2f8",
+      "size": 12733
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10104.png",
+      "hash": "6d7839e3e268b69b91fa6b5b4d1eb0aefef9d71d294cf642242201fcb7a718f2",
+      "size": 11237
+    },
+    {
+      "path": "assets/textures/race/courseicon/course_result_icon_10105.png",
+      "hash": "0541b970cfd48fedbf58414d40bb1451d236ea5d8d65cae43a41fd7f1127ef38",
+      "size": 12431
+    },
+    {
+      "path": "assets/textures/race/daily/tex_race_daily_00.png",
+      "hash": "981e393c880f6991d75b1e66f59e05cf2b5bb58c3725ebe3cb4df554e7ca47a2",
+      "size": 329395
+    },
+    {
+      "path": "assets/textures/race/dailylegend/utx_txt_dailylegend_logo_00.png",
+      "hash": "82cfc360e7fed2003351dd6659aae331b2a5ebe59757b550aa4427e29e4dc426",
+      "size": 391037
+    },
+    {
+      "path": "assets/textures/race/practicerace/tex_race_practicerace_00.png",
+      "hash": "09e058cca45a95ae10128f3ee550ff3ea94dd4edf28af3da834dbe032d39cf1e",
+      "size": 429175
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_frm_raceinfo_logobase_01.png",
+      "hash": "a215e6ed6b0f36aa47970053e35bac53dbb4afeddb34043a69a786a4b48c7203",
+      "size": 184003
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_frm_raceinfo_logobase_15.png",
+      "hash": "90f5129d25bbb2c0c2d87034353281d61922fc88b9b716c71d721b096c3a0508",
+      "size": 186346
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_01.png",
+      "hash": "63870d5ca840558e2d35384a329e306941f18b4012b0181dd29f6dd609c7b408",
+      "size": 132875
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_02.png",
+      "hash": "afb38155d60a8e7c32874b1b462028adf6c3e2cfc8abb035717ab135897470de",
+      "size": 146235
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_03.png",
+      "hash": "cef014572309801cf2333bfe1f104e548789f8e6a97064d15a9284e55dc009b4",
+      "size": 149669
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_04.png",
+      "hash": "fd91bb4502531d03de8c20c27068a58c0752ef4ebe90f5e9d5858a65b6514b43",
+      "size": 139935
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_10000_05.png",
+      "hash": "d94d6ef996c203e81ac65483dd424d9f7546b26d132558cb2f21e8dbe1c75a68",
+      "size": 146815
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_11001_00.png",
+      "hash": "6b71ee9866544a0873824b70161d3e0f9500af770601e59e1807878f9aa1cce1",
+      "size": 194243
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_11002_00.png",
+      "hash": "b249ab1d60dd315c8cb0c65808d91e724d190238d53267eea271c6c239ba591f",
+      "size": 228212
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_11003_00.png",
+      "hash": "68deebf6f6ff60f2c9b6d3b61d85c54aa0e575081f4937b3d03038c84cdd404e",
+      "size": 213080
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_12005_03.png",
+      "hash": "58808d6f8809ee18c977e303b312682aea9a2669ac0870ea85394923f7bd1cc1",
+      "size": 191696
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_12006_03.png",
+      "hash": "0adf3dadab518ae18bc802bf9a042f482505007a4cc5ec26438e5b847157562c",
+      "size": 258446
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_12008_03.png",
+      "hash": "fb1e09202e52b8888429810ff2374ce884f1dfcd7660a7d65331aedbda0a873c",
+      "size": 177646
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_12014_03.png",
+      "hash": "384beacc4b3d0e21c5e3bff63a8e6b53b1afe2a070fed560cddbdf29b99bfc91",
+      "size": 303524
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_12025_03.png",
+      "hash": "46fcf1e4de868edc95c5011f3e1d8f71436edca0fce42b9b3cbebb0a38f74de2",
+      "size": 284264
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_12027_03.png",
+      "hash": "b3e6096279b33ddf853e793fdc18ed7676738aee0b0da9c546d1a8214b7347f8",
+      "size": 214636
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_17001_00.png",
+      "hash": "b9d6e14089ec686e7064c47da4fd96b3401226a960c0e1ac3df9b715f2e51291",
+      "size": 362730
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18001_00.png",
+      "hash": "6af2c6e2b5fc7382aa5d26fc240948fe5ff56914f8fbf9bce2420c49982e23d4",
+      "size": 161770
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18002_00.png",
+      "hash": "3aab692f92dcf11a18f3b2dabac7e0e97af079230eea1fe956b599f13c7e91f3",
+      "size": 263737
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18003_00.png",
+      "hash": "d5884ebcd701f12fc79a53f187fcdf53540c9e9a200bd2b1017e29b30f7e91f7",
+      "size": 179779
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18004_00.png",
+      "hash": "307d7023bb8a82b2c618d7242d82d9fff5b067527d589025774c14f9b363257d",
+      "size": 265154
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18005_00.png",
+      "hash": "d25331a6a9999022da34219f90e9f330b2136cf2e9ac80258ef6a948ec3306ea",
+      "size": 150089
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18006_00.png",
+      "hash": "5810e640c35dd6e84953b5547f3c058ef0fef8585eb06dbc1fa580216f612ccf",
+      "size": 177774
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18007_00.png",
+      "hash": "381db8f21ade629853d9771a638a5e12fb7517243c72c52cc467f52d86d59eef",
+      "size": 178918
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18008_00.png",
+      "hash": "f68af582fdb4d0f0ed73d485cccee9f2a62acb8935e206ceac946158d2f2c75d",
+      "size": 288906
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18010_00.png",
+      "hash": "6895e9eed9a933fa19910b628bdf3b4f565466b08480bdfd835de1f1108e2021",
+      "size": 230912
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18011_00.png",
+      "hash": "2ab0ca1ab412e7115c693c27fff7ae1076d1dd40cc1f18768eac9bf777ecc59f",
+      "size": 144035
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18013_00.png",
+      "hash": "d5177f623b5b41b53b4d3b31b615e170cb467c19e69481118d8a0aebfd59b7c7",
+      "size": 224717
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18018_00.png",
+      "hash": "7fe1d934e5faacba62408397864cf2a91aa1f656495eb28003aed860c2a0ac70",
+      "size": 249445
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18019_00.png",
+      "hash": "970f0a4fdb4864dfe715f2e4b31d2db7592ce64662010cabb478148209cf81c7",
+      "size": 205823
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18021_00.png",
+      "hash": "dba356c922037a2cb0501d46105c562aeaee9878e8b6940b0ac45593343eae07",
+      "size": 146432
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18023_00.png",
+      "hash": "864f5d124044cd0e8884265491cd1af36b29b7de566598ef454fa5075049f114",
+      "size": 228324
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18027_00.png",
+      "hash": "1847ec86e78eafe3891eedf3f92d881d6b56fa26b8f6ae4911d529b30c43c0b3",
+      "size": 267424
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18028_00.png",
+      "hash": "7215ad0c8e8522fd60ab4c9c66277153ed6c10644f3f05bf331b409ca9113859",
+      "size": 161596
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18029_00.png",
+      "hash": "be40d254795f6a8fd083980d80eb6b05405163464da03f6346f64b7f7227be6f",
+      "size": 238715
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_18031_00.png",
+      "hash": "fe8ec3a23b595e99c36eb5109f87dac6fd3d0dd62124711f40fcb7d3fea01afa",
+      "size": 173391
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2001_00.png",
+      "hash": "7aca7e6720b6b7c51ccabf56c8d3ab14bfe7791831152403547904f72806c287",
+      "size": 222434
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2002_00.png",
+      "hash": "57a2503aab1a50f8e081429719b6b00330d5160a753d604835ebd89e8e190289",
+      "size": 164225
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2003_00.png",
+      "hash": "75240a2b5dc33dee719fba8c5061d19b76e6cf6afd87203822746cae26e1793e",
+      "size": 246273
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2004_00.png",
+      "hash": "c511bade05b35770e0554afb15e3d4765d7994379bfec7d26fee084dbae0e4dd",
+      "size": 145891
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2005_00.png",
+      "hash": "9f88b26ea701efaed96d336dfec896ab2ae9846efd8337f98b7e2789f942bab4",
+      "size": 305698
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2006_00.png",
+      "hash": "4771b07280ab908dc6d23544efb736dd08181896145979c4796530e6b8531e09",
+      "size": 142663
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2007_00.png",
+      "hash": "adc42f97138f8ef40607d78798497dd3e2989fb42cd66a1e2be21f28b397998d",
+      "size": 157768
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2008_00.png",
+      "hash": "41c8f6a263f0679d1f63031bb8abb6c6f9d5ae19c622fe2c238cba20f925382b",
+      "size": 162733
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2009_00.png",
+      "hash": "c385588026b2c7c6e6b5800e9781d7c691c8d967064d024967ef5a1c641d2bea",
+      "size": 250239
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2010_00.png",
+      "hash": "a6d1ee5be73ad1d6bf199ed7dbb1a505b2f4edd4e7f700956ea73d33d40ab979",
+      "size": 219788
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2011_00.png",
+      "hash": "1963f89a47bb09ef9b0a8f667af91c27d86850d7459d82fd6ccb565e08a631da",
+      "size": 154978
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2012_00.png",
+      "hash": "f89c4415337a044c3bd64b691acef6148d6de2cbb157ef12d98e1537bef151c7",
+      "size": 268450
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2013_00.png",
+      "hash": "6b92dff0d500c870701792b6236f2db68075518d1b5759626de6485801ac7378",
+      "size": 340152
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2014_00.png",
+      "hash": "28366be158a0591ec89d39cd70bf576257d53eabd4ba10ade64a07f764ff79b6",
+      "size": 282569
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2015_00.png",
+      "hash": "1727a121b1fc14545e9da8d55a6b878228a92847d67a227c9e29387ed6efea72",
+      "size": 201653
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2016_00.png",
+      "hash": "4da67c7a686343db8182612d532e7016c1915d6f68a55073e783adb0ab5dc19e",
+      "size": 154787
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2017_00.png",
+      "hash": "2b0486b7728c38bb0a40e828764c30c98ce743031831f36cb6fdd2d411a8b5e5",
+      "size": 258658
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2018_00.png",
+      "hash": "998e6bed68dbb654a6aeba0faf569f23101c4a3be08ca06e93ad14faeeefae2d",
+      "size": 272681
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2019_00.png",
+      "hash": "69269f7a218c0b5b43ef0b9c44ea49ac53f00af9fcebe87307a1442a5e71e715",
+      "size": 211155
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2020_00.png",
+      "hash": "5cba9d02770d6f61c85a3d9cb6768917d3d8cdbec6532b015b1dc34b520bc5e2",
+      "size": 185942
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2021_00.png",
+      "hash": "44037937ffe1e5c4f92cc275e28a2343a09867cccc61ad0152b360e8dd8dd480",
+      "size": 248316
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2022_00.png",
+      "hash": "e49a26db0f6479ba4d450d27ae4cdebde2bc566d11e5de807a43a3ac864b935c",
+      "size": 190851
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2023_00.png",
+      "hash": "af4d69eb13c2a1995050b6cf79225856c87ae558a7862989dad66af0b9a7761b",
+      "size": 163510
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2024_00.png",
+      "hash": "060085a2f75643918f633934d559f89109e1f00514fbd1cc2da3cd9ba964fa3f",
+      "size": 259426
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2025_00.png",
+      "hash": "79f6b2c76efa009619de9f1c6ded9cebe9357dd2c3d0b3b1dddeaa86a5c00216",
+      "size": 316288
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2026_00.png",
+      "hash": "e8add020481a2cd3bb0d52af9fe605440a92b7fd7cfa64adbcffe7d85e352692",
+      "size": 221945
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2027_00.png",
+      "hash": "2d77dd4d45fddf3fce2a634e522766b37fcd0a31f26c6e3543f112d571055b0f",
+      "size": 235280
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2028_00.png",
+      "hash": "4ed90be9fe5200ebe507baed4a2b19a5db69f36697aad6d18403543bed0f821e",
+      "size": 252459
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2029_00.png",
+      "hash": "c79db6e5bcc7bb2aceb18c48cf3f54e837b897da50fe533b4b9a4825110f3fa3",
+      "size": 171008
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2030_00.png",
+      "hash": "fedd1213d4a0af2df52635639e3ec67810998fabad14955f02f6c2da0fffa957",
+      "size": 392082
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2031_00.png",
+      "hash": "04099d23410f9361ffd38bc41e743dfa36ab7637d3d897e2140cb7751b9c0fe2",
+      "size": 314458
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2032_00.png",
+      "hash": "b949b4a319a21fc5893fe3beaf985d64aaa3c0dae0fcb3e9ea9a79826ab23c61",
+      "size": 373154
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2033_00.png",
+      "hash": "cecf176addcfd6dc1b5894fe2ffefc11c9ddf9ca92672e7eb2644bf9df498e52",
+      "size": 252013
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2034_00.png",
+      "hash": "789c01c5fb9f8e3e0ab8337cf747590883da232ccfa50e7ec081c19f28bf3aa5",
+      "size": 178135
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2035_00.png",
+      "hash": "7ae8d6481e8734e3eb3e4a884ce4c1768dc09ebb1bafa19cf124121b6cad4331",
+      "size": 219788
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2036_00.png",
+      "hash": "60c6ff637276849062c485b9add91a438b42b2be07a325f051959294aefaa3bd",
+      "size": 199217
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2037_00.png",
+      "hash": "ab5b2107c890632f61c897fe0dd058d52d10f0b2e681c3da7754b99bc7131dc9",
+      "size": 139217
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2038_00.png",
+      "hash": "fa5d7f988639b9c19993a5cd4fe8668330213d49b10fd92cbeddd9739b131b85",
+      "size": 173558
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2039_00.png",
+      "hash": "d7e4392b9a64892ac18feb2dc62d7b186f12d87b4d9f3648ebb0b7e498f78930",
+      "size": 195461
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2040_00.png",
+      "hash": "2ef35f77b7062b174b27d90bee5865f326dcb9b652141db9dbe2fd25537a384c",
+      "size": 159151
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_2041_00.png",
+      "hash": "5a6ada1c707d440bede635fd188f9a8f0630b4988b7fac20d049a1a83cc4df2e",
+      "size": 265729
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3001_00.png",
+      "hash": "582a7a39ccd9791d4a0374696d888ed47d3a536e167dd3fa8c5bc99119ad6e6b",
+      "size": 178868
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3002_00.png",
+      "hash": "84718f99fb02a020126e1b3ca02a4771307ef46a5c5f25d72161daba002f0b38",
+      "size": 220610
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3003_00.png",
+      "hash": "f2598cbbbce4b9483a29f2f9d81f7d5a7573fefaa55b51df39e77e07a5fa560c",
+      "size": 203172
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3004_00.png",
+      "hash": "3aa9c872612c6cae4eb02416179bd9c0f281f55e0a256b8da44eabf9588d7f80",
+      "size": 193220
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3005_00.png",
+      "hash": "fd7d89534aea51bf18803cfa50b59ef17c73ec5c3935c8d55a08b8b2d4e4b274",
+      "size": 130994
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3006_00.png",
+      "hash": "10d7ee550417e4adc1a814de92f6f07fcf310114d905e6ed663b85defcbdafa7",
+      "size": 132145
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3007_00.png",
+      "hash": "8d091395aa4eb8343dc1a72123264124335c7e2a07aba28963150ad697f925ab",
+      "size": 278203
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3008_00.png",
+      "hash": "594f86e1704809721fe821214616aae0a2fb5a5f67586a28f9b7b679d7da60cf",
+      "size": 235581
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3009_00.png",
+      "hash": "452cfdf04636867e6f340b15928d0f3a73f382a3466a615c150801ed468242bb",
+      "size": 212360
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3010_00.png",
+      "hash": "f5f18728f2123bbfff76e9771b271201b808f51e352079ec686359d0f9e2d962",
+      "size": 252280
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3011_00.png",
+      "hash": "ce24a0f97fa58f8fbdb7b3e8ea4b6bb0066a51a7f9ed4420817be1d5bbaef4e9",
+      "size": 344186
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3012_00.png",
+      "hash": "f441e48080fdd5d10125098b7a816ecd37a92dde9dac5ed21f3af07dc8cf068d",
+      "size": 241067
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3013_00.png",
+      "hash": "e00ca21ccf556e812d503d7097b8dd587180da97d8f5926dd00f63df86070ad0",
+      "size": 252355
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3014_00.png",
+      "hash": "6da53afb89de36c0f6a5cc49167f905b8c893b990e1bc2772ecb28869aff28e5",
+      "size": 263546
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3015_00.png",
+      "hash": "2e5e0fcbcbb952e1c229538c656d745c2a2cf8e5793d164f1de5d27b8c5dbc66",
+      "size": 287024
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3016_00.png",
+      "hash": "438b4428adc8a2e25e58d63f69dd5ba5448d83ce2216a61c8d613e29270726dc",
+      "size": 211064
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3017_00.png",
+      "hash": "1afe696968b729b86a21d7d4c26de413fbf9351af44c88c421c1bfe5d11ca2bc",
+      "size": 139726
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3018_00.png",
+      "hash": "960fef827a91fc620809c87a2ea3a4a568d7c3d08feece10f1f6220d709b7634",
+      "size": 145350
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3019_00.png",
+      "hash": "8bab03758eb66618635eaba7cd045b73fa4d253a456597994f79a511fd7363cb",
+      "size": 250444
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3020_00.png",
+      "hash": "c64a237dc21b0d02d808b815a0e82a4db35849086da1c8c6f85d69b336d1520a",
+      "size": 327115
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3021_00.png",
+      "hash": "8c6df85d6733ce54430162c88c89fe790c36060468ae49064a434598f698726d",
+      "size": 238003
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3022_00.png",
+      "hash": "da9a1c8ec8cba4aa1e8b6b8397cea8787553202b392a877211e0eb491cc5436b",
+      "size": 184801
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3023_00.png",
+      "hash": "9a150024b14332e01e908e4815b732e4e373515ce3777bf9bd06d50428473286",
+      "size": 166795
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3024_00.png",
+      "hash": "25aafbe20e4eb4eebc6be313994038abf66d0f9f1607485b52e235b1c00e62ee",
+      "size": 239084
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3025_00.png",
+      "hash": "9e3b099f147aa110d19a194ea39c8b5e8549581294c69c9b6d5497c4b24f33ef",
+      "size": 268055
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3026_00.png",
+      "hash": "4659f2c068c73cab838019321f441bf5cca287ebdff5074d64a2ae5710cd67ad",
+      "size": 250655
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3027_00.png",
+      "hash": "88486f921b644faebb25b5507bd5fad92ecef3820a2a5b27140d93e1c4273c9c",
+      "size": 320394
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3028_00.png",
+      "hash": "73fac33bff75ec8c6b13c31280872e2528e80651667cc07c4200fae941aedb38",
+      "size": 276417
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3029_00.png",
+      "hash": "0ac61a1276c02d3693df326c6b4591043de7c26c925bf6b2e0ad8aab63a601fa",
+      "size": 187512
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3030_00.png",
+      "hash": "e2038333b8c8731e866e58e850f2314fab6c5f36cd89623e4844b99360371ddf",
+      "size": 205084
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3031_00.png",
+      "hash": "07fa92005e25e904c58f44a04055e2a27906d03b952310fee6631d3e8d850fc5",
+      "size": 266709
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3032_00.png",
+      "hash": "39af7bece35a9a0631cfa36712bba24689de4a92c2f4b48b19dd8b6f7d0fa17a",
+      "size": 181134
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3033_00.png",
+      "hash": "d9619ff28d90c078b03f85a3aa0de3abad47e7c91bf2b5900b41d2d3e4b944cb",
+      "size": 239771
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3034_00.png",
+      "hash": "f451344ccbd4bed802a1160ca009d08ffd42a5ae68076ea6ac59bd8355657a21",
+      "size": 367344
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3035_00.png",
+      "hash": "b7b087a2b0068252df86c52af878725da79fa0aaf559d1925297c7c5c7367376",
+      "size": 155525
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3036_00.png",
+      "hash": "f34398e021d9c53f800f82677997deb53c547efebf04276052f52d2fc5093f75",
+      "size": 242115
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3037_00.png",
+      "hash": "8fab6a036410a365810d6f4996a630af08da12f7dc6bc1c83d5232c0a7baf7e5",
+      "size": 247682
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3038_00.png",
+      "hash": "0b9dfc50831a6b0fe804f824eade900316fac49d43c91fe2e0f494d7ceab5150",
+      "size": 169696
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3039_00.png",
+      "hash": "bd49272bdb65aa8a5d718e3a5bc56b2b13eb5b3fc4ccdc74633d252f74ccf222",
+      "size": 209540
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3040_00.png",
+      "hash": "12973b2889e35edd35a8e9e5af97abab2dad6c5611b1cd567cd8848474108dde",
+      "size": 203837
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3041_00.png",
+      "hash": "38e4efba3e3f2da9ce0a24f3258d3068e8c7a4a0396467f4af8cc4375d896098",
+      "size": 362699
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3042_00.png",
+      "hash": "209678abb9e188d9e1f8f296ca69ef5d8756bfb64e4f8302f8a8cae0eeb02cc5",
+      "size": 286036
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3043_00.png",
+      "hash": "24f7016701122f5f34c329eb8b2d9eeac3728f138027541b9c4c0d0f0ad87f5c",
+      "size": 199816
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3044_00.png",
+      "hash": "4e00e41d100efe8bd08761b266f4006248f1cb72bfdf19da6f80b13c9ed1f25d",
+      "size": 208556
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3045_00.png",
+      "hash": "3bde1a4c46eb379d7ad8fffdb5679607ae971bdb0e906f58fe26255ab7d982c2",
+      "size": 244716
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3046_00.png",
+      "hash": "a76e1ea450b0afeb57871fcea824d22e9ac93268ec216b426dff339798ed65d8",
+      "size": 188194
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3047_00.png",
+      "hash": "efa2593d8d91c70b7a75f75a8c04186572ef830dc9645c99d68ca5efc6fa7075",
+      "size": 193601
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3048_00.png",
+      "hash": "ff42c780c2a1fc52123eb3d9991c95ee7490ac29507592bf4ec904b81a0ad42c",
+      "size": 230267
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3049_00.png",
+      "hash": "794e0bf1a2a25ec680afc7d692fa09763f7732129dfc61dbcc50937df6ac96ca",
+      "size": 331843
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3050_00.png",
+      "hash": "937b529f0683ddf5583495eabf93a0ec7509dc3332a00a7294fd2689b865afd3",
+      "size": 190360
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3051_00.png",
+      "hash": "1c209efba5f5674eaa9a55d451bfb8e40c38f1ac42761444f6853f03af5d49b6",
+      "size": 417591
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3052_00.png",
+      "hash": "d6d9797ffbfa77f172fb13e3067e4cc7d95c3748d568c29f83c2412a3ff9801c",
+      "size": 352930
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3053_00.png",
+      "hash": "6302171d633909b8d87f735eab26189f4df5769ec7a8e35c5a699c603a96f6ca",
+      "size": 177876
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3054_00.png",
+      "hash": "973295a1dbd31bfeafa11acadb1fd17038b443477c73faa9f2ef7af2e3ef320a",
+      "size": 185661
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3055_00.png",
+      "hash": "9ec7ff9ce050912f1aa5e10430199019241741ecdb363209bb7f069ce2d84238",
+      "size": 266248
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3056_00.png",
+      "hash": "e6769bf3343b478e8085307b45e980b21f07c1786e2376f679b2dcb0e4b524ed",
+      "size": 184002
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3057_00.png",
+      "hash": "d87b1e35afcba43421ff845f414f215f3f1bfb3c907f1f9593bc5cc6bfca6007",
+      "size": 327017
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3058_00.png",
+      "hash": "5a519d8cea4841f99c67d8897af01a986be310fcb4f85e9c04ce61335d198e3a",
+      "size": 187122
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3059_00.png",
+      "hash": "9cd6941b30634b32bf4f3f8c74cdc9cf1e4be5dcc76027987b6ef198056b436b",
+      "size": 248975
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3060_00.png",
+      "hash": "96e025a9f45d6b972563c4b635ae944154bee72c1cb18aebac1cc68f7ca23639",
+      "size": 229634
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3061_00.png",
+      "hash": "a765a7a3b02079a8ee3491d181436a043d6da1189a816c0f072802efa619667c",
+      "size": 248786
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3062_00.png",
+      "hash": "dbfc335dc47ffb280e4d6a25d295a50582a741ad01ecccb327f9d675da8c866e",
+      "size": 284458
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3063_00.png",
+      "hash": "73efb7b088abae90cdf40cd613a9e49530b87f2af7d0babeebc51eb5c2c7c9f1",
+      "size": 218616
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3064_00.png",
+      "hash": "90ca50605d067fad5e48a2a3db4f0516a4b94aafe0ec24d62ddaf60b0ee5550b",
+      "size": 349741
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3065_00.png",
+      "hash": "351d97f022724c6f36967b0de089dcc78375aee96d627fefc3d63fd4e53be5a6",
+      "size": 330399
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3066_00.png",
+      "hash": "0a9481cb17a7520671dae00995b66adc5d8ce589996337b7639904d38ea6c89d",
+      "size": 141704
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3067_00.png",
+      "hash": "49777ef35387e54df01acd2f23f908c6e3efbebbc814cbb8196b59fbd9f53b6f",
+      "size": 211953
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3068_00.png",
+      "hash": "52a21414398a2dd409d7aba1301a16e46395aaed1b23bd90005ad485a0119096",
+      "size": 288058
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3069_00.png",
+      "hash": "7ff9d27c66e58ab6cd36752327cec1429396364a8d228d7f674254c6c99cb68e",
+      "size": 219881
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3070_00.png",
+      "hash": "2271f907c106a31ae96c34f1155f82a30127be7a74e872805c993a56cdd1c45c",
+      "size": 263055
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3071_00.png",
+      "hash": "7c89ec29e4a316d04289c3576e9e03d7f8187239aec5e0eec563566b9b9c3479",
+      "size": 323592
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3072_00.png",
+      "hash": "c6519fdfa1e4307df4d82de2c60527be376109939ad74b8cb0c182c0f0d2f4a8",
+      "size": 236305
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3073_00.png",
+      "hash": "403fc2a16d9782be7722a3aada8cd5202aa7b72f8363f9465ec4413d31d51e30",
+      "size": 282453
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3074_00.png",
+      "hash": "d241ad7f4fc6579211dfeb055333b0bfddfc5e3e2875870805946e45efb60ce8",
+      "size": 201886
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3075_00.png",
+      "hash": "f12bd7c4fe0c3e58bdf54394d5b5aecfaac74d235c149d4c3168e8ba1f2f6369",
+      "size": 195868
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3076_00.png",
+      "hash": "30b3c67714202b85f0e6f09edd05a37859965662a32f14ea79fb0e0ec18d6812",
+      "size": 253236
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_3077_00.png",
+      "hash": "171ab3b40acbb86103dae58c995ecdc88005016132c970eb2175a62b4d5c628a",
+      "size": 162821
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4001_00.png",
+      "hash": "a750e58e976756212280db6c74523ee45beb5f5b93049a4c58b1701310c4d303",
+      "size": 230831
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4002_00.png",
+      "hash": "7f8d064c473bf603894c40c1f05c20e5b86e0e9527b20be26df8fb5cefb29c93",
+      "size": 166147
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4003_00.png",
+      "hash": "a282ee03237365ed9ba6ae7d61faf06bf04a008a0e7e751e87bea9bae7c974ee",
+      "size": 289557
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4004_00.png",
+      "hash": "3351405732c409d7ae93e25276443346454e260e1e6c5d64b242387496e99697",
+      "size": 220279
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4005_00.png",
+      "hash": "08469ba2191fc6d5f087d6851ba8ce59b9399861d898ccf668d9e44d38676ead",
+      "size": 267392
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4006_00.png",
+      "hash": "dc516f19530954ff98551678957a15c576c9f561043cb68e8f63b60f9e53cf40",
+      "size": 254310
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4007_00.png",
+      "hash": "1f679dfde571c77f39f4f9f7875be949baa4c702075744dfc05e306b02825e2e",
+      "size": 205717
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4008_00.png",
+      "hash": "dc5a7be679c62eb7f8351ff646ac4a57f46e08e9b410d2186cd7cd70e835277f",
+      "size": 225757
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4009_00.png",
+      "hash": "dd4a1547d9f8fa477aeb88970dcad897f42532f798f494455d981c2d0b7de06a",
+      "size": 276409
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4010_00.png",
+      "hash": "36509e7084819a0e6bdb6491d4c569d30d4a4f6bff30934b1fbd4923124ec2c7",
+      "size": 281304
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4011_00.png",
+      "hash": "d07c2db8666dde6b2e91492800d0f1a45525a8ba011f58e9a6c04fb4e76c5eb8",
+      "size": 248051
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4012_00.png",
+      "hash": "3d9458130a214ad8542041e0a13ea316124c3caecf8278a3f862b4ccf2d4490c",
+      "size": 251825
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4013_00.png",
+      "hash": "e44bea50a62f11955c5843e78883e3253f93b5dd9fb3a28550a6e555f1f441d4",
+      "size": 227483
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4014_00.png",
+      "hash": "a115313a217e7c30d46fc2dbfebb6ab1b5a77e5b0cadc4a0f65f9b788dba240e",
+      "size": 170555
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4015_00.png",
+      "hash": "4f6fb37095efd604d024e91ed930fe16174c3a2ec8262ef7455edec954df6126",
+      "size": 242052
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4016_00.png",
+      "hash": "1b87eed4e064c255b79c870350eac76487ba54d0d28925ec467c46dfc0704c94",
+      "size": 253696
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4017_00.png",
+      "hash": "6c974f1b2fc7f97891dd8379b8d7f2a3be25e8c7229a2330db9481acd1f7d193",
+      "size": 226815
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4018_00.png",
+      "hash": "6616b08bc78aa60638d8c89b0b58f50e27b1caed80ba651c8748b05e05cf66e7",
+      "size": 245659
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4019_00.png",
+      "hash": "e0637cee99df4a67853418e9d8a828d7b102228f35e4e06f8251335d6ff36eda",
+      "size": 194886
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4020_00.png",
+      "hash": "c8499f08a3336bbbfea0a991bb7777fbd3d10b54b52fa53ef0e79f4f7ce5f421",
+      "size": 235665
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4021_00.png",
+      "hash": "a3784a861129485bede57bb0cc667a84374ac2350521d54f2863748f428d027b",
+      "size": 255115
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4022_00.png",
+      "hash": "aedcf1d1beb672e42469f3a626c3c87808c5a48572038b28e6ba9051b93f9e4a",
+      "size": 234564
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4023_00.png",
+      "hash": "fe79215e21aef09c23fd671d932ff63bc0dcdd34f395aaec030255e011f91a26",
+      "size": 234006
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4024_00.png",
+      "hash": "3ce73d59edac77644e45c9b217a93c7727aa6222f37800c0c93bb3ffeaf180fa",
+      "size": 231354
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4025_00.png",
+      "hash": "b130b19d49ede3b105e0581e14f61f439f18902108e425c14dad3d3b4f844538",
+      "size": 242330
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4026_00.png",
+      "hash": "c0ff88a52e70c9cf9848c83065f62f3f13024fcad9f4dea3369ce23694d298c5",
+      "size": 222443
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4027_00.png",
+      "hash": "4c2f491d1527c319f84a97944d6705c7dd07adf4be9b13efe0b014f4a1b58c54",
+      "size": 224940
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4028_00.png",
+      "hash": "d8c195191495e912c5bd79e376d21e80f0bf40ca6d8ef2d8dcc8070f74676e75",
+      "size": 183996
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4030_00.png",
+      "hash": "61492fd4c401322c307a411b17c34e97abf669c7409c748d27a5d23179fd481c",
+      "size": 200464
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4031_00.png",
+      "hash": "92fda422f1acdb81a4ee47836ed7edbe4b7be84a07f73d206e739b0f32ef2be7",
+      "size": 221750
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4032_00.png",
+      "hash": "eb46d45fa778bde28089fd6445f674ede8250da545122d495187d11ba720aa8d",
+      "size": 269685
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4033_00.png",
+      "hash": "41a3d94ad6da8d949da01fdeddd338ec9029f06f2c34db1a874ea59fa63a74fe",
+      "size": 213396
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4035_00.png",
+      "hash": "749b4adaba325d32a3d388868c5b3658a6b3f230a7973118db1c50d8a3be77bf",
+      "size": 307599
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4036_00.png",
+      "hash": "8f635b579ba80817442aa3c7fb1172f9b712880f6d204343313a599aad543c58",
+      "size": 210003
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4037_00.png",
+      "hash": "3d070ea008d2c2fb86b1793c774a45fde87e24348eb74c3886eb808e5528b3de",
+      "size": 239985
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4038_00.png",
+      "hash": "82b9f46f5a861b6c704be75f99531d573e3f11358f8436b1a7de06b93e34eeb3",
+      "size": 284304
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4039_00.png",
+      "hash": "c50efc4861dbd3dbdf0daa9705815d76883934cf9ede9f37ddf1f96abccd2881",
+      "size": 234331
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4040_00.png",
+      "hash": "eb0fbcda0f45dc77a3b4754e0128457a1f03707ec21098ffb095b141bf524097",
+      "size": 177707
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4041_00.png",
+      "hash": "ce733606be1ee448a10973a67fa4ddc5c9b6e43f024f6c764295418db6891373",
+      "size": 228643
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4042_00.png",
+      "hash": "18d49c71b5072df55d2fea640df5ccd12c0c5cbf1cf1714624b4c8aac4c772df",
+      "size": 220146
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4043_00.png",
+      "hash": "925cc9e2ec333d780ed3d24939f332ff42222fbaaaf3ec2008e82aedc4d4e305",
+      "size": 250385
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4044_00.png",
+      "hash": "2917c63a333b1391330608de283140535fbf81712311766e30a36dab10e15e34",
+      "size": 337946
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4045_00.png",
+      "hash": "8847be432544843ab41c2c2c79aa4a8dcb254d2fa5c0e372115bb73687ae59d0",
+      "size": 244972
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4046_00.png",
+      "hash": "22e87b1e20b9c8dddb6cfeae886c21b2f9ff50696e2c3606b3b1e9f6d2a76225",
+      "size": 343852
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4047_00.png",
+      "hash": "8aa26f9643eee4bd13fc840a22271b390ab571343dd73fa5a42241741db147be",
+      "size": 230916
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4048_00.png",
+      "hash": "22599fefd0cb62267c396fca426e720516faa57ffd693252bb51cbcb7e0a2d9b",
+      "size": 228158
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4049_00.png",
+      "hash": "031420fb836ec36e8177bd343aaeb8e1d0c802df2013297b71f00531cfe5b0a7",
+      "size": 288593
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4050_00.png",
+      "hash": "1b520787dab88c3bd78361c338bd1fbba6a1b3b23138aea6cdedc7109a420dba",
+      "size": 194420
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4051_00.png",
+      "hash": "bf6cce298d1bcde5560bcd6ae7ae3df723f3537a6d5bc33d38418cce80b91b1c",
+      "size": 175598
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4052_00.png",
+      "hash": "cc55a81e7a29542bdf9d44c5ee986f22a1564b306fae9464fb1e1d810e00d72b",
+      "size": 225215
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4053_00.png",
+      "hash": "63d9c312714c103eb8dc55b532df5dfc681604e3eaf31a93ea42cb75015db96c",
+      "size": 177466
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4054_00.png",
+      "hash": "c39caba69101c26a13d30f7804a626424bdcb73e37345488c49e7ff9f5ddda25",
+      "size": 181647
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4055_00.png",
+      "hash": "9c55f8d1b5b364d6ce7b7eb69bb7a76878683dfda7d1fed3e7a52ec8613ea702",
+      "size": 211397
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4056_00.png",
+      "hash": "c55d50d382e72300c8b5e4aa27bb5e1de024a77fc7d29828219095d1b7762ab5",
+      "size": 243705
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4057_00.png",
+      "hash": "a9e9c68b76f7d2352b86c54bcfeb55628c2fc57947c44d93fbacec57ac80f640",
+      "size": 222981
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4058_00.png",
+      "hash": "6333830deda4b2b95e66cedfc17ae4330ac45371dfda81d6a3cd274c58dadfc2",
+      "size": 258004
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4059_00.png",
+      "hash": "2c9adda7f022acb511cd7a6c6a6a7da23092835a6ca21f98764abcbb7a39837c",
+      "size": 232979
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4060_00.png",
+      "hash": "bcede8484d00a5b820b4384338bc726b41fb2481a68a849ce10c31a31f11026a",
+      "size": 261470
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4061_00.png",
+      "hash": "7109f59894c0cdd1e7247bdc5006917dc0c82042e9d2c92c81deb7aa5aa925a5",
+      "size": 232884
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4062_00.png",
+      "hash": "78caa4d85e09bcccc9eaf5d14b1fa87a1dc4c57128c2144621c60b82028effc6",
+      "size": 234078
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4063_00.png",
+      "hash": "94e545c2e4488f698f1e11137a7dab7812214aa844ad59ec1080152e25770af6",
+      "size": 238295
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4064_00.png",
+      "hash": "f1ba807fe1f3aae516bc4faab781716790e9a56af087902033ffc0a3c296d847",
+      "size": 139013
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4065_00.png",
+      "hash": "ae300bf5bfb561c27ea472d881bced8a3cdc9c7c3cf0da73ba55c152b8397aeb",
+      "size": 232476
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4066_00.png",
+      "hash": "281ac4449bc91cd783c548834bfeba8359dfe5b2fc0cfce28ed0ebfe1e881029",
+      "size": 184469
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4068_00.png",
+      "hash": "3fd1ae083d1e2d9ab44d7cfc1b80a7a1a6bc80111d18b91c5f201e35491946ac",
+      "size": 378776
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4069_00.png",
+      "hash": "05c24ae52ecddd2d1a55fdd1dda58798722084dd4e4a5bc35358f8124fe2447c",
+      "size": 313145
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4070_00.png",
+      "hash": "13b237156d34c25147d67b538277501b5c9e86c03dec8b5d26e132e0b170a964",
+      "size": 151827
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4071_00.png",
+      "hash": "2f398347b4647a433deadf5f324bf41ac924b60664d6ce2fc11ebe6e5e799401",
+      "size": 313714
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4072_00.png",
+      "hash": "344b06a9a706ff050247654911c0369dddb80b9f9cd747fccf5c786a204cf829",
+      "size": 138819
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4073_00.png",
+      "hash": "dfe6ac6ea387567863fd2f483be6d27a5c8f0c431217c54337c094441641a934",
+      "size": 185063
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4074_00.png",
+      "hash": "bd19325b8fbc5b1ccdda6f344f07a7fb49f4077bf0c5aa7100c02b44faa58b1e",
+      "size": 170953
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4075_00.png",
+      "hash": "3c4e537714fddbc3a6b41c28330a5ca8477801b1ed80ebca78fbcde24e67f93a",
+      "size": 173242
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4076_00.png",
+      "hash": "c14c17722fcf359152b809ce4e1f71a2427229d9b09750d0355bb378154a2cba",
+      "size": 135896
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4077_00.png",
+      "hash": "8cc82a13959eedee031c1aeb2d3c4a9e5ca9034f756bb91f3aa6a17900a60770",
+      "size": 168639
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4078_00.png",
+      "hash": "61b7677db00901552adfaacd9589b455edbc9ef8f3cd550e62ef388a2a19599e",
+      "size": 203595
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4079_00.png",
+      "hash": "992ce754f84197af0ebac5cfb4cc3eccc25f92cbde712708d318a0fbdbe7869e",
+      "size": 133788
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4080_00.png",
+      "hash": "3dac3ade004e203e7bda20f8fcaee2f930b7c1efed253377d0cbe47400481e7a",
+      "size": 319648
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4081_00.png",
+      "hash": "358aa85835dc565956a45eb28154263b1571b86a9bd9e21391ca6c717b1d8f18",
+      "size": 128552
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4082_00.png",
+      "hash": "c21e54cd9660326771f3556b488713aab962c6e520cc40f68832394bf910dc0d",
+      "size": 234183
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4083_00.png",
+      "hash": "f43229fd6c7130b6b0f370a169d4f362d387965df80e04fedd432c8c0549c23a",
+      "size": 168094
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4084_00.png",
+      "hash": "ba835215059679d3195b7529d1790a06749fc127ad29cbb5113f97e36b53d5b9",
+      "size": 179781
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4085_00.png",
+      "hash": "8d23f0ba0b46976ba7eddb256ccbe46ea903a074af164eca04444946c354e2b7",
+      "size": 253351
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4086_00.png",
+      "hash": "a80ad9ce808fb2c3aa08b0a46a5ecc22fb393a877b5285e8cff527fe7f832138",
+      "size": 322295
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4087_00.png",
+      "hash": "b06ba722c8b198459191ece83d0948a50b354f04752ce649689b50bdb4b44515",
+      "size": 192798
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4088_00.png",
+      "hash": "e177747794ac7613b987933f42e5b38b7349a015eff9035e99837873c44a5670",
+      "size": 209303
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4089_00.png",
+      "hash": "9ace2f2ba4d51ea9d27d761ec44b41007bb6e2b57ac2090173be42a559710d8a",
+      "size": 238598
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4090_00.png",
+      "hash": "28e05f7f13d46945e937376c8ec700146645d6a655eceb30d3deef6659065af4",
+      "size": 278830
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4091_00.png",
+      "hash": "e6ba68e2922e8a94f5f1b728e3185769d6ce1428fafcd0474644184aa0e66e71",
+      "size": 191466
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4092_00.png",
+      "hash": "958cabb6f38f19067f9b77e72d05e985f77035facd1edbbc365451440a7f929b",
+      "size": 262790
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4093_00.png",
+      "hash": "f2e42cd84065dbb9304d3821c96082aab4823270ae2a7a6b1a315fdd86476c53",
+      "size": 230876
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4094_00.png",
+      "hash": "5fc591b06b6436fa7524d3d6623ec8256f00679b788f9824665fa0c86d3ab7e6",
+      "size": 257675
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4095_00.png",
+      "hash": "6f1c5740094d24d13924648f3ead0344a72b6eed4c7c8880cf3b97ad9bac7b6f",
+      "size": 248074
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4096_00.png",
+      "hash": "94f32d95e0c3df2253c6b6726f1833c70db7a3566ed14d31e9bb3d91ecd619d9",
+      "size": 163376
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4097_00.png",
+      "hash": "7179d2489a13638e2d9502f0a10ba41dd64c6da4d1a3f598f7649a062588b7c2",
+      "size": 296263
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4098_00.png",
+      "hash": "634b7d41ecc87e3671f1c838ab2af8c4704809e4ba0f8de95bf85f213a1045f7",
+      "size": 172646
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4099_00.png",
+      "hash": "4c00b3f0075596c01e29b7c0e7a0375eaa7640334e5fa522a391ad659c19da69",
+      "size": 182665
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4100_00.png",
+      "hash": "b7efc39129bf694ff108573b44d29293c41b32f323e11c0ea2cbc7bd5a97abdb",
+      "size": 256065
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4101_00.png",
+      "hash": "9477028d2128b0fe8890fe2297c0539dd77e7cbd8b4a06e41863256cf0beefda",
+      "size": 343452
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4102_00.png",
+      "hash": "368d4ae3d5fd585355dfc001d6d52b24712f9df216591fe381f52767eae703f0",
+      "size": 135261
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4103_00.png",
+      "hash": "6c7329d335fc81f19e73323990ec0230938644dbe0c4bca8e59c6a251de0dd7e",
+      "size": 414093
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4104_00.png",
+      "hash": "6ee8198a1cdc7c4891c8fba9cb0ff546881c2fec28273a53fe9af0903f40603c",
+      "size": 279402
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4105_00.png",
+      "hash": "e3f4caed4a2df19aa70f99bf17bc01c14c821446d501a0b40b60c4c944f7b65a",
+      "size": 282024
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4106_00.png",
+      "hash": "77b9145b9e3b2b6d0190cbba25b6f16f306c3dd9f487396aa3b4d377f2e1f979",
+      "size": 281435
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4107_00.png",
+      "hash": "efcab9b89a50005ce9ac0cb6d87d00709907d5bc42094a8d02fff094475c4c42",
+      "size": 211949
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4108_00.png",
+      "hash": "c1d2a7f8a6c62239826a156e9fb685d61f8f098b34c6cfd0f7ce61b22d460b0e",
+      "size": 300329
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4109_00.png",
+      "hash": "33fcaca32917d15903e5c0fa5e0a80b4ab64a356fbcb88f5561968b5e616375e",
+      "size": 235811
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4110_00.png",
+      "hash": "5a7027e08fff1930013d307e50a04eba324dafc74b252d2822ba40f6ee98004a",
+      "size": 257107
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4111_00.png",
+      "hash": "022fa11b247f20d1ecd7657946ab291e327a5f8c9d7f49720132271c87ba87cf",
+      "size": 197808
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4112_00.png",
+      "hash": "b007f1eff4937b7e366690f1888c9d9d82871ea7f75c9f5b382c5067a1774249",
+      "size": 220351
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4113_00.png",
+      "hash": "85f29461d860166aab22bb68f90fc1091b1f95eaaa6ee03b847c30f87d23874f",
+      "size": 251064
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4114_00.png",
+      "hash": "0b1bd78531d739581871d1a6a894233055b82d211f1d2cb3833a67dcc2c2cddd",
+      "size": 331942
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4115_00.png",
+      "hash": "912566e1d00983f2ef329aee397a77fc7a7489d9d2e92acfef6148585ed33eb6",
+      "size": 222507
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4116_00.png",
+      "hash": "081368268a313f6da2570b96b79a18a2b9769cc50b0f9b2fc95e21e101fe381e",
+      "size": 247140
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4117_00.png",
+      "hash": "3baff1c35957ec072f9ad6a17ff5c08ce9ce2bf1d06bab6129e1e574de4e782d",
+      "size": 317108
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4118_00.png",
+      "hash": "af312b6bff8ac0a3d0ab51115f1af7bf8ef4a61d1d1325578c7f05766ac05eb3",
+      "size": 296062
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4119_00.png",
+      "hash": "e8a74d03514c450815d34e7ca46356497ef22507d52c0d701f0ecfb45aa01a71",
+      "size": 227027
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4120_00.png",
+      "hash": "44eda9fdbc0e3562f7a3a777a35f11106f5d1a48b896d93fcd3870cf91889574",
+      "size": 262749
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4121_00.png",
+      "hash": "d50ed0d2ab7023e18f641d1204a75734b45abbe477a0bb74b7a729d8e9c17176",
+      "size": 246693
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4122_00.png",
+      "hash": "d6bd79e4505ac8ddba3641935ca7334caf8c0436746f4dde799839cd57d30c72",
+      "size": 265376
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4123_00.png",
+      "hash": "aa56da9ab313acb3f96a7ca002ab5d9fa24a14ae892b4dd224bb672a6b70bb19",
+      "size": 245484
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4501_00.png",
+      "hash": "e7419f3e0ba90f37a577818b60a372b6911ebb9b107830400530388967e4ac8b",
+      "size": 175064
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4502_00.png",
+      "hash": "a3da8e9c65d0867f685d8c60fa6f75a52f238911adf85fb0c9d73a2491018758",
+      "size": 149175
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4503_00.png",
+      "hash": "3782a3ff613c4b2956b1e87a6af75675f8db678d71e96a6c727739e09c24bc1e",
+      "size": 157040
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4504_00.png",
+      "hash": "1aec6f977f18c0aebb99e5756376cc09919ce6dbc150f8d3a6d7295db6ab3990",
+      "size": 154417
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4505_00.png",
+      "hash": "39689bb5b22645759f8997291a1baed03765c96d6076b9fa596ced3da0e29d33",
+      "size": 232585
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4506_00.png",
+      "hash": "2187b0bb81ac410132a14d768a7c05dc84f6e70bc3c5dea7b7937118206bfa64",
+      "size": 236238
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4507_00.png",
+      "hash": "85d0058f0caf97da1d977315375a24adb173518d917f4c4a91a7a8fe2ed145c3",
+      "size": 410515
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4508_00.png",
+      "hash": "79f4fe0cfa678c73287e4daf06babce976738755e087c38283819d3b9f866084",
+      "size": 313334
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4509_00.png",
+      "hash": "39b042e5049e3529eed829808815b5806f3ad508f4f82060908500f8a12e2433",
+      "size": 196593
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4510_00.png",
+      "hash": "f08ff01f319a7af22e4eb9fb5429c476cba45ea7f5f87d4fe09395488adf03e3",
+      "size": 181187
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4511_00.png",
+      "hash": "31314479029a640d7767049101a79ded542d6aa80b21dd9f5e418d8d0d0bda08",
+      "size": 218716
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4512_00.png",
+      "hash": "196bc7079a1ae66f6b33b736a47125e25d3f6cd7cbdd3b0fba0d72a03105b0e5",
+      "size": 217825
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4513_00.png",
+      "hash": "7b0d7a2b0d45116c07a1d1312a9648e3f6451f12b54f73288ca5ed870604d40a",
+      "size": 231519
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4514_00.png",
+      "hash": "ae728011637b6b1586e0765614fb562ca40e7cf12b4cf5db2837f2462efcbbd7",
+      "size": 197514
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4515_00.png",
+      "hash": "c7318e1880eb828d80ad589640aab6df514543f1af69b3c9eb2a77e58155a114",
+      "size": 196385
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4516_00.png",
+      "hash": "0677b87251ed4b856cee15fc6df723eae152bf76f7183360de0759df0422a17c",
+      "size": 220895
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4517_00.png",
+      "hash": "4e669f1a0c12d314e14c0ea6374bea356ed99903dc02cd380680de2e53f22dc2",
+      "size": 229927
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4518_00.png",
+      "hash": "9a3865ac1abc1cb932f68b1d73c9b413e6c96af5dc598c6691150527e5b29158",
+      "size": 216094
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4519_00.png",
+      "hash": "6c38afbba8c9d3829b09abe5b716a44b297de8982b17107a94d5e83a8e5d610b",
+      "size": 198626
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4520_00.png",
+      "hash": "93a33c759cce5d4350968e438f22a317c9ba43040343adad55934eeca0353df5",
+      "size": 242476
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4521_00.png",
+      "hash": "4855beef340c1cb8f053b1c50c241291a1cdfeb6b8ae0bdebfe6a6f63da22781",
+      "size": 169778
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4522_00.png",
+      "hash": "1beabca4a83f81e4f59c4ee01f543a4f51d9c2ef8cafe2eb0badc7d567c5bf54",
+      "size": 222706
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4523_00.png",
+      "hash": "a214507952cff34aa78b1f6df5774c210a56b61ca6237d605b762846223b25db",
+      "size": 158484
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4524_00.png",
+      "hash": "4980e40948d8a82b43b7c1a87893194cebe9819829209ac4b202f610e1b4e72b",
+      "size": 166829
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4525_00.png",
+      "hash": "674d686af975928dabf7ea5f2cb73877619eb876a15a5a663ce7fa3fccf3f9d8",
+      "size": 230581
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_4526_00.png",
+      "hash": "7131d19b8f4e138560b5f4c10085540217541ecba6f440f8b566e79ba6d232de",
+      "size": 159525
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5002_00.png",
+      "hash": "4837785bead724385dfbae240ff34dcaca9e9cf8f999900ca12e0bc9977a3b01",
+      "size": 128778
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5200_00.png",
+      "hash": "ac78fd9e72913c59d4c5cd77d3c94e1d02cd7513cbeb7bc02299e783abb604d6",
+      "size": 189417
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5801_00.png",
+      "hash": "f5e25bac80907729105bba04f580fe734e4c4c8602dd48af6006404a3cb2c8bd",
+      "size": 264632
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5802_00.png",
+      "hash": "a9e8943ea14ca47683fc90e28a5b8b8a6f62b5365198fae9e1f533d84339ef72",
+      "size": 313687
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5803_00.png",
+      "hash": "86ad9fc6bfedbad4f012fe368269eed6e0ac552fb42219420d091dd3e436d0ad",
+      "size": 265946
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5804_00.png",
+      "hash": "d2227391322923ab4e3e5c0bb1172872897c53b4a182e0dc3ed9c10844107a8f",
+      "size": 326829
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5805_00.png",
+      "hash": "def48dcacca4934882365c9c1c0f9f9d006a0aabef3a75c34e53bc9eb89a0c42",
+      "size": 319227
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5831_00.png",
+      "hash": "9c4c312e3274a2a518ec5936d0065d4e595d461cbc7ebfbc7ce6c466b4c617ed",
+      "size": 204497
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5832_00.png",
+      "hash": "6bcd3b8b56ce19f7813ec205bdca233ee589f556c598310d895000e540f66344",
+      "size": 254234
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5833_00.png",
+      "hash": "b1d464209ae94d0ad1eb93d7cd405879c78faa027d26cfceb738bf9563b97238",
+      "size": 205938
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5834_00.png",
+      "hash": "958f281673d451dbd7b9e516089c427ced6e4be1f81210e5b9c67b9d53e3503b",
+      "size": 266622
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5835_00.png",
+      "hash": "53fae09fa40ce5d24074f94d36b8cbe7e59ccb3743c02a262c6c88c56ff0f475",
+      "size": 257947
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5920_03.png",
+      "hash": "28681374ff840865155decca20a2050c708ef46caa97a4494f2c7d0cb2939846",
+      "size": 195067
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5921_03.png",
+      "hash": "721ecccaf10e6557f2e1d744ca71a874e2f085be227df26e421ec76ba75dae13",
+      "size": 195067
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5922_03.png",
+      "hash": "c4cf36b5909c054bcdc46067047ac916d9639b12790246b4939c933a46514d1e",
+      "size": 195067
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5930_03.png",
+      "hash": "6a061cff6ada69bc36eb2983a04b9ba805b69ad94d8b109173d45901d136b31e",
+      "size": 259139
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5935_03.png",
+      "hash": "1119a1bc03c67edc708f02d61393491d43c5d6042ea45a000c31abe7a2769b70",
+      "size": 228746
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5940_03.png",
+      "hash": "752c1bcc264632634c5548cb1cdfd8bf915ea2f0a9f02aee92965351e066f7ca",
+      "size": 237758
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5945_03.png",
+      "hash": "cbfe93783be740ffc9811d26073a4aeb0d154fa9adfa27c47c7b3b0a954ae2ba",
+      "size": 273463
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5946_03.png",
+      "hash": "cbfe93783be740ffc9811d26073a4aeb0d154fa9adfa27c47c7b3b0a954ae2ba",
+      "size": 273463
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5947_03.png",
+      "hash": "cbfe93783be740ffc9811d26073a4aeb0d154fa9adfa27c47c7b3b0a954ae2ba",
+      "size": 273463
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5950_03.png",
+      "hash": "98a1ea26aa8f4dda9bf185973c7a4aae0c9e02e370934e14b766b12269e4e0d6",
+      "size": 230250
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5955_03.png",
+      "hash": "130826053ff80a105e63a9e4f05579a38368990aa55c88785c1440d8a573b54a",
+      "size": 227341
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5960_03.png",
+      "hash": "d1e87453d3ba123d79e12efc31250df0843066f2fb1accf270fe741256261b4b",
+      "size": 219839
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5960_04.png",
+      "hash": "20a8ad2c4550b137793e17e177c5354ffb21f310e6d573cc74f434edf95c9f99",
+      "size": 278916
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5965_03.png",
+      "hash": "6d3baa03cb9955fc5029a2486ef0a8874cfa4bb7aef32e70b6da9dd9a5b011f2",
+      "size": 260875
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5970_03.png",
+      "hash": "73bd68fa604f5621945b04365bd8ce52ec6a1266433948f670ca3341b25f8a71",
+      "size": 198221
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5975_03.png",
+      "hash": "ce35d240475d90586f592e11d17d386b091e1964b35595f7ab1a308e210196d5",
+      "size": 230516
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_5980_03.png",
+      "hash": "e33cadc4f6299a18abb8da6c27d956687064d9c61134ca6b0c6c3cbb41b67536",
+      "size": 202448
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_11.png",
+      "hash": "a1f01733ef9ac5c154802b8b57545f154f42962222752aed5ce9b699c90bffca",
+      "size": 286824
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_12.png",
+      "hash": "b30a1e4210e2c8b5e7994ed9e6bf873be1a8f43fef65d9de16055f647f6c0bb9",
+      "size": 295021
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_13.png",
+      "hash": "d03ee71947a2c752494c503c2e564288f60a1123e4917eb62d4e157e4da37fe1",
+      "size": 296759
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_14.png",
+      "hash": "ff45192b506df5e29dbfef3b3412dac26d326f890ec06d4fbbed8439e6d2f82b",
+      "size": 289728
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_15.png",
+      "hash": "3ebdbd0320f060d4f809bde4692a172cecda2a618911ebbd523f2147603d67d9",
+      "size": 295036
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_21.png",
+      "hash": "1c202c0c9bbd429eb9c9afc2d42ad523523ae5fcdfbb5acb0ed535175205ac29",
+      "size": 296424
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_22.png",
+      "hash": "b9ba426597af53b9fedf88139516f324b357a96140ffe234f64b93b548874348",
+      "size": 303987
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_23.png",
+      "hash": "64b404d6109686924958172530723d6e692ff1afd2987662df5c230a481ebe52",
+      "size": 306042
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_24.png",
+      "hash": "cee5c01827d0b8ef63319791a5ddf16881fd17ee74b0320c9caae37b911d3ef9",
+      "size": 299287
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_25.png",
+      "hash": "144d93c2ec0cba706d4e54147e57ee4bf5d618ec74e36f87ae9159b7d6fe37ce",
+      "size": 304190
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6013_31.png",
+      "hash": "f41f2896c178563f73c7bd8d525d2b43aa13f06a087401890653e35435944a8f",
+      "size": 201888
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_11.png",
+      "hash": "ea79b035d827273cc15c59fb5a2ac0fa9a6e6a3909e39204ba0e5abca61e8548",
+      "size": 240777
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_12.png",
+      "hash": "e5580a4018e8d4cbadf760eec5e939e8e53806ca789b133a55c8930d24f89ed0",
+      "size": 249434
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_13.png",
+      "hash": "1204bc9af6f118d7e59f03612e3d72db5b3066f02555884b9c5ce12ba8c665f4",
+      "size": 251216
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_14.png",
+      "hash": "3de4c812b3e1e28c0a0aaec4cd8bb98a9c2c58ee2ca87356efbb9bc85ca3bc94",
+      "size": 244026
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_15.png",
+      "hash": "13b8d9648917ce95152b367465ca64d8c19ca33da83f3f9b18c6d8bf75576bf3",
+      "size": 249472
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_21.png",
+      "hash": "7bce0412fbf8119c2ff0af8d4b66c1b2e4bacc8086c59cad7850e627308ab7fc",
+      "size": 250844
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_22.png",
+      "hash": "af2f76be0973a6d08f5a2dd54d40ef1edf8d95745733476450a83cd7cbb0f8b1",
+      "size": 258832
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_23.png",
+      "hash": "fd480a9bd1e14c7e04b8eb3b474a950dc91af5ce1dc11be1ab6a895a3b29314b",
+      "size": 260735
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_24.png",
+      "hash": "8d22d01ed14d4cf766a575188040a9e858c2e527f862e0391239288c32beb931",
+      "size": 253730
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_25.png",
+      "hash": "36c01c509e216a8ff8832afedf9299a23c1c752bc00b8bda8ff5c914e5916fd4",
+      "size": 258974
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6014_31.png",
+      "hash": "e00d53f4ee1d97fab6d2a56050daef39a0a5c8284456cd786afc46ab2fcb3b62",
+      "size": 156397
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_11.png",
+      "hash": "b7f50b91e622a2546d7db4b258da73c4d8d5545df1ed0ea3861d7b0ba2807cbc",
+      "size": 317098
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_12.png",
+      "hash": "4a8f43540cb8e1e555c4e91a969a152b393fb25e8dddda874e98b44a115c2e27",
+      "size": 325302
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_13.png",
+      "hash": "32a50f09d4eae5e6b16e29d264e4653ff73829bc7510066c16d919f852007e2c",
+      "size": 327043
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_14.png",
+      "hash": "6add14aa925f424cc64e8e53c04d78b9a6fe4fa2a9e03490238bb02f04f6746c",
+      "size": 320024
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_15.png",
+      "hash": "e0d07fba4fb2e7f9d39a007c4f08ef27aed0c2d26888a24c54c0669fe62aeef2",
+      "size": 325320
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_21.png",
+      "hash": "edb3f645bf68bc2391f1401922c1dbe46895bffb02acbfab682258eaaedc4630",
+      "size": 326704
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_22.png",
+      "hash": "877db2ab1a033a044cee77f3b083b4a82ae325f0f8b0cb372eda539202f1aa95",
+      "size": 334306
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_23.png",
+      "hash": "60d6cb05239c47c62057de794450dbeae8935cb19611f1eeaeeaf14628690ff2",
+      "size": 336343
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_24.png",
+      "hash": "13e52915321d298fee6f093c7805bad1a3bdadbf72c6d28e707930691393eddb",
+      "size": 329571
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_25.png",
+      "hash": "0c4c0b392683ec0b47dc6a6bdef14ce733c7b802069f7ebb213ddf9e38673d3d",
+      "size": 334525
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6015_31.png",
+      "hash": "29768d64bdeeb611e16dc1b74b88b38e17fd5436354f057f6fa63f158e5eeb71",
+      "size": 232201
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_11.png",
+      "hash": "ba6dd30021fa02c2431b6030b3e1d63be7d4778374d02f7245a74200813670f5",
+      "size": 268551
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_12.png",
+      "hash": "ddb248bca8919641d03a0f7e30009431dee30565074b12bf2623de9f1305c562",
+      "size": 276387
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_13.png",
+      "hash": "f7375951a818d051cf453436495adb10a21614d322fd9406ec5a84f3b6038acd",
+      "size": 278226
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_14.png",
+      "hash": "89f12ba5e542ce8ff869244a0146f53cf1835f294b5020f8864e1321635c9e59",
+      "size": 270928
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_15.png",
+      "hash": "6fccf5ac8850a06a01cdde46de4d8f368c913d72164fa532222baf9668b69b8c",
+      "size": 276454
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_21.png",
+      "hash": "fc2d73c4ff87c12d0bcdd32a2a0ba6da55e8a8ade389a8181a59e808ec0e4c6d",
+      "size": 277806
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_22.png",
+      "hash": "61da8abf4cdc09602aad4e940929340504194855db79799f0e5c304285034e3a",
+      "size": 285853
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_23.png",
+      "hash": "e72a8f13fe4e0a858bc496a5e501eb62bd033d5198c53484887cb1043c4db72f",
+      "size": 287729
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_24.png",
+      "hash": "3e74b486ab62fa3f7ce6ab124d4e438c2e1a8fdca2bab09af724574b488c7233",
+      "size": 280710
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_25.png",
+      "hash": "059ed87c5a9d9f1b5476ad535b31cf56ddc4cbd78d3561add76aed2434a05caf",
+      "size": 285988
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6016_31.png",
+      "hash": "bb27cfa6554b2f1c5d7ef128c0ce186a3d2f1ec9f0022c82ba2c3ba46899589e",
+      "size": 183398
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_11.png",
+      "hash": "82fda9971339638dc99f7ffe6e4387c93541480b434d50a46947c0bd64303913",
+      "size": 246563
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_12.png",
+      "hash": "231b347e7a370a3d365a24d9be8e22de8c845c7a56c019f26872811ea38a5aef",
+      "size": 254808
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_13.png",
+      "hash": "22bafd294368fbd01ec87796c89fe38605a111cd7e9afdee0f25b580054c02ee",
+      "size": 256569
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_14.png",
+      "hash": "0e1192df2cca8e1302ab5394e7e2ea83bc92e16e8d6c887ce2f747cc421683bb",
+      "size": 249548
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_15.png",
+      "hash": "d17fb4aaf651b89b3de600d544094497133b156af2cb099903e493eeef0df13d",
+      "size": 254779
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_21.png",
+      "hash": "9c9baa742f56ef2f78449914a88958552e7e73882cdcdc7dc8584c980ae0dc61",
+      "size": 256256
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_22.png",
+      "hash": "2fcbff0f9c963c7a91ac0f42a17334930d7873da8da30bd7be6446d3d382ecb4",
+      "size": 264258
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_23.png",
+      "hash": "78b615f4d5323d2345799083d7fde5281deb99ee8bebfc68e9296cdc25b94471",
+      "size": 266159
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_24.png",
+      "hash": "de32379efe31f077849fabd7d4de71bb600597dbba538a2f8fbe756a51c69f1d",
+      "size": 259076
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_25.png",
+      "hash": "c4f256ff28d5cad1284a5b794e77ea82d2a8820aade43fd38cb61901d00add51",
+      "size": 264409
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6017_31.png",
+      "hash": "4686e56d4abbf6886c2af91a6447525788cad12a5de0a9a500e2bdf62c708c1c",
+      "size": 161788
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_01.png",
+      "hash": "63870d5ca840558e2d35384a329e306941f18b4012b0181dd29f6dd609c7b408",
+      "size": 132875
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_02.png",
+      "hash": "afb38155d60a8e7c32874b1b462028adf6c3e2cfc8abb035717ab135897470de",
+      "size": 146235
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_03.png",
+      "hash": "cef014572309801cf2333bfe1f104e548789f8e6a97064d15a9284e55dc009b4",
+      "size": 149669
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_04.png",
+      "hash": "fd91bb4502531d03de8c20c27068a58c0752ef4ebe90f5e9d5858a65b6514b43",
+      "size": 139935
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6100_05.png",
+      "hash": "d94d6ef996c203e81ac65483dd424d9f7546b26d132558cb2f21e8dbe1c75a68",
+      "size": 146815
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_01.png",
+      "hash": "a11790e86a2a0ea01f2eeeeee0eb60396a4ec9c5fbdb4c61ca427800c3779fc5",
+      "size": 95253
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_02.png",
+      "hash": "391431ce6e3581a4092c28000da6925ac94b20ee9fd3bc625d38d08f473b8e4c",
+      "size": 105074
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_03.png",
+      "hash": "ff1cc8f6e5752ab14fe18c9e437beea9778781c9e830f68f7598023fd8958797",
+      "size": 108892
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_04.png",
+      "hash": "5a584b7fbf76295233bf0425bfa241e113751a01901a8b770fcbb3794935fd3b",
+      "size": 100500
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6101_05.png",
+      "hash": "939483328f5156a8d4099a69bb31b3121be9e481c80d0c4a06d0869b3a8b39ec",
+      "size": 106428
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_01.png",
+      "hash": "d027f462aedd5ca6a84fb06d4b7ab0f0596fdc61a4927d08251e895d1533e643",
+      "size": 119833
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_02.png",
+      "hash": "d2bb4cb0ed4df1bc6cb5b6cd8ea32965ba784170fc04bd635510661e791e75f1",
+      "size": 133817
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_03.png",
+      "hash": "c86bcd96a4cfaa5c722910796430fb2e2325c042242847c31ad11c6f9d833cff",
+      "size": 137139
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_04.png",
+      "hash": "1e26243f2c2f7efa244a5c09cdb3d91fb6fdce0af9d084bba70dbae5f6208b95",
+      "size": 126540
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6102_05.png",
+      "hash": "1d43d31ba4ce526870345a6542d56ee39914e125e4f5326937853317adc18bfb",
+      "size": 134602
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_01.png",
+      "hash": "2b133616f8ba2d79d7e997d329b1659a50cd0cfecc1135b5eb8c164120966880",
+      "size": 137126
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_02.png",
+      "hash": "ccd8f0ab12cc20d37f0985d07442ccdcee2dda695c720a1be950f699932cc25a",
+      "size": 151051
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_03.png",
+      "hash": "3c83124cd517a6e6bf5627db9537e5d0e6f4efb6521c96139a23679f652142bb",
+      "size": 154141
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_04.png",
+      "hash": "b8ed90524e93314237fc106e58c0832b73a0bc5cb7032b5c3cfb0e9208ab529c",
+      "size": 143948
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_05.png",
+      "hash": "4a244ffeff6a2d474055aa84c2b135f467296640379b458ee4190b5bc888140a",
+      "size": 151636
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_06.png",
+      "hash": "72905fa8945f533683b2fa3552e9e3a7ee32ed97ad30bdab6f2482e6012deaee",
+      "size": 151475
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_07.png",
+      "hash": "e5678dd1f075f84b4ad3cd3137f3e114f8a8ff3f5c10d62a2bc5cdf505791bed",
+      "size": 144420
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_08.png",
+      "hash": "42fc9c84e39f98e6037c090f552f829e27bae65f6f98937897ed9f69324b758e",
+      "size": 152009
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_09.png",
+      "hash": "548cff63af8a603a1968a8ceb53902ed540878ae65b79a79a463872d4314f39f",
+      "size": 151508
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_10.png",
+      "hash": "a9f4178acd29069f6b82183267163c6e90afc13ff501a62c2a7c5b4157cbf254",
+      "size": 161929
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_11.png",
+      "hash": "12218f52a0be82bf08e52c6f9e10d6d0f00eb7feafd4bd410448d0251392d686",
+      "size": 137352
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_6200_12.png",
+      "hash": "655fa9f94e06f6d42659826b306da57cbd47bb23d6135cb37a6a5e42ad9666b6",
+      "size": 162719
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_9002_00.png",
+      "hash": "8c025e0777023e6804e986faf0541e46acaebb21632333623dcff18361778a7b",
+      "size": 381566
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_9003_00.png",
+      "hash": "f25305c2fedeb49e19810a23f4608d9ac9e733538dac1bb12023e343eb6c806e",
+      "size": 396080
+    },
+    {
+      "path": "assets/textures/race/racetitle/tex_race_rt_000_9005_00.png",
+      "hash": "d1b6f0e7c2ef9dbce60660905dc03abc3e545b41febb22bb18b40a7c8e923b5b",
+      "size": 334527
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12005_00.png",
+      "hash": "552eabe7351bb177f46c406a0c0cc41c030d3cccc8a5f8367ec6462db2bb4764",
+      "size": 98065
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12006_00.png",
+      "hash": "42bdf913e51590d3aae3ee208ed6b7ef9de5959edd8aa7c3dc3c0cf01ea57d36",
+      "size": 103608
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12008_00.png",
+      "hash": "69ff95022859e30247d7431be489e3722b18cd6a8aeb1fee0ee741f894308eb6",
+      "size": 95057
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12014_00.png",
+      "hash": "c3dca19517ec9271c273618f32eb9cdf1334e9531f5de6801db899932bfcc9b5",
+      "size": 124154
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12025_00.png",
+      "hash": "2be5292155b8feeca372cdcd69879ab19d88d3ff5106344c701b8f206793bbff",
+      "size": 109677
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_12027_00.png",
+      "hash": "9871a5d0ddf28e73dadc3c2f9f40a91621416eff5339aa750662dcc9ad26cde9",
+      "size": 103855
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2001_00.png",
+      "hash": "570bec9772da740ead5b77d052e4a7fe30487421461e7004280464841595718f",
+      "size": 104907
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2002_00.png",
+      "hash": "8427fa71b64d301416ba5be8eb77a54810044b0e5fc89445f33c809f6555a17f",
+      "size": 99446
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2003_00.png",
+      "hash": "5b2f33b2a319230c6bb919c6e3731566eac8cd06250f5c794724681f32b5af10",
+      "size": 104202
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2004_00.png",
+      "hash": "32914dfa626a713a734a7092f8474d24c07a3513ad346e61b02a30d3634349fc",
+      "size": 95154
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2005_00.png",
+      "hash": "fff7259c71a2ed050ec4cfb23cc23c3144f0d4adb9d6db49eb2bbb13834b2dfa",
+      "size": 103835
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2006_00.png",
+      "hash": "9164c521bc816c123dca52dbc0994e32cc16dd1aec7fa04852218de3900e87e9",
+      "size": 98072
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2007_00.png",
+      "hash": "0812670ef3b8c204d65dad9a49a586cbb262c255c11821e6cba4581009a6c606",
+      "size": 97450
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2008_00.png",
+      "hash": "b1c15a60de46fb690b8c32c7d53e7630c6ef0ae8fe7c7056b546c1d4021dc05d",
+      "size": 95264
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2009_00.png",
+      "hash": "cb97060b67008d3f348bfc96318142e75d159271243ab213720c5fa47439d315",
+      "size": 109311
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2010_00.png",
+      "hash": "ebdb5e8e58caa1c65e3d7710086cd918c8be3ac3f1f6e1eda5279b340cfdaafb",
+      "size": 103036
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2011_00.png",
+      "hash": "5e23d04ef078ac15bd1148e14aa3665226a27749ee70596e1ced10f69a7f4452",
+      "size": 95763
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2012_00.png",
+      "hash": "372090c778c11e86dc24f17f6e47471ff7f89693fefc95d9c70b6ba548f3de16",
+      "size": 122479
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2013_00.png",
+      "hash": "0d59037a13d9d61ad5aa045f7a484524039d76769ea4b4470e656b1648695038",
+      "size": 110786
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2014_00.png",
+      "hash": "4001b116f44b9e0e8912b11361843452facd49b8530c2b88c1daed5bf57a465c",
+      "size": 115014
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2015_00.png",
+      "hash": "a0a05f4600140ee8d91b7591afed6f89b41c7ef76dbafb1b7f55f7394bd02b7b",
+      "size": 101420
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2016_00.png",
+      "hash": "c85c23dab6b2202829a5a79fbf1b87f9b83e34264fc992e296cd173c3213985e",
+      "size": 97923
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2017_00.png",
+      "hash": "1e373caebafadee0d4d03da17503cec2977dbcb11458057269ecc2cb49926d2e",
+      "size": 109927
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2018_00.png",
+      "hash": "7d268503224a81b87a569282ca949a94eae7addcf0152b59e350d554c08a9199",
+      "size": 113433
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2019_00.png",
+      "hash": "56bcb72ee319cd5cd6d1bca552efbb7b0c6f1c9f13c2cae45ba0d69923ea8161",
+      "size": 102604
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2020_00.png",
+      "hash": "dc692c2fcb9eafd5c09af508bcd4f25906d66fa722447ed7afe6e5d5b32db710",
+      "size": 101424
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2021_00.png",
+      "hash": "6256fd3c12457df1b199f49a2f4509202e4bf923941cc664954969921c915d42",
+      "size": 110929
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2022_00.png",
+      "hash": "69989a8453e2a724624764ece4bbffb0e634dfb5cac708d593a5932f2fb95908",
+      "size": 100616
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2023_00.png",
+      "hash": "ce3a226fcb38677cccf176255d2237d76afc762bdcf185a0f331bcdacbaa49cf",
+      "size": 95778
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2024_00.png",
+      "hash": "7f10e3062423d14ae3f6c2c435c43b81388eb40913a91d79b07b3fac0b07c7ed",
+      "size": 109378
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2025_00.png",
+      "hash": "17750a9a84e5ed40bd96a5dee3dd9b9d3524aada03468e646b3eca95b5d7f117",
+      "size": 118692
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2026_00.png",
+      "hash": "653d6c34478835fafeb7e81dc33a4f7baa6910f2331bf4376372270722ce3045",
+      "size": 108546
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2027_00.png",
+      "hash": "0aaafffaf3dbbc5159978f5575599a5851cad4c318f67de76b03a936727f5ec2",
+      "size": 108104
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2028_00.png",
+      "hash": "acd57324a3704a3fc5eec75c644e02bd0bd64afa799be41a7c4d36686ac4eca4",
+      "size": 120015
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2029_00.png",
+      "hash": "530c0fbf585439b7013bdb45afc4e8b3b474bcbe0d74f3242763809c95141eee",
+      "size": 101383
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2030_00.png",
+      "hash": "e5afaf9ad0e2059e7a92b42723405c1de746a372e32864a181a9f059ff1ab0da",
+      "size": 117827
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2031_00.png",
+      "hash": "f0a29159124cb62a1468587f1efe161a54bddb59fcb0678c94e8669347673037",
+      "size": 119318
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2032_00.png",
+      "hash": "ac9ea36a1b53d45e74d61029fa61254dc7c2de79528302396c22acedfa3ac5e1",
+      "size": 115875
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2033_00.png",
+      "hash": "8ab7a16b40e96e92f2d3170d9afbe63287c9409bb8488cf27dd76d576d0a2edb",
+      "size": 111291
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2034_00.png",
+      "hash": "d2785d8681a5d185bf9375953b2f00c06edca6bb0ff1517fe66b2ffa3afd35ec",
+      "size": 98906
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2036_00.png",
+      "hash": "85194d494540a79cefe6016384f18e12a916d005dbdfaa2732a777eef6a9b841",
+      "size": 101663
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2037_00.png",
+      "hash": "6fe012d5160335f68c23d8df57cd1e31c7c720e004c5cb92f133cf869df62015",
+      "size": 94738
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2038_00.png",
+      "hash": "33317f80fef4bd0c8db4a7b5b08f6ae9ba6d7f2d701189a3aa0e4cb134edeec9",
+      "size": 96270
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2039_00.png",
+      "hash": "c77cd6287d1152594c1005cf9a9e98b91f18d5943b58de81905b3b63df73ba65",
+      "size": 102517
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2040_00.png",
+      "hash": "49c56745caa296d6bdb8037047cf7608d936f98f882e7660d6c18ae23f697ccf",
+      "size": 95313
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_2041_00.png",
+      "hash": "ca867fd1528071496f1e8d1f6ff8cb3d64bc0791250b9258df67456a9b3e6741",
+      "size": 104647
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3001_00.png",
+      "hash": "031e0513973cf52f27074b8804047891b998f933cfedaf504a34fbdc0ee7fb05",
+      "size": 108515
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3002_00.png",
+      "hash": "0f500d5ac4a800c5f570aeb41ad287b81a6c1217855a4fe36e83dff9e1b80af4",
+      "size": 116339
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3003_00.png",
+      "hash": "0e987758488874046aaea58f4e7af8ff9e63895ac502192c4e0041d6ac149411",
+      "size": 109045
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3004_00.png",
+      "hash": "04602b966f17ffbc844294d3cb5131f469d5f334ef5012fb0c67b29ddf97a6b0",
+      "size": 109149
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3005_00.png",
+      "hash": "d49a22829eee2da6416dace2d517d31138b802f22cc3d5a50cd588706a5f3f92",
+      "size": 102048
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3006_00.png",
+      "hash": "a8b59a61267e0c5c133954410517b8ef48b47002964b55ea998070f30beced1f",
+      "size": 100488
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3007_00.png",
+      "hash": "2776b2b500d3fc2d960b89bc5675b8b09dc90294d6810a663b135e5bda9880b2",
+      "size": 122462
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3008_00.png",
+      "hash": "0ac9f12f5a7f3c73f5327e077da0c3376a8d3048a65b38fa24c7f2b41ff68ae5",
+      "size": 115854
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3009_00.png",
+      "hash": "2aeaf1c113d59b22c8f6a6130e2df6f1455fa8d2dbb6e2218290b173b2ff96aa",
+      "size": 112519
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3010_00.png",
+      "hash": "ed20c0789942bb7a0269577552c86b237c951b462cb97cd2441d5e8b65f19c9e",
+      "size": 119080
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3011_00.png",
+      "hash": "cf73d16d277a00d73de3bfd87083c135af6e668856ecabaab30f0fe834c8fbfb",
+      "size": 117777
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3012_00.png",
+      "hash": "89ba713f4d16782e0d4fde490bdfec8a281c0e4db5b187d6800ccb27def88040",
+      "size": 117107
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3013_00.png",
+      "hash": "81808813cb13f44cf1b676a59e9bb2fca69067ba0748a0b892f0c1f7d076ed3e",
+      "size": 131277
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3014_00.png",
+      "hash": "2573bf141c3377270754dde1480caf6b2997106263ebd0a6a28a91c44647fa3d",
+      "size": 120591
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3015_00.png",
+      "hash": "5614f6586b8463ede4c653f36433e64f0f72a3aa31be61399699e25660cf3345",
+      "size": 122818
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3016_00.png",
+      "hash": "8eede9a5ba86f870ff063a757d0ca6bfff7ab47836988ae20b8b840bfb7cb217",
+      "size": 113193
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3017_00.png",
+      "hash": "262cae88b587cd104163fac8b9181ee7cbd20dd92dbb8c2e823f4c7c29e5df00",
+      "size": 102736
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3018_00.png",
+      "hash": "b790f5e38861764d2526c4dfc47661064c1f79814d045361792643da7390e12d",
+      "size": 94853
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3019_00.png",
+      "hash": "7ba197c104e431cd7d15821de40de6ff9cfb88214d2dc1623d683344ab6233e9",
+      "size": 113308
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3020_00.png",
+      "hash": "6905344f834e561150a956b5000bda382aa7f12e22db427aa6913aa733ba9b46",
+      "size": 134828
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3021_00.png",
+      "hash": "f17c3af18ec836f21ea1b28695029f4b64a890b17b8dbb55ec47cc70e96f33ce",
+      "size": 117886
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3022_00.png",
+      "hash": "b70773c78947c98a83a1d69b8234f9b8861a4f41aadbf03472b9baaf94d2a08b",
+      "size": 109573
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3023_00.png",
+      "hash": "d2c90b011284a242d9601977065cd085dfa0a6d2f0bfccc9f94ac0a665a59de0",
+      "size": 106534
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3024_00.png",
+      "hash": "4bb86867cafdab227dfccd156ec9e5e6fef4e2ca26535f225d491600061fe770",
+      "size": 118345
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3025_00.png",
+      "hash": "3a3708de7f249817812061884b9aca5ba664bd7b6ff5a29562d0556fe6a22999",
+      "size": 131902
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3026_00.png",
+      "hash": "16bb4b55e336cecfa22d887c9ff7a26ec83e70365f8e73057952fa0e5b32f5ed",
+      "size": 119272
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3027_00.png",
+      "hash": "b3a344d9a4842340af4c7c044421527a5aea270147834ef341f8f0d9c772c820",
+      "size": 135418
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3028_00.png",
+      "hash": "2437196bade13e411a827b3df561090948b1afb175a136acb30dccf648d9fbfa",
+      "size": 118446
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3029_00.png",
+      "hash": "42cbf2232bb7205456bdd17c5dca8273c0a91da141c2e6559b2ae75475c9ba41",
+      "size": 108367
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3030_00.png",
+      "hash": "d5af89bc39e5ee8cb0a86e39b505b473393914b73af65f5dc70f3f0529b3fd17",
+      "size": 110078
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3031_00.png",
+      "hash": "26019f870423446a10d8d2716ab98c72defc4eb5d5f0ecee022e34571f2b95fe",
+      "size": 120065
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3032_00.png",
+      "hash": "18d458950b191766508123a201799d344a2ce366604a5bd1943bd6eb209be244",
+      "size": 107676
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3033_00.png",
+      "hash": "f5fb6af30a8e06e35411e99710900f58549857e7df1ab5b41a01314b1f9c0dcf",
+      "size": 117931
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3034_00.png",
+      "hash": "187ddba423047230c3d1667e2bb0cf4f1cb11f01792ec1b6e0ffd0ba01d4b3e3",
+      "size": 123864
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3035_00.png",
+      "hash": "2e4ff0bb10aa7656ae09343a62d4be2618bf72293896043aa69b9c2662c87f5f",
+      "size": 106210
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3036_00.png",
+      "hash": "42b00781ac8f82f43c74cbaac67616fd0a7ce44bc83cc1bcf9299f9e4c494c22",
+      "size": 116699
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3037_00.png",
+      "hash": "d1d4647d0a261b2c8e17ad3bccae9237642ee9c154beb87ce1345acd53599576",
+      "size": 119293
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3038_00.png",
+      "hash": "b2ee9315489373be82a71bc448dd3969717a33348448cb5e567990786430adb1",
+      "size": 108861
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3039_00.png",
+      "hash": "2e45e8c3ebdcffc5b7a223b4f84aab0df6727940551ae290339fa9e238cadd01",
+      "size": 111365
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3040_00.png",
+      "hash": "a253888339817dd2e17b8dc83562a887028cfcb29b42d4d02621de448d429268",
+      "size": 112294
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3041_00.png",
+      "hash": "0176dc510276af161806321f2e2b901c6c2737fc18bac99915b53c9d680a149a",
+      "size": 129180
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3042_00.png",
+      "hash": "116ba3f836426db2fcbc5774b7f320b9db46c2fe46ec3a9aa5ec9483e13dd52c",
+      "size": 115448
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3043_00.png",
+      "hash": "d08487ec7139bc0a946ed9c24fbfc3e8707e8182922ce1478109a8a1fc7da44d",
+      "size": 114251
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3044_00.png",
+      "hash": "2031eb9cafb2b592b9f395c7f3ff7d148615e26ca0241200931f5a62514ca6bf",
+      "size": 112574
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3045_00.png",
+      "hash": "8d3b2bb5aa72f916e28b982ca00255a7fb28e7fceb043fbf3adf847ed210bb10",
+      "size": 116822
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3046_00.png",
+      "hash": "fc9156fcd7212f8dcc98966d589fa23fb129ecbcc31ec1847569da0435670840",
+      "size": 109603
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3047_00.png",
+      "hash": "32195e98a96d4de5cab6654f22710993f853f610c4782e97286348d53a4b2df2",
+      "size": 108563
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3048_00.png",
+      "hash": "edb90319f7aad73f736fbba5ab7d0b6187725e72bfe98a5afce1a7649fcc7b1c",
+      "size": 114677
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3049_00.png",
+      "hash": "058e253d1ac1c239cb7e49499655204f45d86912a446b5ed9be14f7eedd4809b",
+      "size": 126138
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3050_00.png",
+      "hash": "f93a47c21bb68587ecad3604aa7193fd1091489c57a9d37b2b8c874d8522f37e",
+      "size": 108324
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3051_00.png",
+      "hash": "8ad2e2fdb9e0cf28141217ecba9169531ba262facba05884c910bdb63ea4bf77",
+      "size": 128031
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3052_00.png",
+      "hash": "eefae452299fe8df54f1eda4d3203cac5afc92a2551a6f38cd4269eb282851c8",
+      "size": 130276
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3053_00.png",
+      "hash": "be7beff02182c1d3e705026ecb625dd7683e06ae1965c880ca077d8b2c518e93",
+      "size": 108351
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3054_00.png",
+      "hash": "5aa52b692107498343cf97bc88cf70ebfb77a8cb7b0b3e1875e45e487ad37260",
+      "size": 110468
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3055_00.png",
+      "hash": "5bcd02d7e0561506ffe9a6df0b6c1ca20cb178630516301d4025e2798ca046f2",
+      "size": 128813
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3056_00.png",
+      "hash": "e711353107ac545f708130829a201eab2b803d16a674344c0468de797d67526a",
+      "size": 108369
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3057_00.png",
+      "hash": "868714f4ed787a26f287b5201e6983346e0d7a93a4a7be3a74e4b3ea73f67120",
+      "size": 130155
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3058_00.png",
+      "hash": "db4f1dbbd786624f70811079d96df831cacddeaebb541ef3b7e53981618301e9",
+      "size": 99106
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3059_00.png",
+      "hash": "95f1395fa30d746fdee78d931391e01b67a17aeaae57e56ff2a56642f9596c92",
+      "size": 118379
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3060_00.png",
+      "hash": "46dfa0e0f0eb288a8d3c34dd4ce18f0e668c311aa21734d910e4724b36e841ce",
+      "size": 117223
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3061_00.png",
+      "hash": "58e87ab5c382d55a84d2a68ee826e6f8c907a2709f1d7fd029956b69a4238ac3",
+      "size": 120636
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3062_00.png",
+      "hash": "349faf73a868acfced6f46a70256ba64033605891f96bfe37754d7727cb0cc1e",
+      "size": 123218
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3063_00.png",
+      "hash": "d5583e6668419fefdeaa6a3b415f47337c42ff63f604c8d66b8f1170063aa131",
+      "size": 112679
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3064_00.png",
+      "hash": "dafcf3646700d870179a66a18c08462086007571d8565be5b00ab492b279e50e",
+      "size": 141093
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3065_00.png",
+      "hash": "adbcef1aa0a50fbb946cae9bf0154ed5f320ef6c1bb190f899e75ee427a9837a",
+      "size": 124496
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3066_00.png",
+      "hash": "29e3d93c8caf2210efd43d2311a18938948fda56a8041c5926a7c65c897c2e41",
+      "size": 101429
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3067_00.png",
+      "hash": "683e31b276e339012e64c79b0bd6f6f24e7f62420817c12bb8cb9da143802b97",
+      "size": 112631
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3068_00.png",
+      "hash": "f4d22d7ff016ab65683b76392b8846d77968ca4e1e444a57606eec6c336d263d",
+      "size": 122579
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3069_00.png",
+      "hash": "bb93a132849a2f66fc585b0b7eafd30b1875e72953932e57397dba0f3a70249f",
+      "size": 115176
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3070_00.png",
+      "hash": "3af15935bf4255b1201815f3e38cbce050ca0e1bf8806b0f466004a2ed8aa3e5",
+      "size": 118594
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3071_00.png",
+      "hash": "71441eb1c3c22c73120c340f908fc95408cceb3b2c408c7bd02c288cb74d5e1d",
+      "size": 120446
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3072_00.png",
+      "hash": "daaf62c3f86bda5698d11b6c8dbeb031d71ab974894c98e4585147beaba68bd0",
+      "size": 109151
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3073_00.png",
+      "hash": "00d9283209d5366cfc87189c7375384dc5940fb0b01bcb2c64c61e6782add0aa",
+      "size": 124467
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3074_00.png",
+      "hash": "bb20733857492df128cacd354247c1f9ef3913ede593ce549edcdd0df017363e",
+      "size": 110240
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3075_00.png",
+      "hash": "9c9105cfd8b1b2aaeadb33cb6bd25004763d1d9fb3cccc14f07110db65d07f78",
+      "size": 108436
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3076_00.png",
+      "hash": "504e4e0f3343ac3e1933d91c7360e4effd2ce8e3bbedd613b4ec5e654677670f",
+      "size": 110900
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_3077_00.png",
+      "hash": "4c07ddbc7fc46378f34f8966136c2ab3fdddaa127ec379677fe4330bdb63cc66",
+      "size": 105583
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4001_00.png",
+      "hash": "43140a33a5fb36bc5f6960f6108737ff1628ec062dd91212b32deade6b0d9c57",
+      "size": 114176
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4002_00.png",
+      "hash": "822c86396b1613551dd06fbb326bd91a9a30c0701fcbffc4767738c6fe9c3c4a",
+      "size": 101245
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4003_00.png",
+      "hash": "4e7517553b6011da7b9fa7717ffa81d93f96e58a8586190f4a8ff5a22fac7888",
+      "size": 119919
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4004_00.png",
+      "hash": "a86ab3b24abf408fa4ec245483bc933d27757f602bdc93da3deed3f87226116f",
+      "size": 108470
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4005_00.png",
+      "hash": "d052b1aeb1715e97009fe35f8da49233c439e3d2f742982de545bab2d44de2d6",
+      "size": 111662
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4006_00.png",
+      "hash": "4557239e2d3f632650f0ebf1214ea9ae879cc5f2ed8f43a9100b6c10e7d724d9",
+      "size": 114681
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4007_00.png",
+      "hash": "7b16aa5c2843a30a04358da04af8fc774e3fd4912b1fd32caf57fb1749705a74",
+      "size": 106466
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4008_00.png",
+      "hash": "d9848014e13dad4e1543dc03274e44faea5d5430faae1eb44f30cfec632d90ce",
+      "size": 104064
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4009_00.png",
+      "hash": "87c60eb2480a265405bb9e9a5166dc2d9132d89726c0849c665825fadb665e30",
+      "size": 119396
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4010_00.png",
+      "hash": "8eff6cc75c39346a63d58f5254e5614b5b002e0a9ac902359a00fb554703bc0e",
+      "size": 117243
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4011_00.png",
+      "hash": "b7a17399583aa315a5159f8153d6103acfc11fd4a9e9207244953b4c1f1acb2f",
+      "size": 113434
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4012_00.png",
+      "hash": "2d62635dcb203c0a40143be0e3ea6f4b97ac921442c27132519ce94d09df7bd2",
+      "size": 110999
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4013_00.png",
+      "hash": "409696ccad50d3ab5d30e1dcf10c4762381635eadec819e933ff535f8b75c512",
+      "size": 107908
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4014_00.png",
+      "hash": "fea0c52fbf7b5de09827e79ef42d5804c4e81ade025922e1fe1174d40746d21a",
+      "size": 102610
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4015_00.png",
+      "hash": "1ed15ad2319647718fc39f699e609a494f04eb19e696564fe76e03003c94a9c4",
+      "size": 107627
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4016_00.png",
+      "hash": "e5ca0af2ba7aaabd4a61767f221480ae20b380b6907f7da2359016f394212114",
+      "size": 113056
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4017_00.png",
+      "hash": "b9ce5b3368b963d7a9b92c89f5664b07e5ac84462750d627576943e1267c623b",
+      "size": 110753
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4018_00.png",
+      "hash": "a8d0e95dde694aa6c6ebe9475c6fe211dd32f7919094e00e014d1383ed285694",
+      "size": 112931
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4019_00.png",
+      "hash": "5f952ef0a28e938f21cdfc9d7055acbeb0218b4e292811f928b274390cbfc5e5",
+      "size": 104580
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4020_00.png",
+      "hash": "0f3a6df43b9860b06058069da5f82b7660302bce9215ad9b3ddb2a0fbe63678b",
+      "size": 105232
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4021_00.png",
+      "hash": "27016ce0d545a95279669d2da49b39ed215aa31900cd2ed2d4c555b359e8c7a6",
+      "size": 116793
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4022_00.png",
+      "hash": "984cda6ee583e8a0bd5971d1a334911e0b119c662146d57599b7fbbcca0cb003",
+      "size": 112564
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4023_00.png",
+      "hash": "9631121d1bcb76723276573dca8afca0070d9aa33b1459dda71274ebef15178f",
+      "size": 113746
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4024_00.png",
+      "hash": "4fdfe2f238223a2af8d30b7b2fd2295804218444ddc07a4a604d5f02aa0841f7",
+      "size": 112474
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4025_00.png",
+      "hash": "c7d5a3ea335a853bd75add5cb5f575da2edc8b0b95a3b07b631d4fd7ec5e4e21",
+      "size": 108036
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4026_00.png",
+      "hash": "a9052cef8eaabb9f53e6cc8db8dd2b014e52d2a16eef4f514ce25bd871ffb8a7",
+      "size": 108110
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4027_00.png",
+      "hash": "0362d8d7f2c32749d137eaeaf0a2bbcc6454097d1b772a7e88ae24b2bd715a56",
+      "size": 112340
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4028_00.png",
+      "hash": "19120ab536d18159bf0c3a5e1b6ddd9d3328da8c07a43b994032584b4baf4d0e",
+      "size": 105289
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4030_00.png",
+      "hash": "010c4dbf4f48d6455075f453fe2317e876615dd028f75fe3cb1a35f26d8b3b15",
+      "size": 104591
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4031_00.png",
+      "hash": "088998870c29ac37b430820fb91d54334b77e94220cf111630f4ce27e7c45bf0",
+      "size": 107567
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4032_00.png",
+      "hash": "4ef9e322d7caecfaca31a0bbc6db0363c78cd417c46a24837fb7c68491ebcc78",
+      "size": 115326
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4033_00.png",
+      "hash": "c723b9a05889ea1e2443357e43df68d13faa7a8f797543c36f5b0a656e82a94f",
+      "size": 109369
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4035_00.png",
+      "hash": "337de567aaef4bc78ea096e1ac3e7db9dacf772092138f78113f0b3f2c0846b5",
+      "size": 115554
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4036_00.png",
+      "hash": "207e6a2babd57610de3313dfec48bd51fe1511847a4e18508330aff25555799c",
+      "size": 106684
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4037_00.png",
+      "hash": "415cc777e4fcbb7cbc3286c1ace379ca6d607018beffe1e1600fa5543ef6e699",
+      "size": 113056
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4038_00.png",
+      "hash": "0d1cec61cbf5773b88facd8cc5276b664dae7006bc8f54c7157cc95abb157e0a",
+      "size": 118916
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4039_00.png",
+      "hash": "2101251f3fee32e41af7ee6822aad01b71167eeb08f3cdc29fae1690a941c99e",
+      "size": 111899
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4040_00.png",
+      "hash": "726fa579b1be80e673f442176f243f6f622016cb792873bfeb675556365bf332",
+      "size": 103401
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4041_00.png",
+      "hash": "db945656ae86daaa61f7ccf99f2ba855e031c182fa31e7ec891857dd9fdd908e",
+      "size": 110643
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4042_00.png",
+      "hash": "756b6694b573431a2114eab6cabb5fb02766438cb54cb447f7997f4b8de2f388",
+      "size": 107104
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4043_00.png",
+      "hash": "2187550325508b47749e930e0b05202767b89e93125df2400a9d5d9fd02919a2",
+      "size": 113570
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4044_00.png",
+      "hash": "a676034d29b46fae64972de800a2fa3e741b054fde371f82b1da8ed3364a62c0",
+      "size": 118184
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4045_00.png",
+      "hash": "f9fed9a25fe689c1561f5310bb8383d78cb2f0f3ffb2ce2052f73d5a64ce2062",
+      "size": 113034
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4046_00.png",
+      "hash": "f4f672adf98347f92073df718824f5ac38621ab5a6261b443ccf25010b0f373c",
+      "size": 117689
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4047_00.png",
+      "hash": "ebc6befda469352ed97994caaeb9a40ab147c6cd02fe76fba0502c3f9b1fabbf",
+      "size": 112638
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4048_00.png",
+      "hash": "de69cab2950fbf78d784beb66c1c5ae491ecae8d8425adb6526a63439ba0941b",
+      "size": 109725
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4049_00.png",
+      "hash": "68cf1e8323ad521e208c4dbe4bdadb17286f8fb1ae67235c6cfcc05eda51c238",
+      "size": 120432
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4050_00.png",
+      "hash": "aadc3230ae310fd01995e6087c81eeb06d23f2c52f4c9ef909daf8734cdd90a9",
+      "size": 110518
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4051_00.png",
+      "hash": "9b5b66f9082e5f99a76d5a0dcb26839888e99b3be0104f0e6586742c1c39e1e2",
+      "size": 104530
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4052_00.png",
+      "hash": "9c021c43824d3ee0ec5f8c96af506ec94d34f8d894e46a6c46252a64d02f9678",
+      "size": 104218
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4053_00.png",
+      "hash": "cac49b2022438c965d54d5750a84b113327b7cf395f7db1a09d27f2ab86efbe2",
+      "size": 105286
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4054_00.png",
+      "hash": "2eb258d99fb1a7707fe3259547c3c0fac3da89ba2275edd672c72ab929745cd2",
+      "size": 104886
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4055_00.png",
+      "hash": "0b2fa093627615cc8c4866d0d6a612a3b5a426e49f1f4f0652119c7706412afa",
+      "size": 103355
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4056_00.png",
+      "hash": "2d4e786144425476b1c4dbed7bea81f3ababbb6e6a0e8515c408e36f4bb22a05",
+      "size": 113444
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4057_00.png",
+      "hash": "020dcb44accb1de4fc30e99e798767a1488d6525bc3774c470e67c2655c1574d",
+      "size": 104129
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4058_00.png",
+      "hash": "bf07cd4468bf8f8b8713a3fa0afd60ef6dd145927ace09d6301ebe8b948e4fc3",
+      "size": 115659
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4059_00.png",
+      "hash": "315318ce7f111507bd9f4f21710e59ba97262920d9cf318eca3f8ddb2991130b",
+      "size": 110516
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4060_00.png",
+      "hash": "1394438859898cec5f2af1ecfc0c3f0a27134b65f2f91804da059eed0cd48497",
+      "size": 114964
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4061_00.png",
+      "hash": "17fdd72d6312425b3c08145d212b9a9c7c94f35baba348555ca19715cb8b0783",
+      "size": 113864
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4062_00.png",
+      "hash": "3a38573fdd2ea6810b916f68ddcac7b309a2274ad90bc2aa0b4618615ae43d6a",
+      "size": 109169
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4063_00.png",
+      "hash": "2f198ff14a6258e860e1c0867bfdb540cb29f7e12e8cec89413f994543e751fe",
+      "size": 111865
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4064_00.png",
+      "hash": "1696755f9fef0730b4a74d58a8cd4328c33b31a151060bed74bfd2e21008ec53",
+      "size": 99924
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4065_00.png",
+      "hash": "a7f537bcda8e1e9501ca07f5bb1d8e1c23206957a801257cc6fcad97ae877183",
+      "size": 106471
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4066_00.png",
+      "hash": "da6b32163c222577f5eea2860f0d8e2a4443a358319e34c6d5e5e2ff94e63efe",
+      "size": 100698
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4068_00.png",
+      "hash": "d86dec39cd367b2f3291b0ea540986f0dde310d6c260382ee4b56a0db1adc92a",
+      "size": 120000
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4069_00.png",
+      "hash": "4debaef8a9fcd6b0a62992f1274cee1deb64578cff5b40042b44085e221e307d",
+      "size": 114316
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4070_00.png",
+      "hash": "27bc72676255a1cc41a63931742e00d7a7d35169c9e3095f164929baa480ad0b",
+      "size": 100015
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4071_00.png",
+      "hash": "bea93d48b93fee4ba21eeca78a79dd5a1f07ea25882f4c9ad48e225f4ebc6d4e",
+      "size": 114068
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4072_00.png",
+      "hash": "af830addceeb0781c6bf854f167f37e47621234614a3160200b3591ccd54c963",
+      "size": 100070
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4073_00.png",
+      "hash": "8b913a1dc29ec9d7f833ea799a0a46a00e092dd61fa9188e057235b3a5c9baba",
+      "size": 104354
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4074_00.png",
+      "hash": "cf878a4003dcc142d035642dcfda4d976e51743dabdf09c1e1b1300db4e661eb",
+      "size": 102673
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4075_00.png",
+      "hash": "44a19532527f5f5c607df2fe3d0861979d79dae9b774ec907fab69f7cfed2dec",
+      "size": 104130
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4076_00.png",
+      "hash": "834c720fe6124b6a6ed32d78a36c4b4afdbd481f09d3534291b49c446911d03d",
+      "size": 98928
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4077_00.png",
+      "hash": "d2c1c6e097ad36ba63f37a08d777bb8ef3efc95a2808fa4e56d51c808acf770b",
+      "size": 104099
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4078_00.png",
+      "hash": "e985e51b9bb152c15fadf6d518fa3857f13080078d352304af7f1b9d0dcb09b9",
+      "size": 107160
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4079_00.png",
+      "hash": "cb6c3d0298bc22d62017d4f8c0756fd314efe86d7d71464dc37b9926dd72cbdb",
+      "size": 100716
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4080_00.png",
+      "hash": "9d7a645bc61974d2f6007d69ff678e690c73d64216eebb5cbe2930d936d1090e",
+      "size": 113791
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4081_00.png",
+      "hash": "c26359e586fac36d4582e33ed83059599312c11d0f8a9e290f5b566f6888fd88",
+      "size": 102733
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4082_00.png",
+      "hash": "e457281e0644cc9297b7cc3e2ecb65b2ed6432264c48ab9b7cb120994e88a528",
+      "size": 108105
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4083_00.png",
+      "hash": "df055b9ae23ab6d649de3d1cb745a055fea5cdf70c99bc6eee0418ef446467af",
+      "size": 103520
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4084_00.png",
+      "hash": "79b69cdac3123456853124a226a94c02c409fd847cbdb2d128746cd11e4a008c",
+      "size": 101872
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4085_00.png",
+      "hash": "c9903d89db0779a6909641df0fd8c34e2837b766dd14d666734b00498b564ec6",
+      "size": 114374
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4086_00.png",
+      "hash": "a92b39ab9c29bc59ea94f26822530230096257b1f3d07f4db1d5df1acc9a7561",
+      "size": 112207
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4087_00.png",
+      "hash": "004369ee1c80ba6affa1c78d5a00bc74998a3af32a41ebf0ce7384d87163c51d",
+      "size": 106850
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4088_00.png",
+      "hash": "959589c64a8a818aa7432beafdaf6a3774fc9bd30d383b6a221ab4cb46a6df6d",
+      "size": 106316
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4089_00.png",
+      "hash": "327ed6613ef85c5d24723e69e716d942171072111b56e3883e631c567a70d8c2",
+      "size": 104665
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4090_00.png",
+      "hash": "0fa561d77ea0cd615118f92b0d6d472160280943f982bad62de22f39260a0e33",
+      "size": 117079
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4091_00.png",
+      "hash": "5e1aba57f4673107b7b11d2b4740480196cf714e1c808c82bdd0535800852e51",
+      "size": 104540
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4092_00.png",
+      "hash": "0a26c4e5f6973158a72429fff5373fdd3f0e3f0341a2570360417634c2117d5e",
+      "size": 109704
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4093_00.png",
+      "hash": "27f62a225a51821444af7ecc7286715215fdbc569da44de22cb25a91996921d8",
+      "size": 109831
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4094_00.png",
+      "hash": "bf8e99b1379bf28e1270e7ee4651432995da477c0a63cf5fd5b85b0c95a55256",
+      "size": 115237
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4095_00.png",
+      "hash": "0567a1fe332e060242ef38e17c22e568cdf1df09dbf373ce9cc8209870f298ad",
+      "size": 112897
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4096_00.png",
+      "hash": "9be695dbad8cca7dc2fd05178311112212b9798d38d31c26d9cb5569f9dae9e6",
+      "size": 103408
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4097_00.png",
+      "hash": "f817e3bf0dbda12f042129b3289710221056ab2b86a0a81a991b35fd4817fe57",
+      "size": 120143
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4098_00.png",
+      "hash": "67ac2e420f0094fedc7c15d1ae79e300667c333c4ad3831e78ea26cdca5f80d8",
+      "size": 101216
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4099_00.png",
+      "hash": "14a61e72d91c9350292c913a7ffa23142121744bf683e741a24e3bde5e0d0a1e",
+      "size": 103346
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4100_00.png",
+      "hash": "0a881f6a256f68c0b1f05e50a639a42bfb00864fad39fd903ede526b02462fda",
+      "size": 114888
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4101_00.png",
+      "hash": "6a9621221b940866ab977b55f56c3c17e4af658541929afcdce849efb2e17c1d",
+      "size": 115211
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4102_00.png",
+      "hash": "63d09b6468d1f237371979b464de77fd614120372c6d081a72048358bd4f18a7",
+      "size": 101013
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4103_00.png",
+      "hash": "1214d4b36bb1999c70fada8bb501b58aac1aa1ae83e2e078e21ca86be9ce3cec",
+      "size": 124759
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4104_00.png",
+      "hash": "79fb34cf2e4c124f9e368678d1b911848c5c85295bf3447f3086d743be923503",
+      "size": 117800
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4105_00.png",
+      "hash": "919a5e3df38efd303ac005a7dc7fe549173f10692b4ad0dcd5f49f38d9e57959",
+      "size": 117947
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4106_00.png",
+      "hash": "c03968faa122ca02fe39ae24d9f4e2f1cc0f8a2f7abceae71f1184639a51e1a3",
+      "size": 119218
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4107_00.png",
+      "hash": "caf1588ee26034498d182225ea08dc80e0981b4042233a6d60bc254891f257cd",
+      "size": 104278
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4108_00.png",
+      "hash": "77da666c9983496521fb3df4007e7148ba48560fd653ab35342c001d5b59e891",
+      "size": 115537
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4109_00.png",
+      "hash": "508651733e0805bfb960b70ce40d3afcac6ac47ddf93b16967a2167477da14e8",
+      "size": 111555
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4110_00.png",
+      "hash": "ddd9f67380c8cbd3ddd81f51dff7b4a7057c53bf95f68626d1ece0e3f392d25d",
+      "size": 115981
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4111_00.png",
+      "hash": "4e0308b8e1f9d5c644d0c928723d95c1ced85cc04ea1695487a36f23ee715f94",
+      "size": 104349
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4112_00.png",
+      "hash": "2c42eea2751e5c66edb90b97a90774b4c1eb68a27aa3e953be2aeab44d6fbdb8",
+      "size": 109571
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4113_00.png",
+      "hash": "5fd1192c4920acb3c76ec05d1d67466c37e9e4ae20e17e50969bec7ba0aa71a4",
+      "size": 111799
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4114_00.png",
+      "hash": "e138a64840b5ab6d7b9c5dbf7c1ac1f0b6b41eccee71f3da1b586d545938e634",
+      "size": 122047
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4115_00.png",
+      "hash": "6a7e3d69cfb07f5720d840b70d8aed96fdfc86711f3850db8ecd81ef9b452aed",
+      "size": 107706
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4116_00.png",
+      "hash": "3c845e9fb096be5bc8b6e039518d711b892525b4d910ddf4b938b16f99cf5c38",
+      "size": 111284
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4117_00.png",
+      "hash": "c8788f7607337bfb81adee74d14b9965e4f09f92731971be49fa3229e493428f",
+      "size": 132430
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4118_00.png",
+      "hash": "88fe3bbbdcb5ef560b18459d281aaea76b7c20aa7fb6bcb56b43318aa616d82f",
+      "size": 119524
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4119_00.png",
+      "hash": "44d9cd3ac60b22682d88ab561aa10949637c7c8e0ff305ffceaba9c9e1cfd845",
+      "size": 110004
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4120_00.png",
+      "hash": "1ba255c979d7e3cbe6aedcab7fa36d494318c08773caf8d2210482efb1365dfe",
+      "size": 117510
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4121_00.png",
+      "hash": "323bb9e197d364440b15febfa137802f86b7880a2e1bc1b601f24e1fa11142ee",
+      "size": 113553
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4122_00.png",
+      "hash": "9aef6ef47e582669d8b77a8097380a6a0955db92bc4408c0acbef19406e2c43e",
+      "size": 116454
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4123_00.png",
+      "hash": "d9bf817904df79655c4bf5561bebc1574b635959240d31a56ef87e4f39928cc2",
+      "size": 113836
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4501_00.png",
+      "hash": "b55a0c5fc7de18d691520efba89345f5dc8defa5047d855d076c93062ee1533f",
+      "size": 102934
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4502_00.png",
+      "hash": "deb156221414831e4758c7f1a0bf6c59ba703676a5c29924404d84437ee5befb",
+      "size": 101653
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4503_00.png",
+      "hash": "f5076a1f5c34f10b1ee31aa6e3bcdfb43b1989cc5ed56751ac8a9d9387f5528b",
+      "size": 100304
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4504_00.png",
+      "hash": "c61ab26484d192e4dc1914c509e6e7483241e93f85bfac5a8cd887c62319d269",
+      "size": 100735
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4505_00.png",
+      "hash": "801136e064cad0eb93ee0f591ca510bdcff23abef50b9e545842a00bd4f2cfbd",
+      "size": 106504
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4506_00.png",
+      "hash": "f235adc83d68e9ed893ea552aa83c8768473d276806dfc5ecb60fcc900b7c6ad",
+      "size": 106726
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4507_00.png",
+      "hash": "26b8a3a23a12ca15b84805de436fb0c4dbb35b91961b9e388d0d7f317aa57e77",
+      "size": 122519
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4508_00.png",
+      "hash": "7809eb33d2d9e1cd3ffb4f1dc88e946a0d448538792446a918b81128dd4f5125",
+      "size": 120163
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4509_00.png",
+      "hash": "d4ab327a36ea7b7cab43eed261b474b3b8312fcc88c92cbeb585432e130e7723",
+      "size": 106253
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4510_00.png",
+      "hash": "c7be5919fc37d28ae6167c9e61b2180d96536c4b2ab36bc8bcaceb181080ed22",
+      "size": 103768
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4511_00.png",
+      "hash": "b077b926a65140076af0e88dd8804bb44c5266fbf287e54ae33938686301a34f",
+      "size": 111122
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4512_00.png",
+      "hash": "1c86b71a6262ffc477971697853452611aa4e3b4a69f90a8681f12b6a212997b",
+      "size": 109244
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4513_00.png",
+      "hash": "b724ac3ad91f9199465d6e008751c5129bb2d7ae8576a45ffe21cceffab77407",
+      "size": 111145
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4514_00.png",
+      "hash": "3048f164d2ce59daaf93c54258ed829d088aa3c7edc795cbff376a4f8f86ea0b",
+      "size": 105210
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4515_00.png",
+      "hash": "9d393b02181b7e592e0ce9a2c7c1985ca82115f0ad20f28698334980c1ce5102",
+      "size": 105086
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4516_00.png",
+      "hash": "0991893d6603075a93e6537ce210008d24fa5262b5128dd057f45a1d827de9f4",
+      "size": 104133
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4517_00.png",
+      "hash": "717d1e76deb19925f108dbc685f4bc1c7e52a93246ac2a6293972783dec5b0e4",
+      "size": 103252
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4518_00.png",
+      "hash": "9e1d788ca53db88df340f4ce40ab69e13f005e0431f7584b6ff6fb2998353e4d",
+      "size": 107615
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4519_00.png",
+      "hash": "cb24c193e7aa0230cb6634d701fd563402faa0ec7f63bb9189e1a9bcf2b44cf2",
+      "size": 106860
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4520_00.png",
+      "hash": "405cedee3fdc8f81fcb1c3f16f19ed6580a512400acbe69b73296ec9ab758d7e",
+      "size": 113619
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4521_00.png",
+      "hash": "960b53c3e294326a8e454301cbef25d149ff168ac58778483839716a1b4f7f85",
+      "size": 102621
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4522_00.png",
+      "hash": "ac8d23cef26e386ed3894b456aeb7e557c49f226ef0ad03c185967db38439378",
+      "size": 110936
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4523_00.png",
+      "hash": "14de36d44f7f6f95dbfad7992958e49187c88a9124b7108b55d4562b2ce7ecab",
+      "size": 102319
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4524_00.png",
+      "hash": "8ff7ed222185e0b841351a3feead48c2acf03fa1dc4c346e9a48a90c663c9dc3",
+      "size": 102648
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4525_00.png",
+      "hash": "b8a52619e374a9a58c85bdbe669dffdcb80c1e168c9d99623a2d64aeab09f072",
+      "size": 111509
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_4526_00.png",
+      "hash": "f2c7875fac05f892e8d43fbfeefaf9f448cc3f3291894cd6e90f16eb6a928ae1",
+      "size": 101031
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5002_00.png",
+      "hash": "a65885badcf3e78c79fbb6ca7840fedc9d767fc002ac91f4734974fbaaf59d92",
+      "size": 96947
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5801_00.png",
+      "hash": "b9ce0a5c0d7f4b138dc9d545e33144d85705854bd5175507e6d076f364dd43d6",
+      "size": 111302
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5831_00.png",
+      "hash": "f8f77f9a72853ff4fca4d55e32e9d932523f79c8d55335271450b28d2b9f2818",
+      "size": 101028
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5920_00.png",
+      "hash": "84bd34c1143daa8948dc3055b4ce20397c93ce96fef5efb3971e64928687e6d0",
+      "size": 98920
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5930_00.png",
+      "hash": "041e57b0de077b303fa2601618d9a10202e1d9f42383d9ae734d2b98fdb415f3",
+      "size": 117313
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5935_00.png",
+      "hash": "5296949832481668f74989b3564167444efa4fd9edaaa7927122902bc0265d55",
+      "size": 101364
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5940_00.png",
+      "hash": "157075348a5ee080d4a0b63d24557e37ca54e3ee567d376b5d965a1d85fc1818",
+      "size": 104500
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5945_00.png",
+      "hash": "c6384e8c94a8084ade031e9b6bfa2c00c3d4c853ce591d87d8c040e41599a42d",
+      "size": 112022
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5950_00.png",
+      "hash": "bc3bba5a1725bacf42138f480bd29069527bc7bf768f155dffa69c2b83446e4c",
+      "size": 104841
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5955_00.png",
+      "hash": "6427aa1f5a45b5a0cc2c863829c648d4c3a4f9c2556bf2aa31f0f9820fe14276",
+      "size": 102387
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5960_00.png",
+      "hash": "2ca4fcc3cf91b80b0efbcae7ce50885d9af1bc1be0cf92d88ba11c9e8204e385",
+      "size": 122477
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5965_00.png",
+      "hash": "af6334d462c6e2b0d0e26a97ad4ebc4c296bfd59b2d76403e3130873af338cde",
+      "size": 116573
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5970_00.png",
+      "hash": "448e71d897e0d185e0197a6b9cd8d4015d0ef2d25e8264e8221be8bb05c7b0dd",
+      "size": 114372
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5975_00.png",
+      "hash": "d4fbf7ff85b4f8b5d9ab9cac9235dab3cb286c6593c21af118e892fb3e296569",
+      "size": 103226
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_5980_00.png",
+      "hash": "1a2a84897bf4b13fdb43605cf02c3217d601524f92973e2cacd36fe53f621b3b",
+      "size": 101270
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_01.png",
+      "hash": "40fbd7bada1a81dac2e708e07d2e3564cd1f1616dde0a1d824404d22d394adc5",
+      "size": 97594
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_02.png",
+      "hash": "291691322eb2124f457a4007fdafd365cdb997f90299e841d2f9c8a0383f1ca6",
+      "size": 100720
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_03.png",
+      "hash": "55af41effa892f70770bde97f06b3db6689ed948929dcd08fc6158f0ee768405",
+      "size": 100513
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_04.png",
+      "hash": "23b29824374458a7b3113b84b7fbf5e5da8dd3c3d7a9c3a4447bd87bee6e1225",
+      "size": 97643
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_6102_05.png",
+      "hash": "0647f5755fbb1c2bfd61da5598ae5f9212eaeb15c6ad56d8ec9c335caf38fc5b",
+      "size": 98811
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_9002_00.png",
+      "hash": "19b1c3a97ad86a677b761672e8da647e50b651ff5875b60e634af8445801fb44",
+      "size": 123476
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_9003_00.png",
+      "hash": "0ad299e5518adcce56f2396177746f6ad81e52a336515c85e577adca03127963",
+      "size": 124597
+    },
+    {
+      "path": "assets/textures/race/racetitle/thumb/thum_race_rt_000_9005_00.png",
+      "hash": "eb86b512444dba622342865d2b17a97075c001519568aacc98f73d923b35a919",
+      "size": 118903
+    },
+    {
+      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_00.png",
+      "hash": "f1c88d034c2cbe7c457e4e057bef35013976b35b2d34d25795ba3bc6def27d71",
+      "size": 182801
+    },
+    {
+      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_txt_00.png",
+      "hash": "58d47b16cd2898f85884cf23c2462080f2a9425d423753d87cb89ac13ba9fc44",
+      "size": 194248
+    },
+    {
+      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_txt_01.png",
+      "hash": "3ba93e63ce352fff7542f4980288148a616c25a998243c7ddcf2d629880975f8",
+      "size": 188967
+    },
+    {
+      "path": "assets/textures/race/teamstadium/logo/tex_race_teamstadium_txt_02.png",
+      "hash": "7e072c27f89803ff5e5cf5550a78c07498f950e66273ac2b4ab626df3e557993",
+      "size": 182654
+    },
+    {
+      "path": "assets/textures/race/teamstadium/teamstadium_race_teambonus_0100.png",
+      "hash": "a022c15ba6340d5bca4695de0e4ffbe5acaec2a543922cfc834ea59e1b9d5493",
+      "size": 43464
+    },
+    {
+      "path": "assets/textures/race/teamstadium/teamstadium_race_teambonus_0101.png",
+      "hash": "3cfbc81abba4f17c1ad07d64a5cefb04d5bf1df340cd583913497a3c888dab44",
+      "size": 42906
+    },
+    {
+      "path": "assets/textures/race/teamstadium/teamstadium_race_teambonus_0102.png",
+      "hash": "85ac8d83eeb0a1f789a55be12dc0ccb5d12bc0e8718cb193dd4c4c609cc2254a",
+      "size": 48084
+    },
+    {
+      "path": "assets/textures/race/teamstadium/tex_race_tr_score_000_001.png",
+      "hash": "73f6dd103e96a0d46d24de43fdf59ca6d540c07583801b5e8fbd946c1d1984e5",
+      "size": 18697
+    },
+    {
+      "path": "assets/textures/race/teamstadium/tex_race_tr_score_000_002.png",
+      "hash": "135db57e14440d53c4493f98202796d6e297313f527eaa15037e44335fb8d904",
+      "size": 14764
+    },
+    {
+      "path": "assets/textures/race/teamstadium/tex_race_tr_score_000_003.png",
+      "hash": "db0f2d4296aef643315aab1a15d4ec505075b469d36d91675d0b5cea7c896214",
+      "size": 17711
+    },
+    {
+      "path": "assets/textures/single/menu/utx_btn_helpandword_00.png",
+      "hash": "0629cecae14f507e934c182cc5693f412a19556b95caa957177747d96cf2574d",
+      "size": 212609
+    },
+    {
+      "path": "assets/textures/single/scenariocook/utx_txt_cooking_possible_00.png",
+      "hash": "67c80e28b4a8e0eea25d15a4b7c7fdef274b6e7dcfd276e1e1d87158f69a0bcd",
+      "size": 183954
+    },
+    {
+      "path": "assets/textures/single/scenariolive/utx_txt_livefever_update_00.png",
+      "hash": "88a32c76e6c2400c3670d2b16eb2d0a40dc817693d6f384816bfefc4888eda1f",
+      "size": 197487
+    },
+    {
+      "path": "assets/textures/single/scenariomecha/utx_txt_chip_open_dialog.png",
+      "hash": "ae4058f795527c3efebc75f3d7b1a4440855d2c30330ab0ead5ce5d3ef24fb7b",
+      "size": 129800
+    },
+    {
+      "path": "assets/textures/single/scenariopioneer/checkpoint/utx_txt_report_cover_00.diff.png",
+      "hash": "d7bccc34832ae1663c8a5f7ccaf1269a5bb59e6c3911fa53751a55cd6ab5402e",
+      "size": 8248
+    },
+    {
+      "path": "assets/textures/single/scenariosport/utx_txt_advice_update_00.png",
+      "hash": "8ab7c0e19201d86ac053fb4accc8044c2debf16cbb8fc8e2ed3793cad85945f8",
+      "size": 72851
+    },
+    {
+      "path": "assets/textures/single/scenariovenus/utx_txt_venusspirit_get_00.png",
+      "hash": "3de82cb8a8e0be2d4aa4868e45970bdd24bcf44c6dc4a5eea4c9c2d44e5d5d22",
+      "size": 214453
+    },
+    {
+      "path": "assets/textures/story/telop/tex_telop_080000007_001.diff.png",
+      "hash": "f00304a78b080d287e2ea807f1f7925f2dc24932ebc21f535a118ab144d46b50",
+      "size": 12793
+    },
+    {
+      "path": "assets/textures/story/telop/tex_telop_080000007_003.diff.png",
+      "hash": "9d2e5adafcb1e2ab03eeeed9b6b8701e6b481fd9e2c2a7b9519d6df70e5037e6",
+      "size": 23288
+    },
+    {
+      "path": "assets/textures/story/telop/tex_telop_080000007_004.diff.png",
+      "hash": "63a5f361197c7aaa76d26dbf5dc5d99f0228b95d3ce91283bf9499baed71a016",
+      "size": 31338
+    },
+    {
+      "path": "assets/textures/story/telop/tex_telop_080000011_000.png",
+      "hash": "7bc943b38a0920cb72c93d603bbe727476ac58055fea11c20b72f555f1c77a9f",
+      "size": 16913
+    },
+    {
+      "path": "assets/textures/story/telop/tex_telop_080000011_001.png",
+      "hash": "27ec2c501914106de1565473e795b36175d85294c37f4d82b7fc8eb4f3554cef",
+      "size": 34414
+    },
+    {
+      "path": "assets/textures/transferevent/00001/transfer_event_logo_00001.png",
+      "hash": "925d3951a7338b3157735a9792784be01aee485f0ea9c880efe66b2f27b56f57",
+      "size": 194350
+    },
+    {
+      "path": "assets/textures/uianimation/flash/race/raceplaying/texture/skillname/skill_name_100971.png",
+      "hash": "b0c44e57ef6c17f3b06363ce575632e7d7ac60b6e57aff2ae1acd8ce35693e8f",
+      "size": 152656
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/racechampion/utx_RaceChampion_000.png",
+      "hash": "0f6519506bf460b05fda26dbbd7ecfb641a6d549aeae0cf8544f165b4db88418",
+      "size": 308458
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/sectionstart/utx_sectionstart_10.png",
+      "hash": "fbdc0a99f28e0e4701fa0298f6cba8256580f91c4afc2b1a44be007c07f532f1",
+      "size": 323652
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_00.diff.png",
+      "hash": "0de8a17d86cfdfee7c7cddd5c279d02f47b252cc0ee0a73dee852f1b90939823",
+      "size": 22907
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_01.diff.png",
+      "hash": "309a31f2cecd83e820235609be251978d5582ddf886c60b4496ceafba134d854",
+      "size": 22117
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_02.diff.png",
+      "hash": "bbb2b6457f0c7b32f595de33b5992e4f643788c8c1d2e4d2a2c7bbe269c78bec",
+      "size": 21870
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_03.diff.png",
+      "hash": "8b1e46d262e957920033ce6631c73dab88c47c4b108a84b5f6b772f953d9d8c1",
+      "size": 24465
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_ico_motivation_l_04.diff.png",
+      "hash": "d7afb0fb319b2a944e608d3ddb2a015f2e7151a5f340be9625ee7ad5483b4ce8",
+      "size": 24543
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_txt_charastatus_l_00.diff.png",
+      "hash": "675953d54b625b069f29a5e2807d344f1d2e3597a94b19264f9f47dc10774ec3",
+      "size": 8465
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_txt_charastatus_l_01.diff.png",
+      "hash": "b49638da91fdfcbc7da0154a07ae80480085ac8d4f50e79ca9aa30559f1f1254",
+      "size": 13548
+    },
+    {
+      "path": "assets/textures/uianimation/flash/singlemode/statusicon/utx_txt_charastatus_l_02.diff.png",
+      "hash": "f48a0dd6ad44a41a046727dce2910d5daea03011f820f08fad012dba5e505642",
+      "size": 15205
+    },
+    {
+      "path": "assets/uianimation/flash/champions/pf_fl_champions_result_finalranking00.json",
+      "hash": "9b488cbbb212cec1327e055643c81b8e8131ca3bafeaf3a7e5a1eb3350735e4f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/chara/prefab/pf_fl_chara_txt_hint_lvup00.json",
+      "hash": "3118bde83424c56d9d0cc63179eee4878879e5b6f142d38d7ca2bfe96b314c03",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/common/pf_fl_cmn_badge00.json",
+      "hash": "a60f640470ebf31eabbc8d03cb7a9e40cba18f308d1e441ee832e4902ff81759",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/common/pf_fl_cmn_txt_event_reward00.json",
+      "hash": "72762778aca553800a3de70ccb21e1be1200ff93bbd49ff79d92969a8d63dc07",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/factorresearch/pf_fl_factorresearch_gauge00.json",
+      "hash": "97730a2423b65acbe4cf9bf45eb2fcd0403b524d09d6198d96e394ee818b4638",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/factorresearch/pf_fl_factorresearch_reward_txt_title00.json",
+      "hash": "1956b2b83ad44acaecf6a90963ca003febe740e810018c1ccc89e20728d1dc29",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/footer/pf_fl_footer_landscape_btn00.json",
+      "hash": "54fbd2fc730116a3002f3686308ced361c45c085667da7ad6cb8ddaefc444fc8",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/gacha/pf_fl_gacha_chara_piece00.json",
+      "hash": "e99050b0aadd81bcb009e983cffad945dd65d8816f4444fc3d62186a25181b0a",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_btn_get_heroskill00.json",
+      "hash": "b2dd3a5b279f61428448edfadd71e340564aa06028d9a3b6538bbacc92f38b3d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_get_heroskill00.json",
+      "hash": "05559f64d8848eb59e8d431e214759376f7c525a5d998ce64c82c5820f32f24f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_matching_comp00.json",
+      "hash": "17df667123a624d4a2e90abcb323cecb0415f87227bf1bf9f2fdb9f1ffef8f9e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_raceresult_gaugemax00.json",
+      "hash": "c22ddd973ccfab3ac1d6fa96ff0156d50eac0721cd29147512cb323d07595ac3",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_raceresult_raceend_pt00.json",
+      "hash": "a3fd19e9c16903702e9b9ed45de9079f5ac301357cb9334bc0b69f87bfc01305",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/heroes/pf_fl_heroes_txt_racereward00.json",
+      "hash": "98073572c5083dfd7ba61583c3a66d0d29b4158d8ddeb6e231c73806e0e3e4d8",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/loginbonus/pf_fl_login_normal_title00.json",
+      "hash": "7568dc9c94cb9c8dce113dfc696a611964694f4691254017ff52b893288de046",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/minigame/mng_0001/pf_fl_mng_credit00.json",
+      "hash": "2124fc7923d5ee809e1541a1171ede2111fd26981e70ab9d24410a10d9434a6d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/minigame/mng_0001/pf_fl_mng_dialog_get00.json",
+      "hash": "cff798628e5ea3d64a1f2cefe597ebf2649e78b30da10a39a5e5ecb63d8d33d6",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/outgame/pf_fl_trainingreport_reward00.json",
+      "hash": "e9717e2ca1f10f91082000c9967bedaaf3424c5c78b1363eb6586cb8066be2ec",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/outgame/pf_fl_transfer_txt_negotiation00.json",
+      "hash": "77b21caffdff23c9a3a7510fb17c454584683dbe87841044fdef51caead09091",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/outgame/prefab/pf_fl_contactcard_photolibrary_icon00.json",
+      "hash": "dd54f8708dc9a10b1d40b0c686d8ecefd9cbb7b21304f447e1067ff56fa409c2",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/race/raceresult/prefab/pf_fl_race_result_rank00.json",
+      "hash": "26d4bdef11764d066a5d8def892e4a874052b4fcafe6b275af7327bb2dc46e84",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/race/racetitle/prefab/pf_fl_race_rt_04_00.json",
+      "hash": "356ea2d9266a9bed422c6a82dbcdead6f4eed9e36e0214db2e52381dde0b3deb",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/race/racetitle/prefab/pf_fl_race_rt_06_00.json",
+      "hash": "74236f37c9a2981ae4abb60b5ce4e26dd0bb3e31d5640e0ee339eac5ba8970fb",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/ratingrace/pf_fl_ratingrace_result_rank00.json",
+      "hash": "fe24b5d6f145a338b85e409847058f8f2d297168f5ad27f6ce1371975e004d50",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_abroad_expedition00.json",
+      "hash": "07805c13db160da8a8f4cac6fc3a06cbbe1217060104cf18eee175f5e28aa942",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_btn_trainingmenu_ssmatch00.json",
+      "hash": "0220080a1aa6b43bab17914d20595a927760890d4bee73706e5d790d132b1f9c",
+      "size": 2380
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_event_racebonus00.json",
+      "hash": "e20826dda2b489ca1f771ce5b356aa1d639e1ea4d85e31f74bd86c1e78e93e34",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_event_stargauge_up00.json",
+      "hash": "ac0926895b920d4967b2e77598d8b3c244048b1df3297accb39414881e4bc86c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_extrarace_result00.json",
+      "hash": "3782209dc27d9f9a47472c02272d2ca37ca7cea6b35a1107ac889b8e42e9c6c1",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_get_response00.json",
+      "hash": "b18dfb96fb4b43f3ef9c92177c3233f63fa11460321f45a1f84e27e2e1b75bd8",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_header_turncounter00.json",
+      "hash": "b1a3c103990f0c69ee592ec6320388b9694899af29160fddae149fee979be486",
+      "size": 2159
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_next_target00.json",
+      "hash": "39a6958eea233d21b436f75d68ee9bc9c7194a9a0cc5bc9814e5b9d597144faa",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_remind_turn00.json",
+      "hash": "f119fec67bf6ec5524761ac7e0fd7216bfc689dc5ec8b1f085d7f718880151cc",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_speech_bubble00.json",
+      "hash": "c7bfa5e84f5a4a8f9866973c9be968829db18c6fab560635961e017355b83918",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/arc/pf_fl_singlemode_arc_txt_lvup_response00.json",
+      "hash": "96f59bb265c29f23c712a74913a54e884b9739fb465ef234224bc477e8b7b5e1",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_badge_garden_reinforcement00.json",
+      "hash": "c2b814fdee212314694fbe5dc9866bb2c493373d29dbf73a3c5cb8c36e633f5f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_btn_recommend_dish00.json",
+      "hash": "d5b7d6eccb2369ac1c8ca3ef79ad6e6097f96a2352e523c055ca23cb209ffe11",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_btn_trainingmenu00.json",
+      "hash": "ddac3300711137195c1e36500ef71bc7e1e403de3dee45169c1de8018a0311b8",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_care_harvestup00.json",
+      "hash": "45e28f07142b28d63d8b6ae6968a061204487f8fad99146239dd610704fc28b4",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_care_title00.json",
+      "hash": "6e9ed4a64f4209d6914520d59d5385251af2fd7ed22d194cbe471ae2db6bad92",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_btn_kaien00.json",
+      "hash": "a8062b8da0c4fb1b24ebb566738454438dee900f2a9e9753d66f5e1e20843d68",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_dish_add00.json",
+      "hash": "9d5244370053acccd959c08940154915d59020d8574af4f4c561be23219f4007",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_dish_efficacy_up00.json",
+      "hash": "0c8ba52524113eb1240845b4e2538998624627a921476dda02b6642b982a5064",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_join00.json",
+      "hash": "3dc23e0c65fd856eb42d196796242c71969ab6b6108b162895c75e73ac024723",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_uptrainingeffect00.json",
+      "hash": "20fd4b2854c4bf29ed7ab91f67b4551eaa3913b0ac006e168bfad7688587cf58",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_event_vegetables_lv_maxup00.json",
+      "hash": "dc38d0514d25568b0f82523928d17d1f94432ba07e6b207385d6d6fca1cf8c73",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_get_vegetables00.json",
+      "hash": "9c4c75135888347145e930e1f42a72ddfa281970fcb8d47abb682958f8fac585",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_header_turncounter00.json",
+      "hash": "136901cff19f1301c847c015dfba766ecc79cb7cb6b7916e920a83d8a4b9a830",
+      "size": 2273
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_premonition00.json",
+      "hash": "5abcee5f5e2053043ceca5b2b19676535b6498f0a71874e7b06f8fa705e11775",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_ptup00.json",
+      "hash": "a08e2efd40b7bd1cc9ac225b132717f862220ab8b151311910c7eff90ce96411",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_remind_turn00.json",
+      "hash": "9bceacc4f03aa4706d56dd6bdd21697c559e5e8dff7c8bab32f547f2af6b0380",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_training_multiple00.json",
+      "hash": "229594caad57d0933925a7ca3ffdf7c268b2d3a9256ae049cd6d88d030af0a04",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_txt_harvest00.json",
+      "hash": "0026876c9e101f19ef9ac12035a61d086d2d4565538da90297074fc23fc2a250",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_txt_manzoku00.json",
+      "hash": "fccfc72f982f3da663afc8a6976d49ce765a79b23e487f81eb4b516183850230",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/cook/pf_fl_singlemode_cook_txt_success00.json",
+      "hash": "6e0a6037a143a6a2c121a91fdc0d60f972123320fc83f06862d8e0728284937f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/free/pf_fl_singlemode_free_header_turncounter00.json",
+      "hash": "ad4fb862ed0e56a05a89486642a2a2d4c7e134f1bd018f55580c9aa500296abe",
+      "size": 762
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_btn_trainingmenu00.json",
+      "hash": "d3236437b05de4915d58b51a3ed8d781d31b7ae5a1ce15d9db8f9f847bf6fffc",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_buff_get00.json",
+      "hash": "0028461d61d17303720fc81192a02dbbddf92f58a4ea204a12e70965bc98cf7d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_enter_masterly00.json",
+      "hash": "6ef6ef2056eb13bf901feb83ccdd01fd8bf17aa36436a1ebea8f240056a852dd",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_enter_masterly01.json",
+      "hash": "63fe4bb4f0336be9a26d79b1505e294fe61c274ba74d006b64070d078fa69e7c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_enter_masterly02.json",
+      "hash": "170afc0195680f718bf3033fd2a71a66d009b2dc7492ae6c026891908ca85cf6",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_event_legendappear00.json",
+      "hash": "fa1739b48ec40d5f0557bfa719b8bf7b79a93b776865155b7b715065c211f2ca",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_eventbonus_upmotivation00.json",
+      "hash": "9a3c69a33800742a4fe873dfbc3c5e74d951854ebf629f7e329c769d6909104c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_extrarace_result00.json",
+      "hash": "85b8fe16d4b3e5ba1b2fd5785861dba72383588f23d7e9aafb10d8086956ba6f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_extrarace_result00_01.json",
+      "hash": "9e195aff97174685b8593940d80d28341cda706d324498f203bddfdfa91de2d1",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_extrarace_result00_02.json",
+      "hash": "c596dab11b90fb7af877ec6a73d01ed5b31414ea4110b97102a82faef7d5bbef",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_header_turncounter00.json",
+      "hash": "c3cee204bc9f2fedbfcdcbd39aa008744a8c2666e20a107a65ca2871c8ccbfc7",
+      "size": 2158
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_icon_motivation00.json",
+      "hash": "abc9b6f135f88201dd4ba95b23de73d697ffbf610ba91c318c9fa538632505f3",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_masterly_frame00.json",
+      "hash": "93e8efc60c10c2fd8ae8f236b731249e23a34fa4b687db6867e5a20dfa5df1fa",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_masterly_frame01.json",
+      "hash": "22373c0d9cebbb0fd8b98ae56bdbf1bb3034412ae7526bcdf52f91f2e8683d70",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_masterly_get00.json",
+      "hash": "6b418c4a2d9773840393a834ec60b2fd18593e266bb9563f2c4f7f3bd50e0e0e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_next_target00.json",
+      "hash": "b4078d5d60607f89b4faa480162a6c685e4ff54ea4323a034a1c70bd1d4e8aac",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_remind_turn00.json",
+      "hash": "c155600e0dbb42cb2268f7d29e7418ec5679cdc25f1704d7c6ad92f2fe574b53",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/legend/pf_fl_singlemode_legend_txt_buff_available00.json",
+      "hash": "e15a7402a1cc7f4352aba3de3b838ad164ea88d73cf691ba868a3d2e83ce382a",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_btn_trainingmenu00.json",
+      "hash": "be5c7ad1c9cbc8b5073538ebb9d1b3b78b58c49d607902f3f41fa9001cc8396f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_event_join00.json",
+      "hash": "067100dcd56e4873231793c88f72c4b623dd576fe43c9c96935649d9153d1138",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_event_live_expectations00.json",
+      "hash": "f2857de7924d0fe34cd15fc11e71f64a73bfa18e1d62fc5c921ece83c2aac1e2",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_event_trainingbonus00.json",
+      "hash": "0fc9b18d0ee99ab9e8571cf5fccc61e41984ff7c78ff27ef301614b003363ec4",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_header_turncounter00.json",
+      "hash": "8806ba3669740a04e499367f07e62b8022a331471f2046b75be6f638d648cdba",
+      "size": 2157
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_remind_turn00.json",
+      "hash": "abe8ae808be0f41417355601cbe494b7fca1edeaccf088b376f6889913bdb42d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_txt_get_livetech00.json",
+      "hash": "e05e55a6977de924da341ef8701519145ab312c197db0ae7ae3ebcd4a5ae16b0",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/live/pf_fl_singlemode_live_txt_get_music00.json",
+      "hash": "908d6f5491172a6f5b07358939085b7b01f64726ab7b2b91a571d770066b0f81",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_btn_overdrive00.json",
+      "hash": "59755ae3f15cc8932ba444178c6a9746c99fdccc508b34474fa1d89beecb279d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_btn_trainingmenu00.json",
+      "hash": "18e5079a40eabf183bb73209f384608e8f76189958548aa07acc58dd78dd8cd8",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_event_join00.json",
+      "hash": "855ef73b19e94c761cb153e0e19a316fdb469e28edfdf0c33cd3f6b65d5eea3b",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_event_uptrainingeffect00.json",
+      "hash": "8e6de8d756cb57c6937888822dc5a9ce3dfcceb7342a331179f2e9cb41c0aa6f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_header_hpgauge00.json",
+      "hash": "052046edcac4eae5d6d9085d58af7054ea17ed96b14ebb070d679811c4a28524",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_header_turncounter00.json",
+      "hash": "2208356a8420ce8f5dd3e0d24cff8ad1cd22292e896c5995c8d364b69c80740e",
+      "size": 2160
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_overdrive_recovery00.json",
+      "hash": "40e5ad08a06a6ea6e03e833275c48c93333029cc2ecdbda25e6572a6e60a7e37",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_overdrive_text00.json",
+      "hash": "18b8f9b044eb055bba5033a2a2343e89df0f685b4714548dac836f7e0a29bcc2",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_remind_turn00.json",
+      "hash": "4020f2c40c7ecdb7d1dd34370423f3878d0f28a5488e21d588de0b4a0b74b449",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_research_lv_maxup00.json",
+      "hash": "181a946eb40c3763458f084f3d951790819353ae5499d69b2b24f723aaee736c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_research_progress00.json",
+      "hash": "8047b4ec7a45b9f54b3abae61d5fb711459357bc761ca20400334346fbc87a3e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_research_progress_text00.json",
+      "hash": "6d87693c0584757a7b8cd8fac714f95d322e620312a5f61ed3c5353fc7b90ed0",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_sp_overdrive_activation00.json",
+      "hash": "666fc4420aae6fe8bc76b734f415595423b6e2500d156a63f22cd41124bacfd9",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_sp_overdrive_btn00.json",
+      "hash": "2260c0a29c6f21be1b59c03b184e014475034f00fe9faa62f4909fa6a83c7e20",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_sp_overdrive_continuation00.json",
+      "hash": "96527827ed2b2f6ef96b44a937497cad9587884ba7b38c8524c97e6539e292c7",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_target_research_level00.json",
+      "hash": "2a471f313ef970d9d2135b83b91102f24934e5cce6bdf0b0f6a4b23151b6228f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_trainingmenu_base00.json",
+      "hash": "53364caac4d4ece2d13b7c8085988a1523033fb557a96d1a8a417dddc54741f9",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_tuning_text00.json",
+      "hash": "6e03b02175dd6a16227d5f446729f43609d08829b8b6794295b289b3ca9b1b79",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_tuning_transition00.json",
+      "hash": "dbcab8dfcf3a3fece087c102fb1baef4a9b2a23b6bac7f9db35802c0720629c9",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_txt_upgraderesult00.json",
+      "hash": "800d677740a9c5a4bedcdbcacc794785f66cf6146c7af67e34b0bf413e262a6e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_upgradeexam_btn00.json",
+      "hash": "f08c4c56975ef8a1d1d24a7eb2f040d2bf2c754d0a2a0219b8144c536d45d517",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/mecha/pf_fl_singlemode_mecha_upgradeexam_start00.json",
+      "hash": "d3c8c65343f4c6dcace7d6a314b60cdb6340ee0bc38acee6d3b0297a80105712",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_break_resultpoint_record00.json",
+      "hash": "49a455c225506b916d4a983dc3f7eb19f788f630af6732c75469f2d07d269160",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_btn_factor_succession00.json",
+      "hash": "2f56cc9a945d83927b1fe1276df3ddfb2c3d129589bd996c45de03fa1256e22d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_btn_trainingmenu00.json",
+      "hash": "5ca125c03e1d16f9536c56f356ae0f8c6dc2b1b84d1e99d234aa81dc6affb61d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_btn_trainingmenu01.json",
+      "hash": "623c924ba07db210673fa4f91e7507f9714bfac80f25711e21511cc998a759ec",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_activecondition00.json",
+      "hash": "8f8514d59cf4d3edc6aee4fced62b172b406d6ec99e7a3bb67b71ceb689ad126",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_apptraining00.json",
+      "hash": "d9d2a614c7d8e345a0441215806e8673efc48e7da3e5fb8976e841b0be9cb088",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_dncondition00.json",
+      "hash": "02f9458954193ab3768d8584f3439739a6d58c457595b712ad1f6ca30e272415",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_dnskill00.json",
+      "hash": "eab73be9fac6a97c72cfbfc4c3e0619cb877ae3b3b81bcb89e9902aa2a6f9285",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_racebonus00.json",
+      "hash": "7265daeb3cc4e17549bc6efdffda097d9356735c10e97912f8b7c6737142e8d7",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_resolve_dnskill00.json",
+      "hash": "bdcea7ac41a10973fca1a082bf7442deb5acf4dcc753fe72fed6f4643cac5aeb",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_resolvecondition00.json",
+      "hash": "9488c1e51108efd6aa6ece950b261b89355662a7a2a683495de7390f6ca8b863",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_succession00.json",
+      "hash": "0826a0491ef93770d48baa6173429e15f04b1ef69a2b63d51f4f77523fd6bbb7",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_target00.json",
+      "hash": "bffd7d0e5aeac535fcdedd4638c2fa056f94cfbaabe9a58c9fbaa8a93fb7051a",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_upcondition00.json",
+      "hash": "5726076133a6ba1a40c651a9c797124fc92aa663182833846f3f5a5857990759",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_upevent00.json",
+      "hash": "7c6fedb1b8a8f309ef11c28486bd5268e7fd11bfab28b3f93493765f37cab612",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_uphint00.json",
+      "hash": "79862540f6e1b9c977976303a361c5c26d9797b0379c316890ca584679ead2d7",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_eventbonus_upskilllv00.json",
+      "hash": "849e912643401c5a1b10c4760f44b79071084a7d95d5de1e65c9c90b24368a1b",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_extrarace_result00.json",
+      "hash": "0153fac8593fb2831d346c946914f7fa4996535c0a6bfd46ecadfe541da01ea9",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_header_hpgauge00.json",
+      "hash": "53bb896434e169c65334ea25b34989de3ca40a23ebff61b42099cc2da32eca8b",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_header_turncounter00.json",
+      "hash": "dcb20f80c267d7c8e17791cd85b0c809ab10e0a091ec3ac2f6286294d03bc15b",
+      "size": 762
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_hint00.json",
+      "hash": "9e67734670bf6f13cd7adf15432b7755c4ff79e4e3b28236244372109c7b34ee",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_icon_motivation00.json",
+      "hash": "a626ef49167c1625b6e682931d7ed1bdad7d2bf92cded21c7ad074a06c718304",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_next_target00.json",
+      "hash": "0c0fa953cd19f8fee4958dbcaadfcd3565700f0686fdf3412c288861a30c24be",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_result_chararank00.json",
+      "hash": "7972800b5d0af60ae4a8a1cf53a37c29d87cb2410d2cc99c6ac1e79b95bf5a28",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_result_scenariorecord00.json",
+      "hash": "936637f2106b93b6fb20cb045dbd5aac036751dadff8f05d187fbe422f6fbae7",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_sectionstart01.json",
+      "hash": "6461cc4fd7f420a21fe16cd7a5a7c75ab7158ad64ce0902f8fec95a928f5611b",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_single_target_achieve00.json",
+      "hash": "b19b27215dfc870d36ba29b1573e7b6c37ce9ca95239fb1c1ed7fc76b3093f99",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_skillupgrade_skillname00.json",
+      "hash": "55355813bb08816ac33451ca522c2a627111c25703c9610231a50886c77609a5",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_start_succession00.json",
+      "hash": "d5e069952512bd95b1185f9f557141bdfd406e4d2f75e48edc21f472558555d6",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_start_tagtraining00.json",
+      "hash": "3dea44838995d33e769084d22321b176be329e36866d9778029a794cf681d2d7",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_target_decision00.json",
+      "hash": "d984b46402457bc683b696774e8deb7762934a8b4d176e2cc9f746e9901d8b7d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_title_getfactor00.json",
+      "hash": "9951c03cb6d04a6424798c6f28c4665cde1db48b2e5800f71d7bb25540cf186f",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_title_getreward00.json",
+      "hash": "8f6711b50251df757b6a6e4649abfd9fe4c3ce50a7b9b3cf4ba15ea18dc9eedf",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_auto_training00.json",
+      "hash": "bb19de5c9d04b49ce9505b72669681e9d517aa364fed37d3fc2133d6cb44d4c8",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_factor_succession00.json",
+      "hash": "666bd68f371303f98fba8b008a2dda73ed9e511adb6955b47a8f9f8e17fdd29e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_tagtrainingresult00.json",
+      "hash": "ff9620f4268e3e8613c321b06abcca17b6e56d0db9b7661baf0010e2b109c4a0",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pf_fl_singlemode_txt_trainingresult00.json",
+      "hash": "697a616e34090c48a8e2a47bb0b9c8255e50fe9475f123d95bc3fd2715f204cb",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_badge_shimatraining00.json",
+      "hash": "fdf598924321852b4e8be9b76ffff5a9e3b915e22ef119f8d43e4b84f025e7b4",
+      "size": 410
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_btn_evaluate_decide00.json",
+      "hash": "cce95c4f3b230918879d57c041072c3140526a8f2c3d3883dd4862d5f9813cdc",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_btn_trainingmenu01.json",
+      "hash": "778359ca4b2de50ac29d491f240fab34a109a81f058cf1c6e7d4a1dc85cc1df3",
+      "size": 408
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_btn_trainingmenu_shima00.json",
+      "hash": "aa731cc4a7da8b99fd4459d7dbbbe69778d584c196fb472c5e8e5c7eeedcf36a",
+      "size": 589
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_construction_progress00.json",
+      "hash": "79645353e9a053e8d07e9233c0a287f4cf3b1d6da83b98eb1b0c46bc047151f3",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_construction_progress_text00.json",
+      "hash": "f644d793587f896a5052a55c26e366dc2e1a1939117d0fede0babafd6b87f69e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_evaluate_start00.json",
+      "hash": "0c0ab0cb8c57f6bd7755a877aa232786ef196d08a4a5882b3225f34f10e9411e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_evaluate_start01.json",
+      "hash": "2141f5bc3ea8b06b7d021e0c6b273a953676c7d8620062c67edc3882893831ee",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_event_join00.json",
+      "hash": "958d7f30a60f7f123ca4da33d7652fff1a6a065c16c610ca499e2cb48df7d7e4",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_gauge_shimatraining00.json",
+      "hash": "0bcaad8a319b531044673fa938fa21477cfbb1625305d5d3ff61e2a088c68792",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_header_turncounter00.json",
+      "hash": "f52a72f8e37835312da6b96ff2936ba0733ea6d18d1d360859337c482a8d31b0",
+      "size": 1325
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_complete00.json",
+      "hash": "9379df548f2b142078375484db5e1d41d364aab7eca0d4a4caecd2d70e3da712",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_complete01.json",
+      "hash": "c1e5cb2f10493a2c82970c82f373e2ea6930ce43d1d4a8a7cae614eafcc13316",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_hint00.json",
+      "hash": "fba3671be7bb7414d18d3e33d04fcfcbbfcfb705499d5f20a78212a325138c1d",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_transition_logo00.json",
+      "hash": "2ae42db5833e969534af2aba938ca5f6feeb76930bbadd4c5624bd3975606961",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_island_transition_logo01.json",
+      "hash": "2c611e6662fa8e2ef63b92168190297bc72ff7b009f14e2abf0513b153177143",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_notice_window00.json",
+      "hash": "3ee9bce05988261e2c50e693bec44c08677cc9b5a8adeb1819262f4f38823f53",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_planning_island00.json",
+      "hash": "8b57be613dc1bc10757d5b710d74fa1e814338affcd1ae1079bd2fbb692c40be",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_remind_turn00.json",
+      "hash": "f32bb27c48848c27411a9b424e01b0ac145906a0c3ee41148353e43741f3c30c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_shimatraining_acquire00.json",
+      "hash": "f8ac0220ab6b804a90ebaa5e62c0c140106753da7cccd2e61845444ba6c97eec",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_shimatraining_period00.json",
+      "hash": "4e46f46270ea3937f02276a844ae5696037fd0939ea1fca99587671fbf595a5c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_shimatraining_split00.json",
+      "hash": "067fa7260b02726c7478a3cc9d92d3130a71bdf321f423d35f16ff90ab82b6b3",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_start_tagtraining00.json",
+      "hash": "831db5309cf545c17235c2a272e8a9fea4bebe5fa1be75d03aa2bdb4348e1cc5",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_training_facility_upgrade00.json",
+      "hash": "e5dd2905954cd706739ba1c1275432c907bfbb90241e6a96de211aa9e7ac9f31",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_trainingmenu_base00.json",
+      "hash": "b64e946a98472225436594c502955f6f07e89f770c22f333e14a174fa1b91b19",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_txt_evaluateresult00.json",
+      "hash": "645008f556fb08a6d2017a8f678e15cd906b00d2d70c5ef2c7cc900810dc15ae",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_txt_shimatraining00.json",
+      "hash": "52a06503492383eada91b0f1230a5d3219f9fbe1fd68d2be0f6ce739a8be68c3",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/pioneer/pf_fl_singlemode_pioneer_txt_tagtrainingresult00.json",
+      "hash": "5e41e6e6826ed7d1aa29cadf481418ee2ce13fc803e485135927f34af323452a",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_btn_competition_decide00.json",
+      "hash": "345f5a6b0d7fffa3399cfc6536d8ee7773e71ce3a2d609e2592bdd10a16a3746",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_btn_trainingmenu00.json",
+      "hash": "5cf9fe957d1c525d7cfe6312cb7aaeadeb520da97654ea0155f4eef618c82d8e",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_competition_gauge00.json",
+      "hash": "a3696648e84e13a583ee9e386135bdb34495bfbeece1dbdcee5ca9fe04c1de90",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_competition_telop00.json",
+      "hash": "9731cb6986d7be122a58acdaecb26fd80cf3ba3eaf946ea4e6aacf6ad8a86ee2",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_event_advice00.json",
+      "hash": "176ead60b7ea5f4781450a485a2983b2cd50b79ab103ef868f7d7ac8eeea60ee",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_event_stance_rankup00.json",
+      "hash": "2c383f4913bbeac0e5ee4c14a779756604ec86b178a80f1681d58a4add6d2f30",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_header_turncounter00.json",
+      "hash": "3ad847f9a0d68880cf44e91aa00f093d53cb05297eee245facd9a1c9192f25b9",
+      "size": 2161
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_remind_turn00.json",
+      "hash": "356cce7e954f5c6f31c1dc5d4ae6bc16bd04b7aa486b6a58de7c9d816346df3a",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_showdown_result00.json",
+      "hash": "890abd5f74ea1a4235b1e73aaa522441487ebfda65277e2682387edbd0513151",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_trainingmenu_base00.json",
+      "hash": "5ef5d0ffc203612258fbcc12841c4c44abf40fc847dc3ebce81fb8b35e29330b",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_competitionend00.json",
+      "hash": "70afc3ea218b6603c1bd8d1272470d2c087d97e9501c1f593b17650fcdafda54",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_heatup00.json",
+      "hash": "c273c93c0d40a8ec9d41b35f0bd4e357950e00c9b876f7664fe8bdac5fd30d04",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_tagtrainingresult00.json",
+      "hash": "f990bb9ccc0b91712aa9e5db9686dd44ec0e0deb8d1a25f4469c96a508e40986",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/sport/pf_fl_singlemode_sport_txt_trainingresult00.json",
+      "hash": "ff51ee6cb5213b24a951812b78c8d536bd3d7f29fd511a0c7bd3792637095ef2",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/teamrace/pf_fl_singlemode_teamrace_btn_trainingmenu00.json",
+      "hash": "7d4fd5e6491f61da4d31b5b7f08cf0582f2f1851830901e4c716df4172664e00",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/teamrace/pf_fl_singlemode_teamrace_header_turncounter00.json",
+      "hash": "f4f43f5ea1a546b88fd258b6c38f25ce3a4d6b94bb4dd929ebfbe6934fb14832",
+      "size": 2159
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_acquire_spirit00.json",
+      "hash": "3386f13c2a76c46b6cca58adcdc5bc963670e430fcc371683bae43c41264b2c4",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_btn_trainingmenu00.json",
+      "hash": "016e8ca7841e829daa1370bd5308fc7ee84b682a0cd7b56a6b048876803c57a0",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_enabletagtraining00.json",
+      "hash": "109efdbe063bbf0abb012c4abce6d6ee1dd9a44aa5143909524b1c951c29e9dc",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_upeventrate00.json",
+      "hash": "1e923aa9da9a4bd61ef885ab8a67212510149ee770c462e62be010a7ffeba202",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_upknowledgelv00.json",
+      "hash": "a934768f130a994a429f72b63644fed78d1f539468fadc321170223f6ea3b892",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_upskillhinteventeffect00.json",
+      "hash": "9a68a76d58b70150df878480cd82f9d1b6edd72566fd687e83605b56667390a7",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_uptrainingeffect00.json",
+      "hash": "483ff81a73fe473f762b22dfb43b4fe84c27e0a1cfdd4b6f9afa63a06c066db6",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_event_venusappear00.json",
+      "hash": "4e95fe9d7e065220ffe429a711c44d3123e4ace19d1c51b544adee07cffb876c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_fragmentlist00.json",
+      "hash": "da9ddb3f214f93565d1df59fe12ce55cfa9dc714a6591c2a434c65b3b32e41f8",
+      "size": 410
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_get_spirit00.json",
+      "hash": "de9f2c6397ff28d3e859706582d85c44dbcc5f12453546f761d90a1c5bc1e919",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_get_venus_spirit00.json",
+      "hash": "87cb67c112e9107df5f1f4c959521cef989d72e8754cb49b96a930ff7370567b",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_header_turncounter00.json",
+      "hash": "f372bf12d775c8cd336cafe6c06f977e29391e0b5f6516af454bcbedb803f926",
+      "size": 3165
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_remind_turn00.json",
+      "hash": "3dd83bf4dea1bd4fb25498218e0013193bd13ec5793b4d4af345e122272f1d9c",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_spirittree00.json",
+      "hash": "6a4074de6817b0e1cd98a48b51261bacc7fb532ea73ff168b991b8f2edef1e33",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_txt_tagtrainingresult00.json",
+      "hash": "14fd5e74e43c76e9964fca881b0b82de533f8374d81a62b16fb45c9d1a505a61",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/singlemode/venus/pf_fl_singlemode_venus_txt_trainingresult00.json",
+      "hash": "7da9f22c47da19d62bd6095d50ef5026ff9816ae7dbb6bb2f93facd1ffcca0aa",
+      "size": 166
+    },
+    {
+      "path": "assets/uianimation/flash/teamstadium/pf_fl_team_icon_winconfirm00.json",
+      "hash": "2f39c774ca4ad6ed17e7d3fa33da204e47cbc4a1e8b43306bc38a70f036d6247",
+      "size": 166
+    },
+    {
+      "path": "character_system_text_dict.json",
+      "hash": "70cfb90964ac589076aadaa3fe6411947a181737671e676e7643da1591001ed3",
+      "size": 220278
+    },
+    {
+      "path": "config.json",
+      "hash": "e8b2f428d411118eac97732783f91c9df50bc3e569ba33716cb7076b514d7d65",
+      "size": 1582
+    },
+    {
+      "path": "font",
+      "hash": "701c57fd5edba8d774d2003df4568114df3be3985f4d3e56048621d8f294f6f1",
+      "size": 2180361
+    },
+    {
+      "path": "font_android",
+      "hash": "c591c48989195582688a6ab8872a15d5eddd07a182fd33c4ebf230ac2bee008a",
+      "size": 2179227
+    },
+    {
+      "path": "hashed_dict.json",
+      "hash": "2f6f90252e6251adb733f53b84fe19e86304703b3bbd79333b90e32ec9666f7c",
+      "size": 9843
+    },
+    {
       "path": "localize_dict.json",
-      "hash": "216508cb625a378b858f1e8b8f1c74652dd67b1472edbc7208fdb185be207126",
-      "size": 35678
+      "hash": "459f3502bd0a08c10304acaefff7d55f88e32aa1142edd4c27d7fc576aefbb68",
+      "size": 271017
     },
     {
       "path": "race_jikkyo_comment_dict.json",
-      "hash": "4cba2476cceab9b48cf43a8ff918e7734c85f5e6ea968d603c61ff02505ba731",
-      "size": 24266
+      "hash": "acf47eab3872600f204f41f2a898c75a033fe334312ce19c91d858fbdeaa7c76",
+      "size": 1255
     },
     {
       "path": "race_jikkyo_message_dict.json",
-      "hash": "b3abee4a2fe9c63c5d05829d49781335640be45e5b71c65a6e3cd516d74b7b5f",
-      "size": 84987
+      "hash": "ad10f35d3714b99ee839a17b0d4a2e6f176b3162ecdbbca346bd22eeb8063ec7",
+      "size": 193549
     },
     {
       "path": "text_data_dict.json",
-      "hash": "8295436912e7b48ee1f8638d87d616cbaaa5391023cadf3da66703a68f2b89f0",
-      "size": 1879909
+      "hash": "13e2176cd87c0b23f2134346e426beb5076eb38900e965d57ca543a28829e0b4",
+      "size": 3352219
     }
   ]
 }

--- a/index.json
+++ b/index.json
@@ -1,7 +1,7 @@
 {
-  "base_url": "https://raw.githubusercontent.com/Hachimi-Hachimi/tl-en/main/localized_data",
-  "zip_url": "https://codeload.github.com/Hachimi-Hachimi/tl-en/zip/refs/heads/main",
-  "zip_dir": "tl-en-main/localized_data",
+  "base_url": "https://raw.githubusercontent.com/Rekoiru/tl-en/dev/localized_data",
+  "zip_url": "https://codeload.github.com/Rekoiru/tl-en/zip/refs/heads/dev",
+  "zip_dir": "tl-en-dev/localized_data",
   "files": [
     {
       "path": "assets/an_texture_sets/as_uMeshParam_fl_footer_btn00/tx_uTex_fl_footer_btn00_0.png",

--- a/index_base.json
+++ b/index_base.json
@@ -1,5 +1,5 @@
 {
-    "base_url": "https://raw.githubusercontent.com/Hachimi-Hachimi/tl-en/main/localized_data",
-    "zip_url": "https://codeload.github.com/Hachimi-Hachimi/tl-en/zip/refs/heads/main",
-    "zip_dir": "tl-en-main/localized_data"
+    "base_url": "https://raw.githubusercontent.com/Rekoiru/tl-en/dev/localized_data",
+    "zip_url": "https://codeload.github.com/Rekoiru/tl-en/zip/refs/heads/dev",
+    "zip_dir": "tl-en-dev/localized_data"
 }

--- a/meta_index.json
+++ b/meta_index.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "English",
-        "index": "https://github.com/signalmoroll/tl-en/raw/refs/heads/dev/index.json",
+        "index": "https://github.com/Rekoiru/tl-en/raw/refs/heads/dev/index.json",
         "short_desc": "Contributors: LeadRDRK, KevinVG207, Rekoiru, flingtest, UmaTL (noccu, LotoDS, SU-trash, robflop, hsven, MiniFoxx, BlunterMonk, CryDuringItAll, Nephiro, watatomo et al.)"
     },
     {

--- a/meta_index.json
+++ b/meta_index.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "English",
-        "index": "https://github.com/Rekoiru/tl-en/raw/refs/heads/dev/index.json",
+        "index": "https://github.com/signalmoroll/tl-en/raw/refs/heads/dev/index.json",
         "short_desc": "Contributors: LeadRDRK, KevinVG207, Rekoiru, flingtest, UmaTL (noccu, LotoDS, SU-trash, robflop, hsven, MiniFoxx, BlunterMonk, CryDuringItAll, Nephiro, watatomo et al.)"
     },
     {

--- a/meta_index.json
+++ b/meta_index.json
@@ -1,0 +1,27 @@
+[
+    {
+        "name": "English",
+        "index": "https://github.com/signalmoroll/tl-en/raw/refs/heads/dev/index.json",
+        "short_desc": "Contributors: LeadRDRK, KevinVG207, Rekoiru, flingtest, UmaTL (noccu, LotoDS, SU-trash, robflop, hsven, MiniFoxx, BlunterMonk, CryDuringItAll, Nephiro, watatomo et al.)"
+    },
+    {
+        "name": "繁體中文",
+        "index": "https://files.leadrdrk.com/hachimi/tl-zh-tw.json",
+        "short_desc": "貢獻者：yotv2000tw, asps76482, seanpai96, LeadRDRK 以及 Trainers' Legend G 譯文倉庫的所有貢獻者"
+    },
+    {
+        "name": "繁體中文（大陸加速鏡像）",
+        "index": "https://fuwadl.yingqwq.cn/zh-tw/index/index.json",
+        "short_desc": "特定地區用戶可選用，與繁體中文的內容相同"
+    },
+    {
+        "name": "简体中文",
+        "index": "https://files.leadrdrk.com/hachimi/tl-zh-cn.json",
+        "short_desc": "贡献者：yingyingyingqwq, 1oschi, ChiKo-qwq, LeadRDRK 以及 Trainers' Legend G 译文仓库的所有贡献者"
+    },
+    {
+        "name": "简体中文（大陆加速镜像）",
+        "index": "https://fuwadl.yingqwq.cn/zh-cn/index/index.json",
+        "short_desc": "贡献者：yingyingyingqwq, 1oschi, ChiKo-qwq, LeadRDRK 以及 Trainers' Legend G 译文仓库的所有贡献者"
+    }
+]


### PR DESCRIPTION
Only contains English for now - my hope is that we can cut down on the number of people in the discord #help channel saying "omg my graphics are broken", etc.
If new hachimi friends can get the edge version's meta index automatically (without having to update localized_data themselves) it should decrease resistance.

Currently this new TL index (and automation) will get in-game TL updates working if the `translation_repo_index` key in `config.json` points to this repo. I've been testing using the following config in my fork:
```
{
  "translation_repo_index": "https://github.com/signalmoroll/tl-en/raw/refs/heads/dev/index.json",
}
```
If merged, though, we'd want to tell hachimibros to use the following URL:
```
{
  "translation_repo_index": "https://github.com/Rekoiru/tl-en/raw/refs/heads/dev/index.json",
}
```

I've also included an updated `meta_index.json` which gets the first-time setup working when the config's `meta_index_url` is pointed at it. Only English is updated ATM, I haven't kept up with the other TLs, but a similar index update script could be applied to those.
Ideally once merged we can make a change to the default config in kairusds/Hachimi-Edge, so it points to this updated `meta_index.json`.